### PR TITLE
test: add menu visibility tests and fix config accessor injection

### DIFF
--- a/public/conversation.php
+++ b/public/conversation.php
@@ -22,7 +22,7 @@ $logger = new SystemLogger();
 $globalsAccessor = new GlobalsAccessor();
 
 $kernel = $globalsAccessor->getKernel();
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $globalsAccessor);
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
 
 $controller = $bootstrap->getConversationController();
 

--- a/public/index.php
+++ b/public/index.php
@@ -22,7 +22,7 @@ $logger = new SystemLogger();
 $globalsAccessor = new GlobalsAccessor();
 
 $kernel = $globalsAccessor->getKernel();
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $globalsAccessor);
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
 
 $controller = $bootstrap->getInboxController();
 

--- a/public/settings.php
+++ b/public/settings.php
@@ -23,7 +23,7 @@ $logger = new SystemLogger();
 $globalsAccessor = new GlobalsAccessor();
 
 $kernel = $globalsAccessor->getKernel();
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $globalsAccessor);
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
 
 $controller = $bootstrap->getSettingsController();
 

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -32,13 +32,12 @@ class Bootstrap
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly Kernel $kernel = new Kernel(),
-        private readonly ConfigAccessorInterface $configAccessor = new GlobalsAccessor()
+        ?ConfigAccessorInterface $configAccessor = null,
     ) {
-        // Use ConfigFactory to determine the appropriate accessor
-        // When external config mode is active (file or env), use the appropriate accessor
-        $accessor = ConfigFactory::isExternalConfigMode()
-            ? ConfigFactory::createConfigAccessor()
-            : $this->configAccessor;
+        // When no accessor is injected, resolve via ConfigFactory (which
+        // detects file/env/database config mode in one pass).
+        // When an accessor IS injected (e.g., mocks in tests), always honor it.
+        $accessor = $configAccessor ?? ConfigFactory::createConfigAccessor();
         $this->globalsConfig = new GlobalConfig($accessor);
         $this->session = new SessionAccessor();
 

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -13,6 +13,7 @@
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\Bootstrap;
+use OpenCoreEMR\Modules\SinchConversations\ConfigFactory;
 use OpenCoreEMR\Modules\SinchConversations\Controller\ConversationController;
 use OpenCoreEMR\Modules\SinchConversations\Controller\InboxController;
 use OpenCoreEMR\Modules\SinchConversations\Controller\SettingsController;
@@ -27,18 +28,36 @@ use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Menu\MenuEvent;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class BootstrapTest extends TestCase
 {
+    /** @var list<string> */
+    private const EXTERNAL_CONFIG_ENV_VARS = [
+        ConfigFactory::ENV_CONFIG_VAR,
+        ConfigFactory::CONFIG_FILE_ENV_VAR,
+        ConfigFactory::SECRETS_FILE_ENV_VAR,
+    ];
+
     private Bootstrap $bootstrap;
     private EventDispatcher $eventDispatcher;
+    /** @var array<string, string|false> Original env var values to restore in tearDown */
+    private array $savedEnv = [];
 
     protected function setUp(): void
     {
         // Clear logs before each test
         SystemLogger::clearLogs();
+
+        // Clear external config env vars so they don't interfere with tests.
+        // Note: Bootstrap now honors injected accessors regardless of external
+        // config mode, but we still clear these for clean test isolation.
+        foreach (self::EXTERNAL_CONFIG_ENV_VARS as $var) {
+            $this->savedEnv[$var] = getenv($var);
+            putenv($var);
+        }
 
         $this->eventDispatcher = new EventDispatcher();
 
@@ -60,6 +79,15 @@ class BootstrapTest extends TestCase
     protected function tearDown(): void
     {
         SystemLogger::clearLogs();
+
+        // Restore original env var values
+        foreach ($this->savedEnv as $var => $value) {
+            if ($value === false) {
+                putenv($var);
+            } else {
+                putenv("$var=$value");
+            }
+        }
     }
 
     public function testBootstrapCanBeConstructed(): void
@@ -208,5 +236,49 @@ class BootstrapTest extends TestCase
     public function testModuleNameConstant(): void
     {
         $this->assertEquals('oce-module-sinch-conversations', Bootstrap::MODULE_NAME);
+    }
+
+    // --- Menu visibility ---
+
+    public function testMenuItemAddedWhenEnabled(): void
+    {
+        $this->bootstrap->subscribeToEvents();
+
+        $modimg = new \stdClass();
+        $modimg->menu_id = 'modimg';
+        $modimg->children = [];
+
+        $event = new MenuEvent([$modimg]);
+        $this->eventDispatcher->dispatch($event, MenuEvent::MENU_UPDATE);
+
+        $menu = $event->getMenu();
+        $children = $menu[0]->children;
+        $matchingChildren = array_filter(
+            $children,
+            static fn($child): bool => isset($child->menu_id)
+                && $child->menu_id === 'oce_sinch_conversations',
+        );
+        $this->assertNotEmpty($matchingChildren, 'Expected oce_sinch_conversations menu item to be present');
+    }
+
+    public function testMenuItemNotAddedWhenDisabled(): void
+    {
+        $mockGlobals = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => '0',
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $bootstrap = new Bootstrap($dispatcher, configAccessor: $mockGlobals);
+        $bootstrap->subscribeToEvents();
+
+        $modimg = new \stdClass();
+        $modimg->menu_id = 'modimg';
+        $modimg->children = [];
+
+        $event = new MenuEvent([$modimg]);
+        $dispatcher->dispatch($event, MenuEvent::MENU_UPDATE);
+
+        $menu = $event->getMenu();
+        $this->assertEmpty($menu[0]->children);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,7 +26,17 @@ require_once __DIR__ . '/Mocks/MockQueryUtils.php';
 require_once __DIR__ . '/Mocks/MockCryptoGen.php';
 require_once __DIR__ . '/Mocks/MockCsrfUtils.php';
 
-// Define OpenEMR global functions used in controllers
+// Define OpenEMR global functions used in controllers and Bootstrap
+if (!function_exists('xl')) {
+    /**
+     * Mock translation function - just returns the input string
+     */
+    function xl(string $text): string
+    {
+        return $text;
+    }
+}
+
 if (!function_exists('xlt')) {
     /**
      * Mock translation function - just returns the input string


### PR DESCRIPTION
## Summary
- Add tests verifying menu item visibility is gated by `isEnabled()`
- Add `xl()` stub to test bootstrap (menu listener uses `xl()`, not `xlt()`)
- Make Bootstrap's `configAccessor` parameter nullable so injected accessors (including mocks) are always honored — fixes a bug where external config mode would override test mocks
- Delegate config resolution entirely to `ConfigFactory::createConfigAccessor()` (already handles file/env/database fallback)
- Stop passing `GlobalsAccessor` explicitly in production entry points so external config mode is respected
- Remove webhook tunnel/URL tasks from Taskfile (moved to #58)

Follow-up to PR #55 (Copilot flagged missing test coverage for the menu change).

## Test plan
- [x] `testMenuItemAddedWhenEnabled` passes
- [x] `testMenuItemNotAddedWhenDisabled` passes
- [x] All 358 tests pass
- [x] All pre-commit checks pass (phpcs, phpstan, rector, require-checker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)