### PR TITLE
feat: add YAML file-based configuration support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "symfony/console": "^6.4",
     "symfony/event-dispatcher": "^6.4",
     "symfony/http-foundation": "^6.4",
+    "symfony/yaml": "^6.4 || ^7.0",
     "twig/twig": "^3.0"
   },
   "require-dev": {

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -211,6 +211,68 @@ For local development and testing, you can configure the module entirely via env
 docker compose exec openemr printenv | grep OCE_SINCH
 ```
 
+## YAML File-Based Configuration
+
+For Kubernetes-style deployments, the module supports YAML config files mounted via ConfigMap and Secret volumes. This is the preferred approach for K8s because it maps directly to volume mounts.
+
+**Config files:**
+- `/etc/oce/sinch-conversations/config.yaml` — non-sensitive settings (from ConfigMap)
+- `/etc/oce/sinch-conversations/secrets.yaml` — sensitive settings (from Secret)
+
+**Override paths via env vars:**
+- `OCE_SINCH_CONVERSATIONS_CONFIG_FILE` — custom path to config file
+- `OCE_SINCH_CONVERSATIONS_SECRETS_FILE` — custom path to secrets file
+
+**Example config.yaml:**
+```yaml
+enabled: true
+project_id: "abc123"
+app_id: "app-456"
+region: us
+default_channel: SMS
+clinic_name: "Example Clinic"
+clinic_phone: "555-1234"
+api_key: "your-api-key"
+```
+
+**Example secrets.yaml:**
+```yaml
+api_secret: "your-api-secret"
+```
+
+**Precedence:** env vars > YAML files > database globals
+
+The module auto-detects file presence — no activation flag needed. When config files are present, the admin UI shows "Configuration Managed Externally" instead of editable fields.
+
+**Imports:** Config files support Symfony-style imports for splitting across files:
+```yaml
+imports:
+  - { resource: secrets.yaml }
+enabled: true
+```
+
+**Testing locally with Docker:**
+```bash
+# Create config files
+mkdir -p tmp/oce-config
+cat > tmp/oce-config/config.yaml <<'EOF'
+enabled: true
+project_id: "test-project"
+app_id: "test-app"
+api_key: "test-key"
+EOF
+
+cat > tmp/oce-config/secrets.yaml <<'EOF'
+api_secret: "test-secret"
+EOF
+
+# Mount into container via compose.override.yml:
+# services:
+#   openemr:
+#     volumes:
+#       - ./tmp/oce-config:/etc/oce/sinch-conversations:ro
+```
+
 ## Environment Details
 
 **Services:**

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -35,8 +35,8 @@ class Bootstrap
         private readonly ConfigAccessorInterface $configAccessor = new GlobalsAccessor()
     ) {
         // Use ConfigFactory to determine the appropriate accessor
-        // When OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1 is set, use EnvironmentConfigAccessor
-        $accessor = ConfigFactory::isEnvConfigMode()
+        // When external config mode is active (file or env), use the appropriate accessor
+        $accessor = ConfigFactory::isExternalConfigMode()
             ? ConfigFactory::createConfigAccessor()
             : $this->configAccessor;
         $this->globalsConfig = new GlobalConfig($accessor);

--- a/src/Module/ConfigFactory.php
+++ b/src/Module/ConfigFactory.php
@@ -4,7 +4,7 @@
  * Factory for creating configuration accessors
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc
  * @license   GNU General Public License 3
@@ -15,12 +15,20 @@ namespace OpenCoreEMR\Modules\SinchConversations;
 /**
  * Factory for creating the appropriate configuration accessor.
  *
- * When OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1 is set, configuration is read from
- * environment variables instead of the database-backed OpenEMR globals.
+ * Supports three modes (checked in order of precedence):
+ * 1. File config: YAML files at conventional or overridden paths
+ * 2. Env config: OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1
+ * 3. Database globals (default)
  */
 class ConfigFactory
 {
     public const ENV_CONFIG_VAR = 'OCE_SINCH_CONVERSATIONS_ENV_CONFIG';
+
+    public const CONFIG_FILE_ENV_VAR = 'OCE_SINCH_CONVERSATIONS_CONFIG_FILE';
+    public const SECRETS_FILE_ENV_VAR = 'OCE_SINCH_CONVERSATIONS_SECRETS_FILE';
+
+    public const CONVENTIONAL_CONFIG_PATH = '/etc/oce/sinch-conversations/config.yaml';
+    public const CONVENTIONAL_SECRETS_PATH = '/etc/oce/sinch-conversations/secrets.yaml';
 
     /**
      * Check if environment-only config mode is enabled
@@ -32,13 +40,68 @@ class ConfigFactory
     }
 
     /**
+     * Check if file-based config mode is active
+     *
+     * File config mode is active when any config files exist at
+     * conventional or overridden paths.
+     */
+    public static function isFileConfigMode(): bool
+    {
+        $loader = new YamlConfigLoader();
+        return $loader->hasConfigFiles(self::getConfigFileCandidates());
+    }
+
+    /**
+     * Check if any external config mode is active (file or env)
+     */
+    public static function isExternalConfigMode(): bool
+    {
+        return self::isFileConfigMode() || self::isEnvConfigMode();
+    }
+
+    /**
      * Create the appropriate config accessor based on environment
+     *
+     * Precedence: file config > env config > database globals
      */
     public static function createConfigAccessor(): ConfigAccessorInterface
     {
+        if (self::isFileConfigMode()) {
+            $loader = new YamlConfigLoader();
+            $paths = $loader->resolveFilePaths(self::getConfigFileCandidates());
+            $yamlData = $loader->load($paths);
+            return new FileConfigAccessor($yamlData);
+        }
+
         if (self::isEnvConfigMode()) {
             return new EnvironmentConfigAccessor();
         }
+
         return new GlobalsAccessor();
+    }
+
+    /**
+     * Get candidate config file paths (overridden + conventional)
+     *
+     * @return list<string>
+     */
+    private static function getConfigFileCandidates(): array
+    {
+        $candidates = [];
+
+        $configOverride = getenv(self::CONFIG_FILE_ENV_VAR);
+        if ($configOverride !== false && $configOverride !== '') {
+            $candidates[] = $configOverride;
+        }
+
+        $secretsOverride = getenv(self::SECRETS_FILE_ENV_VAR);
+        if ($secretsOverride !== false && $secretsOverride !== '') {
+            $candidates[] = $secretsOverride;
+        }
+
+        $candidates[] = self::CONVENTIONAL_CONFIG_PATH;
+        $candidates[] = self::CONVENTIONAL_SECRETS_PATH;
+
+        return $candidates;
     }
 }

--- a/src/Module/FileConfigAccessor.php
+++ b/src/Module/FileConfigAccessor.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * File-based configuration accessor (YAML config files)
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * Read module configuration from YAML files, with env var overrides.
+ *
+ * Precedence: environment variables > YAML files > defaults.
+ * OpenEMR system values (OE_SITE_DIR, webroot, etc.) delegate to GlobalsAccessor.
+ *
+ * @internal Use ConfigFactory::createConfigAccessor() instead of instantiating directly
+ */
+class FileConfigAccessor implements ConfigAccessorInterface
+{
+    /**
+     * Map short YAML keys to internal config keys (oce_sinch_conversations_*)
+     *
+     * @var array<string, string>
+     */
+    private const KEY_MAP = [
+        'enabled' => GlobalConfig::CONFIG_OPTION_ENABLED,
+        'project_id' => GlobalConfig::CONFIG_OPTION_PROJECT_ID,
+        'app_id' => GlobalConfig::CONFIG_OPTION_APP_ID,
+        'api_key' => GlobalConfig::CONFIG_OPTION_API_KEY,
+        'api_secret' => GlobalConfig::CONFIG_OPTION_API_SECRET,
+        'region' => GlobalConfig::CONFIG_OPTION_REGION,
+        'default_channel' => GlobalConfig::CONFIG_OPTION_DEFAULT_CHANNEL,
+        'clinic_name' => GlobalConfig::CONFIG_OPTION_CLINIC_NAME,
+        'clinic_phone' => GlobalConfig::CONFIG_OPTION_CLINIC_PHONE,
+    ];
+
+    /**
+     * Map internal config keys to environment variable names for override support.
+     * Same mapping as EnvironmentConfigAccessor::KEY_MAP.
+     *
+     * @var array<string, string>
+     */
+    private const ENV_OVERRIDE_MAP = [
+        GlobalConfig::CONFIG_OPTION_ENABLED => 'OCE_SINCH_CONVERSATIONS_ENABLED',
+        GlobalConfig::CONFIG_OPTION_PROJECT_ID => 'OCE_SINCH_CONVERSATIONS_PROJECT_ID',
+        GlobalConfig::CONFIG_OPTION_APP_ID => 'OCE_SINCH_CONVERSATIONS_APP_ID',
+        GlobalConfig::CONFIG_OPTION_API_KEY => 'OCE_SINCH_CONVERSATIONS_API_KEY',
+        GlobalConfig::CONFIG_OPTION_API_SECRET => 'OCE_SINCH_CONVERSATIONS_API_SECRET',
+        GlobalConfig::CONFIG_OPTION_REGION => 'OCE_SINCH_CONVERSATIONS_REGION',
+        GlobalConfig::CONFIG_OPTION_DEFAULT_CHANNEL => 'OCE_SINCH_CONVERSATIONS_DEFAULT_CHANNEL',
+        GlobalConfig::CONFIG_OPTION_CLINIC_NAME => 'OCE_SINCH_CONVERSATIONS_CLINIC_NAME',
+        GlobalConfig::CONFIG_OPTION_CLINIC_PHONE => 'OCE_SINCH_CONVERSATIONS_CLINIC_PHONE',
+    ];
+
+    /**
+     * Reverse map: internal config key => short YAML key
+     *
+     * @var array<string, string>
+     */
+    private const REVERSE_KEY_MAP = [
+        GlobalConfig::CONFIG_OPTION_ENABLED => 'enabled',
+        GlobalConfig::CONFIG_OPTION_PROJECT_ID => 'project_id',
+        GlobalConfig::CONFIG_OPTION_APP_ID => 'app_id',
+        GlobalConfig::CONFIG_OPTION_API_KEY => 'api_key',
+        GlobalConfig::CONFIG_OPTION_API_SECRET => 'api_secret',
+        GlobalConfig::CONFIG_OPTION_REGION => 'region',
+        GlobalConfig::CONFIG_OPTION_DEFAULT_CHANNEL => 'default_channel',
+        GlobalConfig::CONFIG_OPTION_CLINIC_NAME => 'clinic_name',
+        GlobalConfig::CONFIG_OPTION_CLINIC_PHONE => 'clinic_phone',
+    ];
+
+    /** @var ParameterBag<string, mixed> */
+    private readonly ParameterBag $bag;
+    private readonly GlobalsAccessor $globalsAccessor;
+
+    /**
+     * @param array<string, mixed> $yamlData merged data from YamlConfigLoader::load()
+     */
+    public function __construct(array $yamlData)
+    {
+        $this->globalsAccessor = new GlobalsAccessor();
+        $this->bag = $this->buildBag($yamlData);
+    }
+
+    /**
+     * Build a ParameterBag from YAML data with env var overrides
+     *
+     * Start with YAML values (mapped to internal keys), then override with
+     * any set environment variables.
+     *
+     * @param array<string, mixed> $yamlData
+     * @return ParameterBag<string, mixed>
+     */
+    private function buildBag(array $yamlData): ParameterBag
+    {
+        $params = [];
+
+        // Map short YAML keys to internal config keys
+        foreach (self::KEY_MAP as $yamlKey => $configKey) {
+            if (array_key_exists($yamlKey, $yamlData)) {
+                $params[$configKey] = $yamlData[$yamlKey];
+            }
+        }
+
+        // Override with environment variables where set
+        foreach (self::ENV_OVERRIDE_MAP as $configKey => $envVar) {
+            $value = getenv($envVar);
+            if ($value !== false) {
+                $params[$configKey] = $value;
+            }
+        }
+
+        return new ParameterBag($params);
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (isset(self::REVERSE_KEY_MAP[$key])) {
+            return $this->bag->get($key, $default);
+        }
+
+        return $this->globalsAccessor->get($key, $default);
+    }
+
+    public function getString(string $key, string $default = ''): string
+    {
+        if (isset(self::REVERSE_KEY_MAP[$key])) {
+            return $this->bag->getString($key, $default);
+        }
+
+        return $this->globalsAccessor->getString($key, $default);
+    }
+
+    public function getBoolean(string $key, bool $default = false): bool
+    {
+        if (isset(self::REVERSE_KEY_MAP[$key])) {
+            return $this->bag->getBoolean($key, $default);
+        }
+
+        return $this->globalsAccessor->getBoolean($key, $default);
+    }
+
+    public function getInt(string $key, int $default = 0): int
+    {
+        if (isset(self::REVERSE_KEY_MAP[$key])) {
+            return $this->bag->getInt($key, $default);
+        }
+
+        return $this->globalsAccessor->getInt($key, $default);
+    }
+
+    public function has(string $key): bool
+    {
+        if (isset(self::REVERSE_KEY_MAP[$key])) {
+            return $this->bag->has($key);
+        }
+
+        return $this->globalsAccessor->has($key);
+    }
+}

--- a/src/Module/GlobalConfig.php
+++ b/src/Module/GlobalConfig.php
@@ -16,22 +16,22 @@ use OpenEMR\Common\Crypto\CryptoGen;
 
 class GlobalConfig
 {
-    private readonly bool $isEnvConfigMode;
+    private readonly bool $isExternalConfigMode;
 
     public function __construct(
         private readonly ConfigAccessorInterface $configAccessor = new GlobalsAccessor()
     ) {
-        $this->isEnvConfigMode = ConfigFactory::isEnvConfigMode();
+        $this->isExternalConfigMode = ConfigFactory::isExternalConfigMode();
     }
 
     public const CONFIG_OPTION_ENABLED = 'oce_sinch_conversations_enabled';
 
     /**
-     * Check if configuration is managed via environment variables
+     * Check if configuration is managed externally (file or env vars)
      */
-    public function isEnvConfigMode(): bool
+    public function isExternalConfigMode(): bool
     {
-        return $this->isEnvConfigMode;
+        return $this->isExternalConfigMode;
     }
     public const CONFIG_OPTION_PROJECT_ID = 'oce_sinch_conversations_project_id';
     public const CONFIG_OPTION_APP_ID = 'oce_sinch_conversations_app_id';
@@ -81,8 +81,8 @@ class GlobalConfig
     {
         $value = $this->configAccessor->getString(self::CONFIG_OPTION_API_SECRET, '');
         if ($value !== '' && $value !== '0') {
-            // In env config mode, secrets are stored as plaintext (no encryption)
-            if ($this->isEnvConfigMode) {
+            // In external config mode, secrets are stored as plaintext (no encryption)
+            if ($this->isExternalConfigMode) {
                 return $value;
             }
             $cryptoGen = new CryptoGen();

--- a/src/Module/YamlConfigLoader.php
+++ b/src/Module/YamlConfigLoader.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Load and merge YAML configuration files
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations;
+
+use OpenCoreEMR\Sinch\Conversation\Exception\ConfigurationException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Parse YAML config files, process imports, and merge into a flat array.
+ *
+ * Supports Symfony-style `imports` for splitting config across files:
+ *
+ *     imports:
+ *       - { resource: secrets.yaml }
+ *
+ * Imported files resolve relative to the importing file's directory.
+ * Parent file keys override imported file keys (later overrides earlier).
+ */
+class YamlConfigLoader
+{
+    /**
+     * Load and merge multiple YAML config files
+     *
+     * Later files override earlier files. Each file's own keys override
+     * keys from its imports.
+     *
+     * @param list<string> $filePaths absolute paths to YAML files
+     * @return array<string, mixed> merged configuration
+     * @throws ConfigurationException if a file exists but is not readable or contains invalid YAML
+     */
+    public function load(array $filePaths): array
+    {
+        $merged = [];
+        foreach ($filePaths as $filePath) {
+            $fileData = $this->loadFile($filePath);
+            $merged = array_merge($merged, $fileData);
+        }
+        return $merged;
+    }
+
+    /**
+     * Check if any config files exist at conventional or overridden paths
+     *
+     * @param list<string> $paths paths to check
+     */
+    public function hasConfigFiles(array $paths): bool
+    {
+        foreach ($paths as $path) {
+            if (file_exists($path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Filter a list of paths to only those that exist
+     *
+     * @param list<string> $paths candidate paths
+     * @return list<string> existing paths
+     */
+    public function resolveFilePaths(array $paths): array
+    {
+        $existing = [];
+        foreach ($paths as $path) {
+            if (file_exists($path)) {
+                $existing[] = $path;
+            }
+        }
+        return $existing;
+    }
+
+    /**
+     * Load a single YAML file, processing any imports
+     *
+     * @return array<string, mixed>
+     * @throws ConfigurationException if file is not readable or contains invalid YAML
+     */
+    private function loadFile(string $filePath): array
+    {
+        if (!is_readable($filePath)) {
+            throw new ConfigurationException(
+                sprintf('Configuration file is not readable: %s', $filePath)
+            );
+        }
+
+        $contents = file_get_contents($filePath);
+        if ($contents === false) {
+            throw new ConfigurationException(
+                sprintf('Failed to read configuration file: %s', $filePath)
+            );
+        }
+
+        try {
+            $data = Yaml::parse($contents);
+        } catch (ParseException $e) {
+            throw new ConfigurationException(
+                sprintf('Invalid YAML in configuration file %s: %s', $filePath, $e->getMessage()),
+                0,
+                $e
+            );
+        }
+
+        if ($data === null) {
+            return [];
+        }
+
+        if (!is_array($data)) {
+            throw new ConfigurationException(
+                sprintf('Configuration file must contain a YAML mapping, got %s: %s', get_debug_type($data), $filePath)
+            );
+        }
+
+        // Process imports
+        $importedData = [];
+        if (isset($data['imports']) && is_array($data['imports'])) {
+            $baseDir = dirname($filePath);
+            foreach ($data['imports'] as $import) {
+                $resource = is_array($import) ? ($import['resource'] ?? null) : $import;
+                if ($resource === null || !is_string($resource)) {
+                    continue;
+                }
+                $importPath = $baseDir . DIRECTORY_SEPARATOR . $resource;
+                $importedData = array_merge($importedData, $this->loadFile($importPath));
+            }
+            unset($data['imports']);
+        }
+
+        // Parent file keys override imported keys
+        /** @var array<string, mixed> */
+        return array_merge($importedData, $data);
+    }
+}

--- a/tests/Unit/ConfigFactoryTest.php
+++ b/tests/Unit/ConfigFactoryTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Unit tests for ConfigFactory
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchConversations\ConfigFactory;
+use OpenCoreEMR\Modules\SinchConversations\EnvironmentConfigAccessor;
+use OpenCoreEMR\Modules\SinchConversations\FileConfigAccessor;
+use OpenCoreEMR\Modules\SinchConversations\GlobalsAccessor;
+use PHPUnit\Framework\TestCase;
+
+class ConfigFactoryTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR);
+        putenv(ConfigFactory::CONFIG_FILE_ENV_VAR);
+        putenv(ConfigFactory::SECRETS_FILE_ENV_VAR);
+        $this->tmpDir = sys_get_temp_dir() . '/config_factory_test_' . uniqid();
+        mkdir($this->tmpDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR);
+        putenv(ConfigFactory::CONFIG_FILE_ENV_VAR);
+        putenv(ConfigFactory::SECRETS_FILE_ENV_VAR);
+        $this->removeDir($this->tmpDir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    // --- Env config mode tests ---
+
+    public function testIsEnvConfigModeReturnsFalseByDefault(): void
+    {
+        $this->assertFalse(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsTrueWhenSetTo1(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=1');
+
+        $this->assertTrue(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsTrueWhenSetToTrue(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=true');
+
+        $this->assertTrue(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsFalseWhenSetTo0(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=0');
+
+        $this->assertFalse(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsFalseWhenSetToFalse(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=false');
+
+        $this->assertFalse(ConfigFactory::isEnvConfigMode());
+    }
+
+    // --- File config mode tests ---
+
+    public function testIsFileConfigModeReturnsFalseByDefault(): void
+    {
+        $this->assertFalse(ConfigFactory::isFileConfigMode());
+    }
+
+    public function testIsFileConfigModeReturnsTrueWhenConfigFileEnvVarPointsToExistingFile(): void
+    {
+        $configFile = $this->tmpDir . '/config.yaml';
+        file_put_contents($configFile, "enabled: true\n");
+        putenv(ConfigFactory::CONFIG_FILE_ENV_VAR . '=' . $configFile);
+
+        $this->assertTrue(ConfigFactory::isFileConfigMode());
+    }
+
+    public function testIsFileConfigModeReturnsTrueWhenSecretsFileEnvVarPointsToExistingFile(): void
+    {
+        $secretsFile = $this->tmpDir . '/secrets.yaml';
+        file_put_contents($secretsFile, "api_secret: x\n");
+        putenv(ConfigFactory::SECRETS_FILE_ENV_VAR . '=' . $secretsFile);
+
+        $this->assertTrue(ConfigFactory::isFileConfigMode());
+    }
+
+    public function testIsFileConfigModeReturnsFalseWhenEnvVarPointsToNonexistentFile(): void
+    {
+        putenv(ConfigFactory::CONFIG_FILE_ENV_VAR . '=/nonexistent/config.yaml');
+
+        $this->assertFalse(ConfigFactory::isFileConfigMode());
+    }
+
+    // --- External config mode tests ---
+
+    public function testIsExternalConfigModeReturnsFalseByDefault(): void
+    {
+        $this->assertFalse(ConfigFactory::isExternalConfigMode());
+    }
+
+    public function testIsExternalConfigModeReturnsTrueForEnvConfig(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=1');
+
+        $this->assertTrue(ConfigFactory::isExternalConfigMode());
+    }
+
+    public function testIsExternalConfigModeReturnsTrueForFileConfig(): void
+    {
+        $configFile = $this->tmpDir . '/config.yaml';
+        file_put_contents($configFile, "enabled: true\n");
+        putenv(ConfigFactory::CONFIG_FILE_ENV_VAR . '=' . $configFile);
+
+        $this->assertTrue(ConfigFactory::isExternalConfigMode());
+    }
+
+    // --- createConfigAccessor tests ---
+
+    public function testCreateConfigAccessorReturnsGlobalsAccessorByDefault(): void
+    {
+        $accessor = ConfigFactory::createConfigAccessor();
+
+        $this->assertInstanceOf(GlobalsAccessor::class, $accessor);
+    }
+
+    public function testCreateConfigAccessorReturnsEnvironmentAccessorWhenEnvSet(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=1');
+
+        $accessor = ConfigFactory::createConfigAccessor();
+
+        $this->assertInstanceOf(EnvironmentConfigAccessor::class, $accessor);
+    }
+
+    public function testCreateConfigAccessorReturnsFileAccessorWhenConfigFileExists(): void
+    {
+        $configFile = $this->tmpDir . '/config.yaml';
+        file_put_contents($configFile, "enabled: true\nproject_id: from-yaml\n");
+        putenv(ConfigFactory::CONFIG_FILE_ENV_VAR . '=' . $configFile);
+
+        $accessor = ConfigFactory::createConfigAccessor();
+
+        $this->assertInstanceOf(FileConfigAccessor::class, $accessor);
+        $this->assertSame('from-yaml', $accessor->getString('oce_sinch_conversations_project_id'));
+    }
+
+    public function testFileConfigTakesPrecedenceOverEnvConfig(): void
+    {
+        // Set up both file and env config
+        $configFile = $this->tmpDir . '/config.yaml';
+        file_put_contents($configFile, "enabled: true\n");
+        putenv(ConfigFactory::CONFIG_FILE_ENV_VAR . '=' . $configFile);
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=1');
+
+        $accessor = ConfigFactory::createConfigAccessor();
+
+        // File config wins
+        $this->assertInstanceOf(FileConfigAccessor::class, $accessor);
+    }
+
+    // --- Constants ---
+
+    public function testEnvConfigVarConstant(): void
+    {
+        $this->assertSame('OCE_SINCH_CONVERSATIONS_ENV_CONFIG', ConfigFactory::ENV_CONFIG_VAR);
+    }
+
+    public function testConfigFileEnvVarConstant(): void
+    {
+        $this->assertSame('OCE_SINCH_CONVERSATIONS_CONFIG_FILE', ConfigFactory::CONFIG_FILE_ENV_VAR);
+    }
+
+    public function testSecretsFileEnvVarConstant(): void
+    {
+        $this->assertSame('OCE_SINCH_CONVERSATIONS_SECRETS_FILE', ConfigFactory::SECRETS_FILE_ENV_VAR);
+    }
+
+    public function testConventionalConfigPathConstant(): void
+    {
+        $this->assertSame('/etc/oce/sinch-conversations/config.yaml', ConfigFactory::CONVENTIONAL_CONFIG_PATH);
+    }
+
+    public function testConventionalSecretsPathConstant(): void
+    {
+        $this->assertSame('/etc/oce/sinch-conversations/secrets.yaml', ConfigFactory::CONVENTIONAL_SECRETS_PATH);
+    }
+}

--- a/tests/Unit/FileConfigAccessorTest.php
+++ b/tests/Unit/FileConfigAccessorTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Unit tests for FileConfigAccessor
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchConversations\FileConfigAccessor;
+use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use PHPUnit\Framework\TestCase;
+
+class FileConfigAccessorTest extends TestCase
+{
+    /**
+     * @var list<string> Environment variables to clean up
+     */
+    private array $envVarsToClean = [
+        'OCE_SINCH_CONVERSATIONS_ENABLED',
+        'OCE_SINCH_CONVERSATIONS_PROJECT_ID',
+        'OCE_SINCH_CONVERSATIONS_APP_ID',
+        'OCE_SINCH_CONVERSATIONS_API_KEY',
+        'OCE_SINCH_CONVERSATIONS_API_SECRET',
+        'OCE_SINCH_CONVERSATIONS_REGION',
+        'OCE_SINCH_CONVERSATIONS_DEFAULT_CHANNEL',
+        'OCE_SINCH_CONVERSATIONS_CLINIC_NAME',
+        'OCE_SINCH_CONVERSATIONS_CLINIC_PHONE',
+    ];
+
+    protected function setUp(): void
+    {
+        $this->clearEnvVars();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearEnvVars();
+    }
+
+    private function clearEnvVars(): void
+    {
+        foreach ($this->envVarsToClean as $var) {
+            putenv($var);
+        }
+    }
+
+    public function testGetStringFromYamlData(): void
+    {
+        $accessor = new FileConfigAccessor([
+            'project_id' => 'yaml-project-123',
+        ]);
+
+        $this->assertSame(
+            'yaml-project-123',
+            $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID)
+        );
+    }
+
+    public function testGetBooleanFromYamlData(): void
+    {
+        $accessor = new FileConfigAccessor([
+            'enabled' => true,
+        ]);
+
+        $this->assertTrue(
+            $accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED)
+        );
+    }
+
+    public function testGetIntFromYamlData(): void
+    {
+        // sinch-conversations doesn't have int config options,
+        // but test the method works with a numeric string value
+        $accessor = new FileConfigAccessor([
+            'enabled' => true,
+        ]);
+
+        // Test with a non-module key that falls through to GlobalsAccessor
+        $this->assertSame(0, $accessor->getInt('nonexistent_key'));
+    }
+
+    public function testReturnsDefaultWhenKeyNotInYaml(): void
+    {
+        $accessor = new FileConfigAccessor([]);
+
+        $this->assertSame(
+            'fallback',
+            $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID, 'fallback')
+        );
+    }
+
+    public function testHasReturnsTrueForYamlKey(): void
+    {
+        $accessor = new FileConfigAccessor([
+            'project_id' => 'abc',
+        ]);
+
+        $this->assertTrue($accessor->has(GlobalConfig::CONFIG_OPTION_PROJECT_ID));
+    }
+
+    public function testHasReturnsFalseForMissingKey(): void
+    {
+        $accessor = new FileConfigAccessor([]);
+
+        $this->assertFalse($accessor->has(GlobalConfig::CONFIG_OPTION_PROJECT_ID));
+    }
+
+    public function testEnvVarOverridesYamlValue(): void
+    {
+        putenv('OCE_SINCH_CONVERSATIONS_PROJECT_ID=env-project-456');
+
+        $accessor = new FileConfigAccessor([
+            'project_id' => 'yaml-project-123',
+        ]);
+
+        $this->assertSame(
+            'env-project-456',
+            $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID)
+        );
+    }
+
+    public function testEnvVarOverridesYamlBoolean(): void
+    {
+        putenv('OCE_SINCH_CONVERSATIONS_ENABLED=0');
+
+        $accessor = new FileConfigAccessor([
+            'enabled' => true,
+        ]);
+
+        $this->assertFalse(
+            $accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED)
+        );
+    }
+
+    public function testYamlValueUsedWhenEnvVarNotSet(): void
+    {
+        $accessor = new FileConfigAccessor([
+            'region' => 'eu',
+        ]);
+
+        $this->assertSame(
+            'eu',
+            $accessor->getString(GlobalConfig::CONFIG_OPTION_REGION)
+        );
+    }
+
+    public function testAllYamlKeysAreMapped(): void
+    {
+        $yamlData = [
+            'enabled' => true,
+            'project_id' => 'proj-123',
+            'app_id' => 'app-456',
+            'api_key' => 'key-789',
+            'api_secret' => 'secret',
+            'region' => 'eu',
+            'default_channel' => 'WHATSAPP',
+            'clinic_name' => 'Test Clinic',
+            'clinic_phone' => '555-1234',
+        ];
+
+        $accessor = new FileConfigAccessor($yamlData);
+
+        $this->assertTrue($accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED));
+        $this->assertSame('proj-123', $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID));
+        $this->assertSame('app-456', $accessor->getString(GlobalConfig::CONFIG_OPTION_APP_ID));
+        $this->assertSame('key-789', $accessor->getString(GlobalConfig::CONFIG_OPTION_API_KEY));
+        $this->assertSame('secret', $accessor->getString(GlobalConfig::CONFIG_OPTION_API_SECRET));
+        $this->assertSame('eu', $accessor->getString(GlobalConfig::CONFIG_OPTION_REGION));
+        $this->assertSame('WHATSAPP', $accessor->getString(GlobalConfig::CONFIG_OPTION_DEFAULT_CHANNEL));
+        $this->assertSame('Test Clinic', $accessor->getString(GlobalConfig::CONFIG_OPTION_CLINIC_NAME));
+        $this->assertSame('555-1234', $accessor->getString(GlobalConfig::CONFIG_OPTION_CLINIC_PHONE));
+    }
+
+    public function testUnknownYamlKeysAreIgnored(): void
+    {
+        $accessor = new FileConfigAccessor([
+            'project_id' => 'abc',
+            'unknown_key' => 'should-be-ignored',
+        ]);
+
+        $this->assertSame('abc', $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID));
+        // Unknown keys don't map to any config option and are silently ignored
+    }
+
+    public function testGetDelegatesToGlobalsForNonModuleKeys(): void
+    {
+        $accessor = new FileConfigAccessor([
+            'project_id' => 'abc',
+        ]);
+
+        // OE_SITE_DIR is a system key that delegates to GlobalsAccessor
+        // In test context (no globals), returns default
+        $this->assertSame('', $accessor->getString('OE_SITE_DIR', ''));
+    }
+}

--- a/tests/Unit/YamlConfigLoaderTest.php
+++ b/tests/Unit/YamlConfigLoaderTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Unit tests for YamlConfigLoader
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchConversations\YamlConfigLoader;
+use OpenCoreEMR\Sinch\Conversation\Exception\ConfigurationException;
+use PHPUnit\Framework\TestCase;
+
+class YamlConfigLoaderTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/yaml_loader_test_' . uniqid();
+        mkdir($this->tmpDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->tmpDir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function writeYaml(string $filename, string $content): string
+    {
+        $path = $this->tmpDir . '/' . $filename;
+        file_put_contents($path, $content);
+        return $path;
+    }
+
+    // --- load() tests ---
+
+    public function testLoadSingleFile(): void
+    {
+        $path = $this->writeYaml('config.yaml', "enabled: true\nproject_id: abc\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path]);
+
+        $this->assertSame(true, $result['enabled']);
+        $this->assertSame('abc', $result['project_id']);
+    }
+
+    public function testLoadMultipleFilesMerges(): void
+    {
+        $path1 = $this->writeYaml('config.yaml', "enabled: true\nproject_id: abc\n");
+        $path2 = $this->writeYaml('secrets.yaml', "api_secret: secret123\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path1, $path2]);
+
+        $this->assertSame(true, $result['enabled']);
+        $this->assertSame('abc', $result['project_id']);
+        $this->assertSame('secret123', $result['api_secret']);
+    }
+
+    public function testLaterFilesOverrideEarlierFiles(): void
+    {
+        $path1 = $this->writeYaml('first.yaml', "region: us\n");
+        $path2 = $this->writeYaml('second.yaml', "region: eu\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path1, $path2]);
+
+        $this->assertSame('eu', $result['region']);
+    }
+
+    public function testLoadEmptyFileReturnsEmptyArray(): void
+    {
+        $path = $this->writeYaml('empty.yaml', '');
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path]);
+
+        $this->assertSame([], $result);
+    }
+
+    // --- Imports ---
+
+    public function testImportsAreProcessed(): void
+    {
+        $this->writeYaml('secrets.yaml', "api_secret: imported-secret\n");
+        $path = $this->writeYaml('config.yaml', "imports:\n  - { resource: secrets.yaml }\nenabled: true\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path]);
+
+        $this->assertSame(true, $result['enabled']);
+        $this->assertSame('imported-secret', $result['api_secret']);
+        $this->assertArrayNotHasKey('imports', $result);
+    }
+
+    public function testParentKeysOverrideImportedKeys(): void
+    {
+        $this->writeYaml('base.yaml', "region: us\nproject_id: base-project\n");
+        $path = $this->writeYaml('config.yaml', "imports:\n  - { resource: base.yaml }\nregion: eu\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path]);
+
+        $this->assertSame('eu', $result['region']);
+        $this->assertSame('base-project', $result['project_id']);
+    }
+
+    public function testStringImportFormat(): void
+    {
+        $this->writeYaml('secrets.yaml', "api_secret: secret-value\n");
+        $path = $this->writeYaml('config.yaml', "imports:\n  - secrets.yaml\nenabled: true\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path]);
+
+        $this->assertSame(true, $result['enabled']);
+        $this->assertSame('secret-value', $result['api_secret']);
+    }
+
+    public function testImportsKeyIsRemovedFromResult(): void
+    {
+        $this->writeYaml('other.yaml', "key: value\n");
+        $path = $this->writeYaml('config.yaml', "imports:\n  - { resource: other.yaml }\nenabled: true\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->load([$path]);
+
+        $this->assertArrayNotHasKey('imports', $result);
+    }
+
+    // --- Error handling ---
+
+    public function testThrowsOnUnreadableFile(): void
+    {
+        $path = $this->writeYaml('unreadable.yaml', "enabled: true\n");
+        chmod($path, 0000);
+
+        $loader = new YamlConfigLoader();
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('not readable');
+
+        try {
+            $loader->load([$path]);
+        } finally {
+            chmod($path, 0644);
+        }
+    }
+
+    public function testThrowsOnMalformedYaml(): void
+    {
+        $path = $this->writeYaml('bad.yaml', "enabled: true\n  invalid: indentation\n");
+
+        $loader = new YamlConfigLoader();
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('Invalid YAML');
+        $loader->load([$path]);
+    }
+
+    public function testThrowsOnNonMappingYaml(): void
+    {
+        $path = $this->writeYaml('scalar.yaml', "just a string\n");
+
+        $loader = new YamlConfigLoader();
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('must contain a YAML mapping');
+        $loader->load([$path]);
+    }
+
+    // --- hasConfigFiles() ---
+
+    public function testHasConfigFilesReturnsTrueWhenFileExists(): void
+    {
+        $path = $this->writeYaml('config.yaml', "enabled: true\n");
+
+        $loader = new YamlConfigLoader();
+
+        $this->assertTrue($loader->hasConfigFiles([$path]));
+    }
+
+    public function testHasConfigFilesReturnsFalseWhenNoFilesExist(): void
+    {
+        $loader = new YamlConfigLoader();
+
+        $this->assertFalse($loader->hasConfigFiles(['/nonexistent/config.yaml']));
+    }
+
+    public function testHasConfigFilesReturnsTrueWhenAnyFileExists(): void
+    {
+        $path = $this->writeYaml('secrets.yaml', "api_secret: x\n");
+
+        $loader = new YamlConfigLoader();
+
+        $this->assertTrue($loader->hasConfigFiles(['/nonexistent/config.yaml', $path]));
+    }
+
+    // --- resolveFilePaths() ---
+
+    public function testResolveFilePathsReturnsOnlyExistingPaths(): void
+    {
+        $existing = $this->writeYaml('config.yaml', "enabled: true\n");
+
+        $loader = new YamlConfigLoader();
+        $result = $loader->resolveFilePaths(['/nonexistent/path.yaml', $existing]);
+
+        $this->assertSame([$existing], $result);
+    }
+
+    public function testResolveFilePathsReturnsEmptyWhenNoneExist(): void
+    {
+        $loader = new YamlConfigLoader();
+        $result = $loader->resolveFilePaths(['/nonexistent/a.yaml', '/nonexistent/b.yaml']);
+
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `YamlConfigLoader` and `FileConfigAccessor` classes for reading module config from YAML files with env var overrides
- Update `ConfigFactory` with file config detection and precedence (file > env > database)
- Rename `isEnvConfigMode` to `isExternalConfigMode` to cover both file and env config modes
- Add unit tests for all new and modified classes

## Related PRs

- opencoreemr/oce-module-sinch-fax#87
- opencoreemr/oce-module-template#12

## Test plan

- [ ] `composer check` passes (phpstan, phpcs, rector, require-checker)
- [ ] `composer test` passes (all unit tests)
- [ ] Verify module works with no config files present (database mode)
- [ ] Verify module reads config from YAML files when present
- [ ] Verify env vars override YAML values
- [ ] Verify admin UI shows "managed externally" when config files present