### PR TITLE
fix: use config accessor for menu visibility instead of global_req

### DIFF
--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -224,6 +224,10 @@ class Bootstrap
         $this->eventDispatcher->addListener(
             MenuEvent::MENU_UPDATE,
             function (MenuEvent $event): void {
+                if (!$this->globalsConfig->isEnabled()) {
+                    return;
+                }
+
                 $menu = $event->getMenu();
 
                 $menuItem = new \stdClass();
@@ -234,7 +238,6 @@ class Bootstrap
                 $menuItem->url = '/interface/modules/custom_modules/' . self::MODULE_NAME . '/public/index.php';
                 $menuItem->children = [];
                 $menuItem->acl_req = [];
-                $menuItem->global_req = [GlobalConfig::CONFIG_OPTION_ENABLED];
 
                 // Add to the modules section
                 foreach ($menu as $section) {


### PR DESCRIPTION
## Summary
- Replace `global_req` menu gate with `isEnabled()` check in the menu event listener
- `global_req` only checks `$GLOBALS` from the database, which doesn't exist when using env-based config
- `isEnabled()` goes through the config accessor, which respects env vars and YAML files
- Matches the pattern used by oce-module-sinch-fax

## Test plan
- [ ] Module menu appears when using env-based config (`OCE_SINCH_CONVERSATIONS_ENV_CONFIG=1`)
- [ ] Module menu hidden when `enabled` is false (both DB and env modes)
- [ ] All 356 tests pass