### PR TITLE
chore(docker): disable telemetry in dev environment

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -68,6 +68,8 @@ services:
       # Enable REST APIs for testing
       OPENEMR_SETTING_rest_api: 1
       OPENEMR_SETTING_rest_fhir_api: 1
+      # Disable telemetry in development
+      OPENEMR_DISABLE_TELEMETRY: 'true'
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Set `OPENEMR_DISABLE_TELEMETRY` in the dev Docker Compose environment

## Test plan

- [ ] `docker compose up -d --wait` starts successfully
- [ ] Telemetry requests are not made during development