### PR TITLE
fix: surface exceptions instead of swallowing in webhook and consent service

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -43,7 +43,8 @@
     "xlj",
     "attr",
     "text",
-    "date"
+    "date",
+    "random_bytes"
   ],
   "php-core-extensions": [
     "Core",

--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -192,24 +192,32 @@ class WebhookController
             );
 
             // Check for keyword responses (STOP, START, HELP)
+            $autoResponseError = null;
             if ($messageBody !== '' && $channelIdentity !== '') {
                 $keywordResponse = $this->keywordHandler->handleInboundMessage($channelIdentity, $messageBody);
                 if ($keywordResponse !== null) {
-                    $this->sendKeywordResponse($channelIdentity, $keywordResponse);
+                    $autoResponseError = $this->sendKeywordResponse($channelIdentity, $keywordResponse);
                 }
             }
 
-            $this->logger->info("Successfully processed inbound message: {$messageId}");
+            $this->logger->info('Successfully processed inbound message', ['messageId' => $messageId]);
 
-            return new JsonResponse(
-                ['status' => 'success', 'messageId' => $messageId],
-                Response::HTTP_OK
-            );
+            $responseBody = ['status' => 'success', 'messageId' => $messageId];
+            if ($autoResponseError !== null) {
+                $responseBody['autoResponseError'] = $autoResponseError;
+            }
+
+            return new JsonResponse($responseBody, Response::HTTP_OK);
         } catch (\Throwable $e) {
-            $this->logger->error("Failed to process inbound message {$messageId}: " . $e->getMessage());
+            $errorId = bin2hex(random_bytes(4));
+            $this->logger->error('Failed to process inbound message', [
+                'messageId' => $messageId,
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
 
             return new JsonResponse(
-                ['error' => 'Failed to process message', 'messageId' => $messageId],
+                ['error' => "Failed to process message (ref: $errorId)", 'messageId' => $messageId],
                 Response::HTTP_INTERNAL_SERVER_ERROR
             );
         }
@@ -477,33 +485,40 @@ class WebhookController
 
     /**
      * Send an auto-response for a detected keyword
+     *
+     * @return string|null Generic error message on failure, null on success or no matching contact
      */
     private function sendKeywordResponse(
         string $phoneNumber,
         string $responseMessage
-    ): void {
+    ): ?string {
+        $sql = "SELECT patient_id FROM oce_sinch_contacts WHERE channel_identity = ? LIMIT 1";
+        $contact = QueryUtils::querySingleRow($sql, [$phoneNumber]);
+
+        if (!$contact) {
+            $this->logger->debug('No contact found for keyword response', ['phone' => $phoneNumber]);
+            return null;
+        }
+
         try {
-            // Find patient by contact identity to use MessageService
-            $sql = "SELECT patient_id FROM oce_sinch_contacts WHERE channel_identity = ? LIMIT 1";
-            $contact = QueryUtils::querySingleRow($sql, [$phoneNumber]);
-
-            if (!$contact) {
-                $this->logger->debug("No contact found for keyword response to: {$phoneNumber}");
-                return;
-            }
-
             $this->messageService->sendToPatient(
                 (int) $contact['patient_id'],
                 $phoneNumber,
                 $responseMessage,
                 new MessageOptions(templateKey: 'keyword_response', skipConsentCheck: true)
             );
-
-            $this->logger->info("Sent keyword auto-response to: {$phoneNumber}");
         } catch (\Throwable $e) {
-            // Log but don't fail the webhook - the inbound message was already stored
-            $this->logger->error("Failed to send keyword response to {$phoneNumber}: " . $e->getMessage());
+            $errorId = bin2hex(random_bytes(4));
+            $this->logger->error('Failed to send keyword response', [
+                'phone' => $phoneNumber,
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
+            return "Failed to send auto-response (ref: $errorId)";
         }
+
+        $this->logger->info('Sent keyword auto-response', ['phone' => $phoneNumber]);
+        return null;
     }
 
     /**

--- a/src/Module/Service/ConsentService.php
+++ b/src/Module/Service/ConsentService.php
@@ -6,7 +6,7 @@
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
  * @license   GNU General Public License 3
  */
 
@@ -56,13 +56,15 @@ class ConsentService
      * @param string $phoneNumber
      * @param string $method web_form, portal, in_person, etc
      * @param string|null $ipAddress
+     * @return bool True if opt-in confirmation was sent, false if it failed.
+     *               Consent is always recorded regardless of return value.
      */
     public function optIn(
         int $patientId,
         string $phoneNumber,
         string $method,
         ?string $ipAddress = null
-    ): void {
+    ): bool {
         $sql = "INSERT INTO oce_sinch_patient_consent (
             patient_id, phone_number, opted_in, opt_in_method,
             opt_in_date, opt_in_ip_address, opted_out,
@@ -84,13 +86,20 @@ class ConsentService
         ]);
 
         $this->syncHipaaAllowSms($patientId, 'YES');
-        $this->logger->debug("Patient {$patientId} opted in via {$method}");
+        $this->logger->debug('Patient opted in', ['patientId' => $patientId, 'method' => $method]);
 
         try {
             $this->sendOptInConfirmation($patientId, $phoneNumber);
         } catch (\Throwable $e) {
-            $this->logger->error("Failed to send opt-in confirmation: " . $e->getMessage());
+            $this->logger->error('Failed to send opt-in confirmation', [
+                'patientId' => $patientId,
+                'phone' => $phoneNumber,
+                'exception' => $e,
+            ]);
+            return false;
         }
+
+        return true;
     }
 
     /**

--- a/tests/Unit/Controller/WebhookControllerTest.php
+++ b/tests/Unit/Controller/WebhookControllerTest.php
@@ -368,6 +368,10 @@ class WebhookControllerTest extends TestCase
 
         // Inbound message was stored — webhook should still succeed
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getContent(), true);
+        $this->assertArrayHasKey('autoResponseError', $body);
+        $this->assertStringStartsWith('Failed to send auto-response (ref: ', $body['autoResponseError']);
     }
 
     public function testKeywordResponseSkippedWhenNoContact(): void

--- a/tests/Unit/Service/ConsentServiceTest.php
+++ b/tests/Unit/Service/ConsentServiceTest.php
@@ -118,8 +118,9 @@ class ConsentServiceTest extends TestCase
                 skipConsentCheck: true,
             ));
 
-        $this->service->optIn(1, '+15551234567', 'web_form', '192.168.1.1');
+        $result = $this->service->optIn(1, '+15551234567', 'web_form', '192.168.1.1');
 
+        $this->assertTrue($result);
         $queries = QueryUtils::getQueries();
         $insertQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'INSERT INTO oce_sinch_patient_consent'));
         $this->assertNotEmpty($insertQueries);
@@ -138,8 +139,15 @@ class ConsentServiceTest extends TestCase
         $this->messageService->method('sendToPatient')
             ->willThrowException(new \RuntimeException('API error'));
 
-        // Should not throw — logs error instead
-        $this->service->optIn(1, '+15551234567', 'web_form');
+        // Should not throw — opt-in succeeds but returns false to indicate confirmation failed
+        $result = $this->service->optIn(1, '+15551234567', 'web_form');
+
+        $this->assertFalse($result);
+
+        // Consent record is still persisted even when confirmation fails
+        $queries = QueryUtils::getQueries();
+        $insertQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'INSERT INTO oce_sinch_patient_consent'));
+        $this->assertNotEmpty($insertQueries);
 
         $logs = SystemLogger::getLogs();
         $errorLogs = array_filter($logs, fn($log) => $log['level'] === 'error');


### PR DESCRIPTION
## Summary
- `WebhookController::sendKeywordResponse()` returns a generic error message with traceable ref ID (or null on success/no contact) instead of swallowing send failures
- `handleMessageInbound()` includes `autoResponseError` in the 200 response body when keyword auto-response fails
- `ConsentService::optIn()` returns `bool` — consent is always recorded; return value indicates whether confirmation was sent
- All logging in changed code converted to PSR-3 context arrays with `'exception' => $e`

Addresses the swallow-and-log portion of #35. Exception message exposure locations tracked in #44.

## Test plan
- [x] Keyword response failure surfaces `autoResponseError` with ref ID in webhook response (still 200)
- [x] Opt-in returns true on success, false when confirmation fails
- [x] Consent INSERT is verified even when confirmation fails
- [x] All 303 tests pass with updated assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)