### PR TITLE
fix(config): use ConfigFactory to properly read environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 *.log
 .local
 .env
+compose.override.yml
 
 # PHPUnit
 .phpunit.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,31 @@ task check
 task module:cleanup
 ```
 
-### Module Configuration Notes
+### Configuration Modes
+
+The module supports two configuration modes:
+
+1. **Database Globals** (default): Configure via Admin > Config > OpenCoreEMR Sinch Conversations
+2. **Environment Variables**: Set `OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1` and provide credentials via env vars
+
+For local development, use the env var approach:
+```bash
+cp compose.override.yml.example compose.override.yml
+# Edit .env with your Sinch credentials
+docker compose up -d --wait
+```
+
+See [Docker docs](docs/development/docker.md#environment-based-configuration) for details.
+
+### Testing Tips
+
+**CRITICAL:** When the module's enabled status changes, you must **log out and log back in** for the menu to update. The module menu item won't appear/disappear until after re-login.
+
+**Never refresh pages in OpenEMR** - close tabs and re-navigate through menus instead.
+
+See [Navigation docs](docs/browser-automation/openemr-navigation.md#critical-testing-behaviors) for browser automation guidelines.
+
+### CLI Commands
 
 This module includes CLI commands for debugging and automation:
 

--- a/compose.override.yml.example
+++ b/compose.override.yml.example
@@ -1,0 +1,12 @@
+# Docker Compose override for local testing
+# Copy to compose.override.yml (which is gitignored and auto-loaded by docker compose)
+#
+# Usage:
+#   cp compose.override.yml.example compose.override.yml
+#   # Ensure .env has your Sinch credentials
+#   docker compose up -d --wait
+
+services:
+  openemr:
+    env_file:
+      - .env

--- a/docs/browser-automation/openemr-navigation.md
+++ b/docs/browser-automation/openemr-navigation.md
@@ -85,6 +85,38 @@ OpenEMR uses Bootstrap modals:
 - Target elements within modal context
 - Close button typically in top-right corner
 
+## Critical Testing Behaviors
+
+### Module Enable/Disable Requires Re-login
+
+**IMPORTANT:** When the module's enabled status changes (either via Admin > Config checkbox or environment variable), the user must **log out and log back in** for the change to take effect.
+
+This is because:
+- The menu system reads the module's enabled global at login time
+- Changing the enabled setting doesn't update the current session's menu
+- The module menu item only appears after a fresh login with the setting enabled
+
+**Testing workflow:**
+1. Enable module in Admin > Config > OpenCoreEMR Sinch Conversations
+2. Click Save
+3. Log out (user menu > Logout)
+4. Log back in
+5. Module now appears in Modules menu
+
+### Never Navigate Directly to URLs
+
+**CRITICAL:** Never navigate directly to OpenEMR URLs. Always use the menu system.
+
+OpenEMR uses session tokens in URLs. Direct navigation:
+- Bypasses the tab/iframe system
+- Can trigger alerts or security errors
+- Breaks the navigation state
+
+**Always:**
+- Navigate via menu clicks
+- Close tabs using the X button
+- Re-open pages through the menu
+
 ## Common Navigation Issues
 
 **Issue: Menu item not clickable**
@@ -103,6 +135,16 @@ OpenEMR uses Bootstrap modals:
 - Look for "Save" or "Submit" button
 - Check for validation errors
 - Verify CSRF token is present
+
+**Issue: Module not appearing in menu**
+- Check if module is enabled in Admin > Config
+- Log out and log back in after enabling
+- Verify `OCE_SINCH_CONVERSATIONS_ENABLED=1` if using env config
+
+**Issue: Page refresh needed but can't refresh**
+- Close the current tab (click X on the tab)
+- Re-navigate through the menu
+- Never use browser refresh (Cmd+R) in OpenEMR
 
 ## URL Patterns
 

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -167,6 +167,50 @@ docker compose exec mysql mariadb-dump -uroot -proot openemr oce_sinch_conversat
 docker compose exec -T mysql mariadb-dump -uroot -proot openemr < module_backup.sql
 ```
 
