### PR TITLE
docs: add info.txt, versioning, and error handling rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,36 @@ For AI agents working with Sinch APIs:
 2. **Fetch latest if needed**: https://developers.sinch.com/llms.txt
 
 See [docs/sinch/api-reference.md](docs/sinch/api-reference.md) for additional APIs not covered in llms.txt.
+
+## Module info.txt (REQUIRED)
+
+**Every module MUST have an `info.txt` file.** OpenEMR reads this file to display the module name in the admin UI.
+
+Format: Single line with the display name (e.g., `OpenCoreEMR Sinch Conversations Module`). If missing, OpenEMR falls back to the directory name.
+
+## Versioning with Release Please
+
+Module versions are managed automatically by Release Please. **Never edit version numbers manually.**
+
+- `.release-please-manifest.json` - Source of truth for version
+- `version.php` - Updated automatically via `extra-files` in release-please-config.json
+- Merge PRs with conventional commit titles; Release Please handles the rest
+
+## CRITICAL: Handling Errors and Warnings
+
+**NEVER ignore errors or warnings from any check.** Make every effort to fix them properly.
+
+**Forbidden shortcuts (require explicit user approval):**
+- Adding entries to `symbol-whitelist` in `.composer-require-checker.json`
+- Adding entries to a PHPStan baseline file
+- Using `@phpstan-ignore-*` annotations
+- Using `// phpcs:ignore` comments
+- Suppressing warnings with `@SuppressWarnings`
+
+If suppression seems genuinely necessary, **ask the user first** and explain why it cannot be fixed properly.
+
+**The right approach:**
+1. Understand what the error is telling you
+2. Fix the root cause (add missing types, fix logic, add dependencies)
+3. If stuck, ask the user for guidance
+4. Only suppress with explicit user approval and a comment explaining why


### PR DESCRIPTION
## Summary

Add critical documentation for AI agents working on this module:
- **info.txt requirement** - OpenEMR needs this for module registration
- **Release Please versioning** - Never edit version numbers manually
- **Error handling rules** - Never ignore errors, ask user before suppressing

🤖 Generated with [Claude Code](https://claude.ai/code)