### PR TITLE
deps: widen psr/http-message to ^1.1 || ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7.0",
     "openemr/oe-module-installer-plugin": "^0.1.5",
-    "psr/http-message": "^2.0",
+    "psr/http-message": "^1.1 || ^2.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
     "symfony/console": "^6.4 || ^7.0",
     "symfony/event-dispatcher": "^6.4 || ^7.0",


### PR DESCRIPTION
## Summary

- Widen `psr/http-message` from `^2.0` to `^1.1 || ^2.0`
- Fixes a composer dependency conflict that prevents installation alongside OpenEMR v8_0_0 (which requires `^1.1`)
- Safe because the module only *consumes* `ResponseInterface` — it doesn't implement it, so both v1 and v2 are compatible

## Test plan

- [ ] CI checks pass
- [ ] `composer install` resolves successfully with OpenEMR v8_0_0 dependencies