### PR TITLE
feat: gate message sending on consent and hipaa_allowsms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ This document describes the architectural patterns and conventions for OpenEMR m
 |----------|-------------|
 | [API Reference](docs/sinch/api-reference.md) | Sinch API documentation links and usage guidance |
 
+### Regulatory
+
+| Document | Description |
+|----------|-------------|
+| [Regulatory Considerations](docs/regulatory.md) | TCPA, HIPAA, FCC rules, healthcare exemptions, consent model |
+
 ## Quick Reference
 
 ### Key Patterns

--- a/docs/regulatory.md
+++ b/docs/regulatory.md
@@ -1,0 +1,260 @@
+# Regulatory Considerations
+
+This document covers the regulatory landscape for automated patient
+messaging via SMS in a US healthcare context. It is intended for
+AI-assisted humans making implementation decisions about this module.
+
+This is not legal advice. Consult healthcare regulatory counsel before
+making compliance decisions.
+
+## Regulatory Framework at a Glance
+
+| Regulation | Governs | Key concern for this module |
+|------------|---------|----------------------------|
+| [TCPA](#tcpa) | Automated calls and texts | Consent, opt-out handling, healthcare exemption conditions |
+| [HIPAA](#hipaa) | Protected health information | PHI in message content, encryption, BAA with Sinch |
+| [FCC Orders](#fcc-consent-revocation-rule) | TCPA implementation details | "Revoke all" scope, 10-business-day opt-out window |
+| [CAN-SPAM](#can-spam) | Commercial email | Not applicable to SMS; noted here to clarify boundaries |
+| [Carrier policies](#carrier-and-aggregator-requirements) | SMS delivery | STOP enforcement at the carrier level, independent of app logic |
+
+## TCPA
+
+The Telephone Consumer Protection Act (47 U.S.C. 227) restricts
+automated calls and text messages. The implementing rules are at
+[47 CFR 64.1200](https://www.ecfr.gov/current/title-47/chapter-I/subchapter-B/part-64/subpart-L/section-64.1200).
+
+### Healthcare exemption
+
+The FCC created a limited exemption in 2012 for healthcare messages
+sent by or on behalf of a HIPAA covered entity or its business
+associate. This module operates under this exemption when all
+conditions are met.
+
+**Qualifying message types** (47 CFR 64.1200(a)(2)):
+
+- Appointment and exam confirmations and reminders
+- Wellness checkup reminders
+- Hospital pre-registration instructions
+- Pre-operative instructions
+- Lab results
+- Post-discharge follow-up to prevent readmission
+
+**Conditions** (all must be satisfied):
+
+| Condition | Limit |
+|-----------|-------|
+| Recipient number | Must be the number provided by the patient |
+| Frequency | Max 1 message/day, max 3 calls+texts/week per provider |
+| Length | 160 characters or less for texts |
+| Content | No marketing, solicitation, advertising, billing, or debt collection |
+| HIPAA | Must comply with HIPAA Privacy Rule |
+| Opt-out | Must offer an easy opt-out mechanism (reply STOP for texts) |
+| Consent | Prior express consent (not written consent) for cell phones |
+
+**What this means for the module:** Messages sent through this module
+qualify for the exemption only if they stay within these bounds. The
+module does not currently enforce the frequency or character limits;
+these are the caller's responsibility. If a message contains
+marketing or billing content, the full TCPA consent requirements
+apply (prior express written consent).
+
+**References:**
+- [FCC-20-186 (2020 healthcare exemption order)](https://docs.fcc.gov/public/attachments/FCC-20-186A1.pdf)
+- [Federal Register: Limits on Exempted Calls (2021)](https://www.federalregister.gov/documents/2021/02/25/2021-01190/limits-on-exempted-calls-under-the-telephone-consumer-protection-act-of-1991)
+- [Bass Berry: TCPA Exemptions for Healthcare Companies](https://www.bassberry.com/news/tcpa-exemptions-for-healthcare-companies/)
+- [Manatt: The TCPA and Healthcare](https://www.manatt.com/insights/newsletters/health-highlights/the-tcpa-and-healthcare-consent-exemptions-and-ri)
+
+### Consent types
+
+| Consent level | Required for | How obtained |
+|---------------|-------------|--------------|
+| Prior express consent | Healthcare texts to cell phones under the exemption | Patient provides their cell number to the provider |
+| Prior express written consent | Non-exempt automated texts (marketing, billing) | Signed written agreement, including electronic |
+
+The module's `ConsentService` tracks opt-in and opt-out at the
+module level. The `hipaa_allowsms` field in OpenEMR's `patient_data`
+table serves as the patient-level consent flag. Both must be
+affirmative before sending (enforced by `MessageService`).
+
+## FCC Consent Revocation Rule
+
+In February 2024 the FCC adopted new rules on consent revocation
+([FCC-24-16](https://www.fcc.gov/document/tcpa-rules-revoking-consent-unwanted-robocallsrobotexts),
+codified at 47 CFR 64.1200(a)(10)).
+
+### What took effect April 11, 2025
+
+- Callers must honor opt-out requests within **10 business days**
+- The following keywords are "reasonable means per se" for revoking
+  consent via text: **STOP, QUIT, END, REVOKE, OPT OUT, CANCEL,
+  UNSUBSCRIBE**
+- Revocation via SMS applies to both **robotexts and robocalls**
+  from that caller
+- Revocation via SMS does **not** apply to email (governed by
+  CAN-SPAM) or live human calls
+
+### "Revoke all" provision (delayed)
+
+The original rule required that an opt-out from one type of message
+(e.g. appointment reminders) must revoke consent for **all** future
+robocalls and robotexts from that caller on unrelated matters. This
+is the "revoke all" provision.
+
+**Current status:** The FCC has delayed this provision twice:
+- First delay: April 11, 2025 to April 11, 2026
+  ([DA-25-312](https://docs.fcc.gov/public/attachments/DA-25-312A1.pdf))
+- Second delay: April 11, 2026 to **January 31, 2027**
+  ([DA-26-12](https://docs.fcc.gov/public/attachments/DA-26-12A1.pdf))
+
+The FCC is reconsidering this provision in an open rulemaking. It may
+be narrowed or modified before taking effect.
+
+**What this means for the module:** Currently, a STOP in response to
+an appointment reminder only revokes consent for that type of
+communication. When/if the "revoke all" provision takes effect, a
+single STOP would revoke consent for all automated messaging from
+the organization. The module should be prepared for either outcome.
+
+### Opt-out scope summary (as of March 2026)
+
+| Patient action | Blocks | Does not block |
+|----------------|--------|----------------|
+| Texts STOP | Automated texts and prerecorded calls from this sender | Email, patient portal, live calls, mail |
+| Revoke all (not yet in effect) | All automated texts and calls from the organization | Email, portal, live calls, mail |
+
+## HIPAA
+
+The HIPAA Privacy Rule (45 CFR 164) and Security Rule govern how
+PHI is handled in patient communications.
+
+### Key requirements for SMS messaging
+
+| Requirement | CFR | How the module addresses it |
+|-------------|-----|----------------------------|
+| Minimum necessary | 45 CFR 164.502(b) | Message templates should contain only the minimum PHI needed |
+| Patient communication preferences | 45 CFR 164.522(b) | Patients may request confidential communications by alternative means; if reasonable, the provider must honor it |
+| Transmission security | 45 CFR 164.312(e)(1) | SMS is inherently not encrypted end-to-end; see risk discussion below |
+| Business associate agreement | 45 CFR 164.308(b) | Required with Sinch; see [Sinch HIPAA page](https://www.sinch.com/hipaa/) |
+| Access controls | 45 CFR 164.312(a) | Module respects OpenEMR's ACL system |
+
+### SMS and PHI risk
+
+Standard SMS is not encrypted in transit. The HIPAA Security Rule
+does not prohibit unencrypted channels outright, but requires a risk
+assessment. Under 45 CFR 164.522(b), if a patient requests
+communication via SMS and is informed of the risks, the provider
+may comply.
+
+**Practical guidance:**
+- Keep message content minimal (e.g. "You have an appointment
+  tomorrow at 2pm" rather than diagnosis details)
+- Do not include diagnosis codes, test results, or treatment details
+  in SMS
+- Use the patient portal for PHI-rich communications
+- Document patient consent to receive SMS in the medical record
+  (this is what `hipaa_allowsms` represents)
+
+### Sinch as a business associate
+
+Sinch offers a BAA as an addendum to their Terms of Service. A BAA
+must be executed before transmitting any PHI through the Sinch API.
+Sinch's HIPAA compliance has been validated by a third party.
+
+**References:**
+- [Sinch HIPAA Compliance](https://www.sinch.com/hipaa/)
+- [HHS: Business Associate Contracts](https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html)
+- [45 CFR 164.312 (Security Rule technical safeguards)](https://www.law.cornell.edu/cfr/text/45/part-164/subpart-C)
+
+## CAN-SPAM
+
+The CAN-SPAM Act (15 U.S.C. 7701) governs commercial email. It does
+**not** apply to SMS. It is noted here only to clarify that an SMS
+opt-out does not extend to email, and email opt-out rules are a
+separate concern.
+
+## Carrier and Aggregator Requirements
+
+Independent of TCPA and HIPAA, mobile carriers and messaging
+aggregators (including Sinch) enforce their own policies:
+
+- **STOP enforcement at the carrier level:** When a subscriber texts
+  STOP to a short code or long code, the carrier may block further
+  messages from that sender at the network level, regardless of what
+  the application does. The module's opt-out handling reflects
+  reality — the messages would not be delivered anyway.
+
+### Sinch consent management and SMS STOP delivery
+
+Sinch's Conversation API has two consent management mechanisms that
+behave differently depending on the channel:
+
+**OPT_OUT / OPT_IN webhook callbacks:** These fire for channels with
+native consent support (e.g. Viber Business Messages). They do
+**not** fire for SMS. Per Sinch docs: "Opt-in and opt-out callbacks
+are only supported on Conversation API channels that support opt-in
+and opt-out notification types."
+
+**SMS STOP keywords:** On the SMS channel, STOP messages arrive as
+regular `MESSAGE_INBOUND` webhook events. The module's
+`KeywordHandlerService` detects these and calls
+`ConsentService::optOut()`. This is the correct approach for SMS.
+
+| Channel | How STOP arrives | Module handler |
+|---------|-----------------|----------------|
+| SMS | MESSAGE_INBOUND | KeywordHandlerService |
+| Viber BM, others | OPT_OUT callback | WebhookController::handleOptOut() |
+
+Sinch also has a "consent management mode" (Primary vs Secondary)
+that controls whether Sinch blocks outbound messages to opted-out
+recipients:
+- **Primary:** Sinch blocks future messages. The app still receives
+  the opt-out notification.
+- **Secondary:** Sinch does not block. The app must enforce opt-out
+  itself (which this module does via `MessageService` consent gating).
+- **10DLC registration:** Long-code SMS campaigns must be registered
+  under the 10DLC framework. Healthcare is a recognized use case
+  with favorable throughput limits.
+- **Message content filtering:** Carriers may filter messages that
+  appear to contain prohibited content (SHAFT categories). Healthcare
+  messages are generally exempt but poorly-worded messages can still
+  trigger filters.
+
+## How the Module Maps to These Requirements
+
+| Module component | Regulatory requirement |
+|-----------------|----------------------|
+| `hipaa_allowsms` check | TCPA prior express consent; HIPAA patient communication preference |
+| `ConsentService` opt-in/opt-out | TCPA consent tracking; carrier STOP compliance |
+| `MessageService` consent gating | Prevents sending to patients who have revoked consent |
+| `skip_consent_check` for keyword responses | TCPA-required STOP/HELP confirmations must be delivered |
+| `skip_consent_check` for opt-in confirmations | Initial opt-in confirmation sent before consent record exists |
+| `WebhookController` OPT_OUT/OPT_IN handlers | Sync consent from Sinch-managed channels (Viber BM, etc.) |
+| `KeywordHandlerService` STOP/START detection | SMS opt-out (OPT_OUT callback does not fire for SMS) |
+| Message templates | Support HIPAA minimum necessary principle; enforce 160-char limit per TCPA exemption |
+| Sinch BAA | HIPAA business associate requirement |
+
+## Open Questions
+
+These are unresolved design questions with regulatory implications:
+
+1. **Frequency enforcement:** The TCPA healthcare exemption limits
+   messages to 1/day and 3/week. The module does not currently
+   enforce this. Should it?
+
+2. **Character limit enforcement:** The exemption requires 160
+   characters or less. Should the module enforce or warn?
+
+3. **Fallback channels:** When a patient opts out of SMS, how should
+   the system notify staff to use an alternative channel for critical
+   communications (portal, phone, mail)?
+
+4. **"Revoke all" preparation:** If the FCC's revoke-all provision
+   takes effect, a STOP on one message type revokes all automated
+   messaging. The module currently tracks opt-out at the
+   phone-number level, which aligns with this. But organizational
+   systems that send from multiple numbers or through multiple
+   vendors would need coordination.
+
+5. **PHI in messages:** Should the module enforce content restrictions
+   (no diagnosis codes, no billing info) or leave this to the
+   template author?

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -367,7 +367,8 @@ class Bootstrap
         return new Controller\WebhookController(
             $this->globalsConfig,
             $this->getKeywordHandlerService(),
-            $this->getMessageService()
+            $this->getMessageService(),
+            $this->getConsentService()
         );
     }
 

--- a/src/Module/Channel.php
+++ b/src/Module/Channel.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Messaging channel types
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations;
+
+enum Channel: string
+{
+    case SMS = 'SMS';
+    case WHATSAPP = 'WHATSAPP';
+    case RCS = 'RCS';
+}

--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -13,7 +13,9 @@
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenCoreEMR\Modules\SinchConversations\Service\KeywordHandlerService;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageOptions;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
 use OpenCoreEMR\Sinch\Conversation\Exception\UnauthorizedException;
@@ -30,7 +32,8 @@ class WebhookController
     public function __construct(
         private readonly GlobalConfig $globalConfig,
         private readonly KeywordHandlerService $keywordHandler,
-        private readonly MessageService $messageService
+        private readonly MessageService $messageService,
+        private readonly ConsentService $consentService
     ) {
         $this->logger = new SystemLogger();
     }
@@ -89,6 +92,8 @@ class WebhookController
         return match ($eventTypeRaw) {
             'MESSAGE_INBOUND' => $this->handleMessageInbound($payload),
             'MESSAGE_DELIVERY' => $this->handleMessageDelivery($payload),
+            'OPT_OUT' => $this->handleOptOut($payload),
+            'OPT_IN' => $this->handleOptIn($payload),
             default => $this->handleUnknownEvent($eventTypeRaw),
         };
     }
@@ -248,6 +253,108 @@ class WebhookController
     }
 
     /**
+     * Handle OPT_OUT callback from Sinch consent management
+     *
+     * Fires on channels with native opt-out support (e.g. Viber BM).
+     * SMS opt-outs arrive as MESSAGE_INBOUND and are handled by KeywordHandlerService.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function handleOptOut(array $payload): Response
+    {
+        $notification = $payload['opt_out_notification'] ?? [];
+        $identity = $this->extractString($notification, 'identity', '');
+        $channel = $this->extractString($notification, 'channel', '');
+        $status = $this->extractString($notification, 'status', '');
+        $contactId = $this->extractString($notification, 'contact_id', '');
+
+        $this->logger->info("Processing OPT_OUT: identity={$identity}, channel={$channel}, status={$status}");
+
+        if ($status !== 'OPT_OUT_SUCCEEDED') {
+            $this->logger->warning("OPT_OUT did not succeed (status={$status}), skipping");
+            return new JsonResponse(['status' => 'ignored'], Response::HTTP_OK);
+        }
+
+        $patientId = $this->lookupPatientByContactOrIdentity($contactId, $identity);
+        if ($patientId === null) {
+            $this->logger->warning("No patient found for OPT_OUT: identity={$identity}, contact={$contactId}");
+            return new JsonResponse(['status' => 'no_patient'], Response::HTTP_OK);
+        }
+
+        try {
+            $this->consentService->optOut($patientId, $identity, "sinch_{$channel}");
+            $this->logger->info("Recorded OPT_OUT for patient {$patientId} on {$channel}");
+        } catch (\Throwable $e) {
+            $this->logger->error("Failed to record OPT_OUT for patient {$patientId}: " . $e->getMessage());
+        }
+
+        return new JsonResponse(['status' => 'success'], Response::HTTP_OK);
+    }
+
+    /**
+     * Handle OPT_IN callback from Sinch consent management
+     *
+     * Fires on channels with native opt-in support (e.g. Viber BM).
+     * SMS opt-ins arrive as MESSAGE_INBOUND and are handled by KeywordHandlerService.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function handleOptIn(array $payload): Response
+    {
+        $notification = $payload['opt_in_notification'] ?? [];
+        $identity = $this->extractString($notification, 'identity', '');
+        $channel = $this->extractString($notification, 'channel', '');
+        $status = $this->extractString($notification, 'status', '');
+        $contactId = $this->extractString($notification, 'contact_id', '');
+
+        $this->logger->info("Processing OPT_IN: identity={$identity}, channel={$channel}, status={$status}");
+
+        if ($status !== 'OPT_IN_SUCCEEDED') {
+            $this->logger->warning("OPT_IN did not succeed (status={$status}), skipping");
+            return new JsonResponse(['status' => 'ignored'], Response::HTTP_OK);
+        }
+
+        $patientId = $this->lookupPatientByContactOrIdentity($contactId, $identity);
+        if ($patientId === null) {
+            $this->logger->warning("No patient found for OPT_IN: identity={$identity}, contact={$contactId}");
+            return new JsonResponse(['status' => 'no_patient'], Response::HTTP_OK);
+        }
+
+        try {
+            $this->consentService->optIn($patientId, $identity, "sinch_{$channel}");
+            $this->logger->info("Recorded OPT_IN for patient {$patientId} on {$channel}");
+        } catch (\Throwable $e) {
+            $this->logger->error("Failed to record OPT_IN for patient {$patientId}: " . $e->getMessage());
+        }
+
+        return new JsonResponse(['status' => 'success'], Response::HTTP_OK);
+    }
+
+    /**
+     * Look up patient ID by Sinch contact ID or channel identity (phone number)
+     */
+    private function lookupPatientByContactOrIdentity(string $contactId, string $identity): ?int
+    {
+        if ($contactId !== '') {
+            $sql = "SELECT patient_id FROM oce_sinch_contacts WHERE contact_id = ? LIMIT 1";
+            $result = QueryUtils::querySingleRow($sql, [$contactId]);
+            if ($result) {
+                return (int) $result['patient_id'];
+            }
+        }
+
+        if ($identity !== '') {
+            $sql = "SELECT patient_id FROM oce_sinch_contacts WHERE channel_identity = ? LIMIT 1";
+            $result = QueryUtils::querySingleRow($sql, [$identity]);
+            if ($result) {
+                return (int) $result['patient_id'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Handle unknown event types gracefully
      */
     private function handleUnknownEvent(string $eventType): Response
@@ -389,7 +496,7 @@ class WebhookController
                 (int) $contact['patient_id'],
                 $phoneNumber,
                 $responseMessage,
-                ['template_key' => 'keyword_response']
+                new MessageOptions(templateKey: 'keyword_response', skipConsentCheck: true)
             );
 
             $this->logger->info("Sent keyword auto-response to: {$phoneNumber}");

--- a/src/Module/Service/ConsentService.php
+++ b/src/Module/Service/ConsentService.php
@@ -144,8 +144,9 @@ class ConsentService
 
         $message = $this->templateService->render('opt_in_confirmation', $variables);
 
-        $this->messageService->sendToPatient($patientId, $phoneNumber, $message, [
-            'template_key' => 'opt_in_confirmation',
-        ]);
+        $this->messageService->sendToPatient($patientId, $phoneNumber, $message, new MessageOptions(
+            templateKey: 'opt_in_confirmation',
+            skipConsentCheck: true,
+        ));
     }
 }

--- a/src/Module/Service/MessageOptions.php
+++ b/src/Module/Service/MessageOptions.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Typed options for sending messages
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\Channel;
+
+class MessageOptions
+{
+    /**
+     * @param ?string $sender Override the clinic phone as sender
+     * @param ?Channel $channel Channel for sender routing (set automatically when sender is auto-populated)
+     * @param ?string $templateKey Stored in oce_sinch_messages for tracking which template was used
+     * @param array<string, mixed> $metadata Opaque data passed through to the Sinch API
+     * @param list<Channel> $channelPriority Channel priority order for message routing
+     * @param bool $skipConsentCheck Bypass eligibility checks for system messages (e.g. opt-in confirmations)
+     */
+    public function __construct(
+        public readonly ?string $sender = null,
+        public readonly ?Channel $channel = null,
+        public readonly ?string $templateKey = null,
+        public readonly array $metadata = [],
+        public readonly array $channelPriority = [],
+        public readonly bool $skipConsentCheck = false,
+    ) {
+    }
+
+    /**
+     * Build the options array expected by ConversationApiClient::sendMessage()
+     *
+     * @return array<string, mixed>
+     */
+    public function toApiOptions(): array
+    {
+        $options = [];
+
+        if ($this->sender !== null) {
+            $options['sender'] = $this->sender;
+        }
+
+        if ($this->channel !== null) {
+            $options['channel'] = $this->channel->value;
+        }
+
+        if ($this->channelPriority !== []) {
+            $options['channel_priority'] = array_map(
+                static fn(Channel $c): string => $c->value,
+                $this->channelPriority
+            );
+        }
+
+        if ($this->metadata !== []) {
+            $options['metadata'] = $this->metadata;
+        }
+
+        return $options;
+    }
+}

--- a/src/Module/Service/MessageService.php
+++ b/src/Module/Service/MessageService.php
@@ -12,6 +12,7 @@
 
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
+use OpenCoreEMR\Modules\SinchConversations\Channel;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
@@ -32,10 +33,6 @@ class MessageService
     /**
      * Send message to a patient
      *
-     * @param int $patientId
-     * @param string $phoneNumber
-     * @param string $message
-     * @param array<string, mixed> $options
      * @return array<string, mixed> Message data
      * @throws ValidationException
      */
@@ -43,24 +40,36 @@ class MessageService
         int $patientId,
         string $phoneNumber,
         string $message,
-        array $options = []
+        ?MessageOptions $options = null
     ): array {
+        $options ??= new MessageOptions();
+
+        if (!$options->skipConsentCheck) {
+            $this->assertPatientEligible($patientId, $phoneNumber);
+        }
+
         $contactId = $this->getOrCreateContact($patientId, $phoneNumber);
 
         $conversationId = $this->getOrCreateConversation($contactId, $patientId);
 
         // Add configured clinic phone as sender if not already set
-        if (!isset($options['sender'])) {
+        if ($options->sender === null) {
             $senderPhone = $this->config->getClinicPhone();
-            if (!empty($senderPhone)) {
-                $options['sender'] = $senderPhone;
-                $options['channel'] = 'SMS'; // Required for sender to work
+            if ($senderPhone !== '') {
+                $options = new MessageOptions(
+                    sender: $senderPhone,
+                    channel: Channel::SMS,
+                    templateKey: $options->templateKey,
+                    metadata: $options->metadata,
+                    channelPriority: $options->channelPriority,
+                    skipConsentCheck: $options->skipConsentCheck,
+                );
                 $this->logger->debug("Using configured sender: {$senderPhone}");
             }
         }
 
         try {
-            $response = $this->apiClient->sendMessage($contactId, $message, $options);
+            $response = $this->apiClient->sendMessage($contactId, $message, $options->toApiOptions());
         } catch (\Throwable $e) {
             $this->logger->error("Failed to send message: " . $e->getMessage());
             throw new ValidationException("Failed to send message: " . $e->getMessage());
@@ -74,12 +83,10 @@ class MessageService
     /**
      * Send batch messages to multiple patients
      *
-     * @param array<int, int> $patientIds
-     * @param string $message
-     * @param array<string, mixed> $options
+     * @param list<int> $patientIds
      * @return array<string, mixed> Results
      */
-    public function sendBatch(array $patientIds, string $message, array $options = []): array
+    public function sendBatch(array $patientIds, string $message, ?MessageOptions $options = null): array
     {
         $results = [
             'sent' => 0,
@@ -90,7 +97,7 @@ class MessageService
         foreach ($patientIds as $patientId) {
             $phoneNumber = $this->getPatientPhone($patientId);
 
-            if (!$phoneNumber) {
+            if ($phoneNumber === null) {
                 $results['failed']++;
                 $results['errors'][] = "Patient {$patientId}: No phone number";
                 continue;
@@ -110,10 +117,6 @@ class MessageService
 
     /**
      * Get or create a Sinch contact for patient
-     *
-     * @param int $patientId
-     * @param string $phoneNumber
-     * @return string Contact ID
      */
     private function getOrCreateContact(int $patientId, string $phoneNumber): string
     {
@@ -144,10 +147,6 @@ class MessageService
 
     /**
      * Get or create a conversation
-     *
-     * @param string $contactId
-     * @param int $patientId
-     * @return string Conversation ID
      */
     private function getOrCreateConversation(string $contactId, int $patientId): string
     {
@@ -174,16 +173,13 @@ class MessageService
     /**
      * Store outbound message in database
      *
-     * @param string $conversationId
      * @param array<string, mixed> $response
-     * @param string $message
-     * @param array<string, mixed> $options
      */
     private function storeOutboundMessage(
         string $conversationId,
         array $response,
         string $message,
-        array $options
+        MessageOptions $options
     ): void {
         $sql = "INSERT INTO oce_sinch_messages (
             conversation_id, message_id, direction, channel,
@@ -195,8 +191,8 @@ class MessageService
             $conversationId,
             $response['id'] ?? uniqid('msg_'),
             $message,
-            $options['template_key'] ?? null,
-            json_encode($options['metadata'] ?? []),
+            $options->templateKey,
+            json_encode($options->metadata ?: []),
         ]);
 
         $sql = "UPDATE oce_sinch_conversations
@@ -206,10 +202,39 @@ class MessageService
     }
 
     /**
-     * Get patient phone number
+     * Assert patient is eligible to receive messages
      *
-     * @param int $patientId
-     * @return string|null
+     * Check both OpenEMR's hipaa_allowsms field and module-level consent.
+     * Query consent directly to avoid circular dependency (ConsentService depends on MessageService).
+     *
+     * @throws ValidationException
+     */
+    private function assertPatientEligible(int $patientId, string $phoneNumber): void
+    {
+        $sql = "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?";
+        $result = QueryUtils::querySingleRow($sql, [$patientId]);
+        $hipaaAllowSms = $result['hipaa_allowsms'] ?? '';
+
+        if ($hipaaAllowSms !== 'YES') {
+            throw new ValidationException(
+                "Patient {$patientId} has not allowed SMS (hipaa_allowsms is not YES)"
+            );
+        }
+
+        $sql = "SELECT opted_in, opted_out
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?";
+        $consent = QueryUtils::querySingleRow($sql, [$patientId, $phoneNumber]);
+
+        if (!$consent || !($consent['opted_in'] ?? false) || ($consent['opted_out'] ?? false)) {
+            throw new ValidationException(
+                "Patient {$patientId} has not consented to messages at {$phoneNumber}"
+            );
+        }
+    }
+
+    /**
+     * Get patient phone number
      */
     private function getPatientPhone(int $patientId): ?string
     {

--- a/tests/Unit/Controller/WebhookControllerTest.php
+++ b/tests/Unit/Controller/WebhookControllerTest.php
@@ -14,7 +14,9 @@ namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\Controller\WebhookController;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenCoreEMR\Modules\SinchConversations\Service\KeywordHandlerService;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageOptions;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -29,6 +31,7 @@ class WebhookControllerTest extends TestCase
     private GlobalConfig&MockObject $mockConfig;
     private KeywordHandlerService&MockObject $mockKeywordHandler;
     private MessageService&MockObject $mockMessageService;
+    private ConsentService&MockObject $mockConsentService;
     private WebhookController $controller;
 
     protected function setUp(): void
@@ -44,11 +47,13 @@ class WebhookControllerTest extends TestCase
 
         $this->mockKeywordHandler = $this->createMock(KeywordHandlerService::class);
         $this->mockMessageService = $this->createMock(MessageService::class);
+        $this->mockConsentService = $this->createMock(ConsentService::class);
 
         $this->controller = new WebhookController(
             $this->mockConfig,
             $this->mockKeywordHandler,
-            $this->mockMessageService
+            $this->mockMessageService,
+            $this->mockConsentService
         );
     }
 
@@ -84,7 +89,8 @@ class WebhookControllerTest extends TestCase
         $controller = new WebhookController(
             $mockConfig,
             $this->mockKeywordHandler,
-            $this->mockMessageService
+            $this->mockMessageService,
+            $this->mockConsentService
         );
 
         $request = $this->makeRequest('POST', ['trigger' => 'MESSAGE_INBOUND']);
@@ -103,7 +109,8 @@ class WebhookControllerTest extends TestCase
         $controller = new WebhookController(
             $mockConfig,
             $this->mockKeywordHandler,
-            $this->mockMessageService
+            $this->mockMessageService,
+            $this->mockConsentService
         );
 
         $request = $this->makeRequest('POST', ['trigger' => 'MESSAGE_INBOUND']);
@@ -123,7 +130,8 @@ class WebhookControllerTest extends TestCase
         $controller = new WebhookController(
             $mockConfig,
             $this->mockKeywordHandler,
-            $this->mockMessageService
+            $this->mockMessageService,
+            $this->mockConsentService
         );
 
         $request = $this->makeRequest('POST', ['trigger' => 'MESSAGE_INBOUND'], 'wrong', 'wrong');
@@ -325,7 +333,7 @@ class WebhookControllerTest extends TestCase
 
         $this->mockMessageService->expects($this->once())
             ->method('sendToPatient')
-            ->with(10, '+15551234567', 'You have been unsubscribed.', ['template_key' => 'keyword_response']);
+            ->with(10, '+15551234567', 'You have been unsubscribed.', new MessageOptions(templateKey: 'keyword_response', skipConsentCheck: true));
 
         $response = $this->controller->dispatch($request);
 
@@ -491,6 +499,169 @@ class WebhookControllerTest extends TestCase
                 && !str_contains($q['sql'], 'delivered_at')
         );
         $this->assertNotEmpty($updateQueries);
+    }
+
+    // --- OPT_OUT / OPT_IN tests ---
+
+    public function testOptOutCallsConsentService(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_contacts WHERE contact_id = ? LIMIT 1",
+            ['contact-xyz'],
+            [['patient_id' => 5]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('optOut')
+            ->with(5, '+15559876543', 'sinch_VIBERBM');
+
+        $request = $this->makeRequest('POST', [
+            'trigger' => 'OPT_OUT',
+            'opt_out_notification' => [
+                'contact_id' => 'contact-xyz',
+                'channel' => 'VIBERBM',
+                'identity' => '+15559876543',
+                'status' => 'OPT_OUT_SUCCEEDED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseContains($response, 'status', 'success');
+    }
+
+    public function testOptOutIgnoresFailedStatus(): void
+    {
+        $this->mockConsentService->expects($this->never())->method('optOut');
+
+        $request = $this->makeRequest('POST', [
+            'trigger' => 'OPT_OUT',
+            'opt_out_notification' => [
+                'contact_id' => 'contact-xyz',
+                'channel' => 'VIBERBM',
+                'identity' => '+15559876543',
+                'status' => 'OPT_OUT_FAILED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseContains($response, 'status', 'ignored');
+    }
+
+    public function testOptOutHandlesUnknownPatient(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_contacts WHERE contact_id = ? LIMIT 1",
+            ['contact-unknown'],
+            []
+        );
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_contacts WHERE channel_identity = ? LIMIT 1",
+            ['+15559876543'],
+            []
+        );
+
+        $this->mockConsentService->expects($this->never())->method('optOut');
+
+        $request = $this->makeRequest('POST', [
+            'trigger' => 'OPT_OUT',
+            'opt_out_notification' => [
+                'contact_id' => 'contact-unknown',
+                'channel' => 'SMS',
+                'identity' => '+15559876543',
+                'status' => 'OPT_OUT_SUCCEEDED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseContains($response, 'status', 'no_patient');
+    }
+
+    public function testOptOutFallsBackToIdentityLookup(): void
+    {
+        // Contact ID lookup fails
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_contacts WHERE contact_id = ? LIMIT 1",
+            ['contact-missing'],
+            []
+        );
+        // Identity lookup succeeds
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_contacts WHERE channel_identity = ? LIMIT 1",
+            ['+15559876543'],
+            [['patient_id' => 7]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('optOut')
+            ->with(7, '+15559876543', 'sinch_SMS');
+
+        $request = $this->makeRequest('POST', [
+            'trigger' => 'OPT_OUT',
+            'opt_out_notification' => [
+                'contact_id' => 'contact-missing',
+                'channel' => 'SMS',
+                'identity' => '+15559876543',
+                'status' => 'OPT_OUT_SUCCEEDED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testOptInCallsConsentService(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_contacts WHERE contact_id = ? LIMIT 1",
+            ['contact-xyz'],
+            [['patient_id' => 5]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('optIn')
+            ->with(5, '+15559876543', 'sinch_VIBERBM');
+
+        $request = $this->makeRequest('POST', [
+            'trigger' => 'OPT_IN',
+            'opt_in_notification' => [
+                'contact_id' => 'contact-xyz',
+                'channel' => 'VIBERBM',
+                'identity' => '+15559876543',
+                'status' => 'OPT_IN_SUCCEEDED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseContains($response, 'status', 'success');
+    }
+
+    public function testOptInIgnoresFailedStatus(): void
+    {
+        $this->mockConsentService->expects($this->never())->method('optIn');
+
+        $request = $this->makeRequest('POST', [
+            'trigger' => 'OPT_IN',
+            'opt_in_notification' => [
+                'contact_id' => 'contact-xyz',
+                'channel' => 'VIBERBM',
+                'identity' => '+15559876543',
+                'status' => 'OPT_IN_FAILED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseContains($response, 'status', 'ignored');
     }
 
     // --- Logging tests ---

--- a/tests/Unit/Service/ConsentServiceTest.php
+++ b/tests/Unit/Service/ConsentServiceTest.php
@@ -14,6 +14,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageOptions;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use OpenCoreEMR\Modules\SinchConversations\Service\TemplateService;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
@@ -112,7 +113,10 @@ class ConsentServiceTest extends TestCase
 
         $this->messageService->expects($this->once())
             ->method('sendToPatient')
-            ->with(1, '+15551234567', 'Welcome!', ['template_key' => 'opt_in_confirmation']);
+            ->with(1, '+15551234567', 'Welcome!', new MessageOptions(
+                templateKey: 'opt_in_confirmation',
+                skipConsentCheck: true,
+            ));
 
         $this->service->optIn(1, '+15551234567', 'web_form', '192.168.1.1');
 

--- a/tests/Unit/Service/MessageOptionsTest.php
+++ b/tests/Unit/Service/MessageOptionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Unit tests for MessageOptions
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\Channel;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageOptions;
+use PHPUnit\Framework\TestCase;
+
+class MessageOptionsTest extends TestCase
+{
+    public function testDefaultsProduceEmptyApiOptions(): void
+    {
+        $options = new MessageOptions();
+
+        $this->assertSame([], $options->toApiOptions());
+        $this->assertNull($options->sender);
+        $this->assertNull($options->channel);
+        $this->assertNull($options->templateKey);
+        $this->assertSame([], $options->metadata);
+        $this->assertSame([], $options->channelPriority);
+        $this->assertFalse($options->skipConsentCheck);
+    }
+
+    public function testToApiOptionsIncludesSenderAndChannel(): void
+    {
+        $options = new MessageOptions(
+            sender: '+15551234567',
+            channel: Channel::SMS,
+        );
+
+        $this->assertSame([
+            'sender' => '+15551234567',
+            'channel' => 'SMS',
+        ], $options->toApiOptions());
+    }
+
+    public function testToApiOptionsIncludesChannelPriority(): void
+    {
+        $options = new MessageOptions(
+            channelPriority: [Channel::SMS, Channel::WHATSAPP],
+        );
+
+        $this->assertSame([
+            'channel_priority' => ['SMS', 'WHATSAPP'],
+        ], $options->toApiOptions());
+    }
+
+    public function testToApiOptionsIncludesMetadata(): void
+    {
+        $options = new MessageOptions(
+            metadata: ['campaign' => 'reminder'],
+        );
+
+        $this->assertSame([
+            'metadata' => ['campaign' => 'reminder'],
+        ], $options->toApiOptions());
+    }
+
+    public function testToApiOptionsOmitsModuleOnlyFields(): void
+    {
+        $options = new MessageOptions(
+            templateKey: 'appointment_reminder',
+            skipConsentCheck: true,
+        );
+
+        $this->assertSame([], $options->toApiOptions());
+        $this->assertSame('appointment_reminder', $options->templateKey);
+        $this->assertTrue($options->skipConsentCheck);
+    }
+
+    public function testToApiOptionsFullyPopulated(): void
+    {
+        $options = new MessageOptions(
+            sender: '+15551234567',
+            channel: Channel::WHATSAPP,
+            templateKey: 'test',
+            metadata: ['key' => 'value'],
+            channelPriority: [Channel::WHATSAPP, Channel::SMS],
+            skipConsentCheck: true,
+        );
+
+        $this->assertSame([
+            'sender' => '+15551234567',
+            'channel' => 'WHATSAPP',
+            'channel_priority' => ['WHATSAPP', 'SMS'],
+            'metadata' => ['key' => 'value'],
+        ], $options->toApiOptions());
+    }
+}

--- a/tests/Unit/Service/MessageServiceTest.php
+++ b/tests/Unit/Service/MessageServiceTest.php
@@ -13,6 +13,7 @@
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageOptions;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
@@ -41,10 +42,129 @@ class MessageServiceTest extends TestCase
         $this->service = new MessageService($this->config, $this->apiClient);
     }
 
+    /**
+     * Set up mock results so patient passes eligibility checks
+     */
+    private function mockPatientEligible(int $patientId, string $phoneNumber): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            [$patientId],
+            [['hipaa_allowsms' => 'YES']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [$patientId, $phoneNumber],
+            [['opted_in' => true, 'opted_out' => false]]
+        );
+    }
+
+    // --- consent and hipaa gating ---
+
+    public function testSendToPatientThrowsWhenHipaaDisallowsSms(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            [1],
+            [['hipaa_allowsms' => 'NO']]
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('hipaa_allowsms is not YES');
+
+        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+    }
+
+    public function testSendToPatientThrowsWhenHipaaFieldMissing(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            [1],
+            []
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('hipaa_allowsms is not YES');
+
+        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+    }
+
+    public function testSendToPatientThrowsWhenNoConsent(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            [1],
+            [['hipaa_allowsms' => 'YES']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [1, '+15559999999'],
+            []
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('has not consented');
+
+        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+    }
+
+    public function testSendToPatientThrowsWhenOptedOut(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            [1],
+            [['hipaa_allowsms' => 'YES']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [1, '+15559999999'],
+            [['opted_in' => true, 'opted_out' => true]]
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('has not consented');
+
+        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+    }
+
+    public function testSendToPatientSkipsConsentCheckWhenOptionSet(): void
+    {
+        // No eligibility mocks — would fail if checked
+        QueryUtils::setMockResult(
+            "SELECT contact_id FROM oce_sinch_contacts
+                WHERE patient_id = ? AND channel_identity = ?",
+            [1, '+15559999999'],
+            [['contact_id' => 'contact-abc']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT conversation_id FROM oce_sinch_conversations
+                WHERE contact_id = ? AND patient_id = ?",
+            ['contact-abc', 1],
+            [['conversation_id' => 'conv-123']]
+        );
+
+        $this->apiClient->method('sendMessage')
+            ->willReturn(['id' => 'msg-skip']);
+
+        $result = $this->service->sendToPatient(1, '+15559999999', 'Hello', new MessageOptions(
+            skipConsentCheck: true,
+        ));
+
+        $this->assertEquals('msg-skip', $result['id']);
+    }
+
     // --- sendToPatient ---
 
     public function testSendToPatientWithExistingContact(): void
     {
+        $this->mockPatientEligible(1, '+15559999999');
+
         // Existing contact
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
@@ -76,6 +196,8 @@ class MessageServiceTest extends TestCase
 
     public function testSendToPatientCreatesNewContact(): void
     {
+        $this->mockPatientEligible(1, '+15559999999');
+
         // No existing contact
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
@@ -111,6 +233,8 @@ class MessageServiceTest extends TestCase
 
     public function testSendToPatientThrowsWhenCreateContactFails(): void
     {
+        $this->mockPatientEligible(1, '+15559999999');
+
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
                 WHERE patient_id = ? AND channel_identity = ?",
@@ -127,6 +251,8 @@ class MessageServiceTest extends TestCase
 
     public function testSendToPatientAddsSenderFromConfig(): void
     {
+        $this->mockPatientEligible(1, '+15559999999');
+
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
                 WHERE patient_id = ? AND channel_identity = ?",
@@ -154,6 +280,8 @@ class MessageServiceTest extends TestCase
 
     public function testSendToPatientPreservesExplicitSender(): void
     {
+        $this->mockPatientEligible(1, '+15559999999');
+
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
                 WHERE patient_id = ? AND channel_identity = ?",
@@ -176,11 +304,15 @@ class MessageServiceTest extends TestCase
             )
             ->willReturn(['id' => 'msg-004']);
 
-        $this->service->sendToPatient(1, '+15559999999', 'Hello', ['sender' => '+15550000000']);
+        $this->service->sendToPatient(1, '+15559999999', 'Hello', new MessageOptions(
+            sender: '+15550000000',
+        ));
     }
 
     public function testSendToPatientThrowsOnApiFailure(): void
     {
+        $this->mockPatientEligible(1, '+15559999999');
+
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
                 WHERE patient_id = ? AND channel_identity = ?",
@@ -220,6 +352,9 @@ class MessageServiceTest extends TestCase
             []
         );
 
+        // Patient 1 eligibility
+        $this->mockPatientEligible(1, '+15551111111');
+
         // Patient 1 send flow
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
@@ -243,10 +378,54 @@ class MessageServiceTest extends TestCase
         $this->assertStringContainsString('No phone number', $results['errors'][0]);
     }
 
+    public function testSendBatchSkipsIneligiblePatient(): void
+    {
+        // Patient 1: has phone but hipaa_allowsms is NO
+        QueryUtils::setMockResult(
+            "SELECT phone_cell FROM patient_data WHERE pid = ?",
+            [1],
+            [['phone_cell' => '+15551111111']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            [1],
+            [['hipaa_allowsms' => 'NO']]
+        );
+
+        // Patient 2: eligible
+        QueryUtils::setMockResult(
+            "SELECT phone_cell FROM patient_data WHERE pid = ?",
+            [2],
+            [['phone_cell' => '+15552222222']]
+        );
+        $this->mockPatientEligible(2, '+15552222222');
+        QueryUtils::setMockResult(
+            "SELECT contact_id FROM oce_sinch_contacts
+                WHERE patient_id = ? AND channel_identity = ?",
+            [2, '+15552222222'],
+            [['contact_id' => 'c2']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT conversation_id FROM oce_sinch_conversations
+                WHERE contact_id = ? AND patient_id = ?",
+            ['c2', 2],
+            [['conversation_id' => 'conv-2']]
+        );
+        $this->apiClient->method('sendMessage')->willReturn(['id' => 'msg-batch-2']);
+
+        $results = $this->service->sendBatch([1, 2], 'Batch message');
+
+        $this->assertEquals(1, $results['sent']);
+        $this->assertEquals(1, $results['failed']);
+        $this->assertStringContainsString('hipaa_allowsms', $results['errors'][0]);
+    }
+
     // --- getOrCreateConversation (tested indirectly) ---
 
     public function testCreatesNewConversationWhenNoneExists(): void
     {
+        $this->mockPatientEligible(1, '+15559999999');
+
         QueryUtils::setMockResult(
             "SELECT contact_id FROM oce_sinch_contacts
                 WHERE patient_id = ? AND channel_identity = ?",


### PR DESCRIPTION
## Summary

- Check `patient_data.hipaa_allowsms` and module-level consent (`opted_in && !opted_out`) before sending messages
- `sendToPatient()` throws `ValidationException` when either check fails; `sendBatch()` skips and logs per-patient
- Replace untyped `$options` array with `MessageOptions` value object and `Channel` enum across all callers
- `skipConsentCheck` for system messages: opt-in confirmations and TCPA-required keyword responses (STOP/START/HELP)
- Handle `OPT_OUT`/`OPT_IN` webhook callbacks for channels with native consent support (Viber BM, etc.); SMS opt-outs still arrive as `MESSAGE_INBOUND` via `KeywordHandlerService`
- Inject `ConsentService` into `WebhookController` with patient lookup by contact ID with fallback to channel identity
- Add `docs/regulatory.md` covering TCPA healthcare exemption, FCC consent revocation rules, HIPAA SMS requirements, and per-channel STOP delivery differences

## Test plan

- [x] hipaa_allowsms=NO blocks send
- [x] Missing patient record blocks send
- [x] No consent record blocks send
- [x] opted_out=true blocks send
- [x] skipConsentCheck bypasses checks (opt-in confirmations, keyword responses)
- [x] sendBatch skips ineligible, continues for others
- [x] MessageOptions value object: defaults, toApiOptions(), all fields
- [x] OPT_OUT callback calls ConsentService::optOut()
- [x] OPT_OUT with failed status is ignored
- [x] OPT_OUT with unknown patient returns gracefully
- [x] OPT_OUT falls back to identity lookup when contact ID not found
- [x] OPT_IN callback calls ConsentService::optIn()
- [x] OPT_IN with failed status is ignored
- [x] All 303 tests pass, all pre-commit hooks pass

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)