### PR TITLE
chore: fix @link URLs to point to opencoreemr.com

### DIFF
--- a/bin/install-module.php
+++ b/bin/install-module.php
@@ -14,7 +14,7 @@
  *   php bin/install-module.php module:unregister oce-module-sinch-conversations
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/cli.php
+++ b/cli.php
@@ -5,7 +5,7 @@
  * Sinch Conversations Module CLI
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/config/templates.php
+++ b/config/templates.php
@@ -7,7 +7,7 @@
  * They follow HIPAA/TCPA compliance guidelines.
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/openemr.bootstrap.php
+++ b/openemr.bootstrap.php
@@ -4,7 +4,7 @@
  * Initializes the OpenCoreEmr Sinch Conversations Module
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/public/conversation.php
+++ b/public/conversation.php
@@ -4,7 +4,7 @@
  * Conversation thread view
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/public/index.php
+++ b/public/index.php
@@ -4,7 +4,7 @@
  * Main entry point for Sinch Conversations inbox
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/public/settings.php
+++ b/public/settings.php
@@ -4,7 +4,7 @@
  * Settings and configuration
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -4,7 +4,7 @@
  * Initializes the OpenCoreEmr Sinch Conversations Module
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/ConfigAccessorInterface.php
+++ b/src/Module/ConfigAccessorInterface.php
@@ -4,7 +4,7 @@
  * Interface for typed configuration access
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Console/Command/AbstractModuleCommand.php
+++ b/src/Module/Console/Command/AbstractModuleCommand.php
@@ -6,7 +6,7 @@
  * Handles OpenEMR bootstrapping and common options.
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/Command/ModuleDisableCommand.php
+++ b/src/Module/Console/Command/ModuleDisableCommand.php
@@ -4,7 +4,7 @@
  * Command to disable an OpenEMR module
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/Command/ModuleEnableCommand.php
+++ b/src/Module/Console/Command/ModuleEnableCommand.php
@@ -4,7 +4,7 @@
  * Command to enable an OpenEMR module
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/Command/ModuleInstallCommand.php
+++ b/src/Module/Console/Command/ModuleInstallCommand.php
@@ -4,7 +4,7 @@
  * Command to install an OpenEMR module's SQL
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/Command/ModuleInstallEnableCommand.php
+++ b/src/Module/Console/Command/ModuleInstallEnableCommand.php
@@ -4,7 +4,7 @@
  * Command to register, install, and enable an OpenEMR module in one step
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/Command/ModuleListCommand.php
+++ b/src/Module/Console/Command/ModuleListCommand.php
@@ -4,7 +4,7 @@
  * Command to list all registered OpenEMR modules
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/Command/ModuleRegisterCommand.php
+++ b/src/Module/Console/Command/ModuleRegisterCommand.php
@@ -4,7 +4,7 @@
  * Command to register an OpenEMR module
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/Command/ModuleUnregisterCommand.php
+++ b/src/Module/Console/Command/ModuleUnregisterCommand.php
@@ -4,7 +4,7 @@
  * Command to unregister an OpenEMR module
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Console/ModuleInstaller.php
+++ b/src/Module/Console/ModuleInstaller.php
@@ -6,7 +6,7 @@
  * Handles register, install, enable, disable, and unregister operations.
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3

--- a/src/Module/Controller/ConversationController.php
+++ b/src/Module/Controller/ConversationController.php
@@ -4,7 +4,7 @@
  * Conversation Controller - View and interact with message threads
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Controller/InboxController.php
+++ b/src/Module/Controller/InboxController.php
@@ -4,7 +4,7 @@
  * Inbox Controller - Message list and dashboard
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -4,7 +4,7 @@
  * Settings Controller - Module configuration
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/EnvironmentConfigAccessor.php
+++ b/src/Module/EnvironmentConfigAccessor.php
@@ -4,7 +4,7 @@
  * Environment-based configuration accessor
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/GlobalConfig.php
+++ b/src/Module/GlobalConfig.php
@@ -4,7 +4,7 @@
  * Manages the configuration options for the OpenCoreEMR Sinch Conversations Module.
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/GlobalsAccessor.php
+++ b/src/Module/GlobalsAccessor.php
@@ -4,7 +4,7 @@
  * Central accessor for OpenEMR globals
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -4,7 +4,7 @@
  * Configuration Service - Handles saving and validating module settings
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Service/ConsentService.php
+++ b/src/Module/Service/ConsentService.php
@@ -4,7 +4,7 @@
  * Patient Consent Management Service
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Service/KeywordHandlerService.php
+++ b/src/Module/Service/KeywordHandlerService.php
@@ -4,7 +4,7 @@
  * Keyword Handler Service for HELP/STOP/START keywords
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Service/MessagePollingService.php
+++ b/src/Module/Service/MessagePollingService.php
@@ -4,7 +4,7 @@
  * Message Polling Service for checking new messages
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Service/MessageService.php
+++ b/src/Module/Service/MessageService.php
@@ -4,7 +4,7 @@
  * Message Service for sending messages
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Service/TemplateService.php
+++ b/src/Module/Service/TemplateService.php
@@ -4,7 +4,7 @@
  * Message Template Service
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -4,7 +4,7 @@
  * Template Sync Service - Syncs local templates to Sinch
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Module/SessionAccessor.php
+++ b/src/Module/SessionAccessor.php
@@ -4,7 +4,7 @@
  * Central accessor for PHP session
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -4,7 +4,7 @@
  * Sinch Conversations API Client
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/AccessDeniedException.php
+++ b/src/Sinch/Conversation/Exception/AccessDeniedException.php
@@ -4,7 +4,7 @@
  * Exception thrown when access is forbidden (403)
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/ApiException.php
+++ b/src/Sinch/Conversation/Exception/ApiException.php
@@ -4,7 +4,7 @@
  * Exception thrown when Sinch Conversation API returns an error (500)
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/BaseException.php
+++ b/src/Sinch/Conversation/Exception/BaseException.php
@@ -4,7 +4,7 @@
  * Base exception class for Sinch Conversation API
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/ConfigurationException.php
+++ b/src/Sinch/Conversation/Exception/ConfigurationException.php
@@ -4,7 +4,7 @@
  * Exception thrown when configuration is invalid (500)
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/ExceptionInterface.php
+++ b/src/Sinch/Conversation/Exception/ExceptionInterface.php
@@ -4,7 +4,7 @@
  * Base exception interface for Sinch Conversation API exceptions
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/NotFoundException.php
+++ b/src/Sinch/Conversation/Exception/NotFoundException.php
@@ -4,7 +4,7 @@
  * Exception thrown when a requested resource is not found (404)
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/UnauthorizedException.php
+++ b/src/Sinch/Conversation/Exception/UnauthorizedException.php
@@ -4,7 +4,7 @@
  * Exception thrown when authentication is required (401)
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/src/Sinch/Conversation/Exception/ValidationException.php
+++ b/src/Sinch/Conversation/Exception/ValidationException.php
@@ -4,7 +4,7 @@
  * Exception thrown when input validation fails (400)
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3

--- a/version.php
+++ b/version.php
@@ -4,7 +4,7 @@
  * Package version data for the OpenCoreEmr Sinch Conversations Module
  *
  * @package   OpenCoreEMR
- * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   GNU General Public License 3


### PR DESCRIPTION
## Summary

- Update all 42 `@link` docblock annotations from `http://www.open-emr.org` to `https://opencoreemr.com`
- This is an OpenCoreEMR module, not upstream OpenEMR

## Test plan

- [x] Docblock-only change, no logic affected
- [x] All pre-commit hooks pass (PHPStan, PHPCS, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)