+## Environment-Based Configuration
+
+For local development and testing, you can configure the module entirely via environment variables instead of database globals.
+
+### Setup
+
+1. **Copy the example file:**
+   ```bash
+   cp compose.override.yml.example compose.override.yml
+   ```
+
+2. **Create `.env` with your Sinch credentials:**
+   ```bash
+   OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1
+   OCE_SINCH_CONVERSATIONS_ENABLED=1
+   OCE_SINCH_CONVERSATIONS_PROJECT_ID=your-project-id
+   OCE_SINCH_CONVERSATIONS_APP_ID=your-app-id
+   OCE_SINCH_CONVERSATIONS_API_KEY=your-api-key
+   OCE_SINCH_CONVERSATIONS_API_SECRET=your-api-secret
+   OCE_SINCH_CONVERSATIONS_REGION=us
+   OCE_SINCH_CONVERSATIONS_DEFAULT_CHANNEL=SMS
+   OCE_SINCH_CONVERSATIONS_CLINIC_NAME=Your Clinic Name
+   OCE_SINCH_CONVERSATIONS_CLINIC_PHONE=10907
+   ```
+
+3. **Restart containers:**
+   ```bash
+   docker compose down && docker compose up -d --wait
+   ```
+
+### Key Points
+
+- `OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1` enables environment mode
+- When enabled, the module reads from env vars instead of database globals
+- The Settings page will show env var values (currently still editable - future improvement to make read-only)
+- Both `.env` and `compose.override.yml` are gitignored
+
+### Verifying Configuration
+
+```bash
+# Check env vars are loaded in container
+docker compose exec openemr printenv | grep OCE_SINCH
+```
+
 ## Environment Details
 
 **Services:**

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -32,9 +32,14 @@ class Bootstrap
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly Kernel $kernel = new Kernel(),
-        private readonly GlobalsAccessor $globals = new GlobalsAccessor()
+        private readonly ConfigAccessorInterface $configAccessor = new GlobalsAccessor()
     ) {
-        $this->globalsConfig = new GlobalConfig($this->globals);
+        // Use ConfigFactory to determine the appropriate accessor
+        // When OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1 is set, use EnvironmentConfigAccessor
+        $accessor = ConfigFactory::isEnvConfigMode()
+            ? ConfigFactory::createConfigAccessor()
+            : $this->configAccessor;
+        $this->globalsConfig = new GlobalConfig($accessor);
         $this->session = new SessionAccessor();
 
         $templatePath = \dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR;

--- a/templates/settings/config.html.twig
+++ b/templates/settings/config.html.twig
@@ -353,6 +353,11 @@
             const alertDiv = document.getElementById('test-sms-alert');
             const formData = new FormData(this);
 
+            // Append timestamp to message for test identification
+            const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19);
+            const originalMessage = formData.get('message');
+            formData.set('message', originalMessage + ' [' + timestamp + ']');
+
             btn.disabled = true;
             btn.textContent = {{ 'Sending...'|xlj }};
 

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -54,7 +54,7 @@ class BootstrapTest extends TestCase
             GlobalConfig::CONFIG_OPTION_CLINIC_PHONE => '+15551234567',
         ]);
 
-        $this->bootstrap = new Bootstrap($this->eventDispatcher, globals: $mockGlobals);
+        $this->bootstrap = new Bootstrap($this->eventDispatcher, configAccessor: $mockGlobals);
     }
 
     protected function tearDown(): void
@@ -177,7 +177,7 @@ class BootstrapTest extends TestCase
             GlobalConfig::CONFIG_OPTION_REGION => 'us',
         ]);
 
-        $bootstrap = new Bootstrap($this->eventDispatcher, globals: $mockGlobals);
+        $bootstrap = new Bootstrap($this->eventDispatcher, configAccessor: $mockGlobals);
 
         SystemLogger::clearLogs();
         $bootstrap->subscribeToEvents();


### PR DESCRIPTION
## Summary

Bootstrap was always using `GlobalsAccessor` regardless of the `OCE_SINCH_CONVERSATIONS_ENV_CONFIG` setting. Now properly checks `ConfigFactory::isEnvConfigMode()` and uses `EnvironmentConfigAccessor` when env config is enabled.

## Changes

- Fix Bootstrap to use ConfigFactory for env config detection
- Update Bootstrap tests for renamed parameter
- Add timestamp to test SMS messages for easier identification
- Add `compose.override.yml.example` for local dev with env vars
- Add documentation for env config setup and testing behaviors

## Test plan

- [x] Set `OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1` in Docker environment
- [x] Verify settings page shows values from environment variables
- [x] Send test SMS successfully from settings page
- [x] Confirm SMS includes timestamp

🤖 Generated with [Claude Code](https://claude.ai/code)