### PR TITLE
fix: line length warning in WebhookController opt-out call

### DIFF
--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -330,7 +330,8 @@ class WebhookController
         $failures = 0;
         foreach ($patientIds as $patientId) {
             try {
-                $this->consentService->optOut($patientId, $normalizedIdentity, "sinch_{$channel}", channel: $channelEnum);
+                $method = "sinch_{$channel}";
+                $this->consentService->optOut($patientId, $normalizedIdentity, $method, channel: $channelEnum);
             } catch (\Throwable $e) {
                 $failures++;
                 $errorId = bin2hex(random_bytes(4));


### PR DESCRIPTION
## Summary
- Extract `$method` variable to shorten the `optOut()` call line below 120 chars
- Fixes phpcs warning introduced by the squash merge of #47

## Test plan
- [x] phpcs passes
- [x] All 356 tests pass