### PR TITLE
feat: register appointment reminders as OpenEMR background service

### DIFF
--- a/ModuleManagerListener.php
+++ b/ModuleManagerListener.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Module lifecycle hook handler
+ *
+ * Called by the module installer (ModuleInstaller::callModuleListener) during
+ * enable, disable, and unregister actions. Manages the module's
+ * background_services table registration for appointment reminders.
+ *
+ * Note: The installer does not call the "install" hook, so enable() handles
+ * initial registration via upsert.
+ *
+ * This class intentionally has no namespace — the module installer requires
+ * it via require_once and looks for a global-namespace ModuleManagerListener.
+ *
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @link      https://www.opencoreemr.com
+ */
+
+declare(strict_types=1);
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MissingNamespace
+class ModuleManagerListener
+{
+    private const SERVICE_NAME = 'oce_sinch_reminders';
+
+    private const REQUIRE_ONCE_PATH =
+        '/interface/modules/custom_modules/oce-module-sinch-conversations/background_service_entry.php';
+
+    /**
+     * Return the module namespace for the class loader
+     */
+    public static function getModuleNamespace(): string
+    {
+        return 'OpenCoreEMR\\Modules\\SinchConversations\\';
+    }
+
+    /**
+     * Return the PSR-4 source path relative to the module directory
+     *
+     * The default assumption in upstream OpenEMR is '/src', but this
+     * module maps its namespace to '/src/Module'.
+     */
+    public static function getModuleSourcePath(): string
+    {
+        return '/src/Module';
+    }
+
+    /**
+     * Return a new instance for the module installer
+     */
+    public static function initListenerSelf(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Dispatch lifecycle actions
+     *
+     * Catches exceptions from lifecycle methods, logs them with a traceable
+     * error ID, and returns a user-safe message. The caller
+     * (ModuleInstaller::callModuleListener) displays the returned string.
+     *
+     * @param string $methodName
+     * @param int    $modId
+     * @param string $currentActionStatus
+     */
+    public function moduleManagerAction($methodName, $modId, string $currentActionStatus = 'Success'): string
+    {
+        if (!method_exists($this, $methodName)) {
+            return $currentActionStatus;
+        }
+
+        try {
+            $this->$methodName();
+        } catch (\Throwable $e) {
+            $errorId = \OpenCoreEMR\Modules\SinchConversations\ErrorId::generate();
+            (new SystemLogger())->error(
+                'Background service lifecycle action failed',
+                ['errorId' => $errorId, 'method' => $methodName, 'mod_id' => $modId, 'exception' => $e]
+            );
+            return "Background service $methodName failed (ref: $errorId). Check logs for details.";
+        }
+
+        return $currentActionStatus;
+    }
+
+    /**
+     * On install: register the background service
+     *
+     * Not currently called by our ModuleInstaller, but kept as a safety
+     * net in case upstream adds an install hook in the future.
+     */
+    private function install(): void
+    {
+        $this->registerBackgroundService();
+    }
+
+    /**
+     * On enable: register (if needed) and activate the background service
+     *
+     * The install hook is not called by the module installer, so we ensure
+     * the background service row exists before activating it. The upsert
+     * sets active=1 on fresh INSERT, but the explicit UPDATE is needed for
+     * re-enable after disable (where ON DUPLICATE KEY UPDATE does not
+     * reset active).
+     */
+    private function enable(): void
+    {
+        $this->registerBackgroundService();
+        $this->setBackgroundServiceActive(true);
+    }
+
+    /**
+     * On disable: deactivate the background service
+     */
+    private function disable(): void
+    {
+        $this->setBackgroundServiceActive(false);
+    }
+
+    /**
+     * On unregister: remove the background service
+     */
+    private function unregister(): void
+    {
+        $this->deleteBackgroundService();
+    }
+
+    /**
+     * Insert or update the background service registration
+     *
+     * @throws \Throwable on database failure
+     */
+    private function registerBackgroundService(): void
+    {
+        $sql = <<<'SQL'
+            INSERT INTO `background_services`
+                (`name`, `title`, `active`, `running`, `next_run`,
+                 `execute_interval`, `function`, `require_once`, `sort_order`)
+            VALUES
+                (?, 'Sinch Appointment Reminders', 1, 0, NOW(),
+                 15, 'oce_sinch_run_appointment_reminders', ?, 100)
+            ON DUPLICATE KEY UPDATE
+                `title` = VALUES(`title`),
+                `function` = VALUES(`function`),
+                `require_once` = VALUES(`require_once`),
+                `execute_interval` = VALUES(`execute_interval`),
+                `sort_order` = VALUES(`sort_order`)
+            SQL;
+
+        QueryUtils::sqlStatementThrowException($sql, [
+            self::SERVICE_NAME,
+            self::REQUIRE_ONCE_PATH,
+        ]);
+    }
+
+    /**
+     * Activate or deactivate the background service
+     *
+     * @throws \Throwable on database failure
+     */
+    private function setBackgroundServiceActive(bool $active): void
+    {
+        $sql = <<<'SQL'
+            UPDATE `background_services` SET `active` = ? WHERE `name` = ?
+            SQL;
+
+        QueryUtils::sqlStatementThrowException($sql, [
+            $active ? 1 : 0,
+            self::SERVICE_NAME,
+        ]);
+    }
+
+    /**
+     * Remove the background service registration
+     *
+     * @throws \Throwable on database failure
+     */
+    private function deleteBackgroundService(): void
+    {
+        $sql = <<<'SQL'
+            DELETE FROM `background_services` WHERE `name` = ?
+            SQL;
+
+        QueryUtils::sqlStatementThrowException($sql, [self::SERVICE_NAME]);
+    }
+}

--- a/background_service_entry.php
+++ b/background_service_entry.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Background service entry point for appointment reminders
+ *
+ * This file is require_once'd by OpenEMR's background service system
+ * (execute_background_services.php). It defines the function registered
+ * in the background_services table, which delegates to
+ * AppointmentReminderService::run().
+ *
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @link      https://www.opencoreemr.com
+ */
+
+declare(strict_types=1);
+
+/**
+ * Run appointment reminders via the background service system
+ *
+ * Called by OpenEMR's execute_background_services.php after require_once'ing
+ * this file. The function name matches the `function` column in the
+ * background_services table row for 'oce_sinch_reminders'.
+ */
+function oce_sinch_run_appointment_reminders(): void
+{
+    $moduleDir = __DIR__;
+    $fileroot = (string) ($GLOBALS['fileroot'] ?? '');
+    if ($fileroot === '') {
+        return;
+    }
+
+    // The module's openemr.bootstrap.php registers namespaces via the
+    // ModulesClassLoader, but background services bypass that path.
+    // Register namespaces directly so autoloading works.
+    $classLoader = new \OpenEMR\Core\ModulesClassLoader($fileroot);
+    $classLoader->registerNamespaceIfNotExists(
+        'OpenCoreEMR\\Sinch\\Conversation\\',
+        $moduleDir . '/src/Sinch/Conversation'
+    );
+    $classLoader->registerNamespaceIfNotExists(
+        'OpenCoreEMR\\Modules\\SinchConversations\\',
+        $moduleDir . '/src/Module'
+    );
+
+    $config = new \OpenCoreEMR\Modules\SinchConversations\GlobalConfig(
+        \OpenCoreEMR\Modules\SinchConversations\ConfigFactory::createConfigAccessor()
+    );
+
+    if (!$config->isEnabled()) {
+        return;
+    }
+
+    $kernel = ($GLOBALS['kernel'] ?? null) instanceof \OpenEMR\Core\Kernel
+        ? $GLOBALS['kernel']
+        : new \OpenEMR\Core\Kernel();
+    $bootstrap = new \OpenCoreEMR\Modules\SinchConversations\Bootstrap(
+        $kernel->getEventDispatcher(),
+        $kernel
+    );
+
+    $service = $bootstrap->getAppointmentReminderService();
+    $service->run();
+}

--- a/docs/plans/50-cron-api-endpoint.md
+++ b/docs/plans/50-cron-api-endpoint.md
@@ -1,0 +1,177 @@
+# Plan: Trigger Appointment Reminders via Background Service (#50)
+
+## Context
+
+OpenEMR's background service system is being modernized upstream
+(openemr/openemr#11325). The plan introduces:
+
+- `BackgroundServiceRegistry` for standardized module registration (openemr/openemr#11329)
+- `BackgroundServiceRunner` for extracted orchestration (openemr/openemr#11327)
+- REST API at `/apis/{site}/api/admin/background-services/{name}/run` with OAuth2 (openemr/openemr#11330)
+- CLI tooling: `bin/background-services list/run/crontab` (openemr/openemr#11328)
+
+None of these are merged yet. Our approach: register as a background
+service now using the existing table, so we're aligned with upstream's
+direction. When the upstream API lands, triggering comes for free.
+
+## Approach
+
+### Phase 1: Register as background service (now)
+
+Register `AppointmentReminderService` in the `background_services` table
+during module install. This integrates with:
+
+- The existing Ajax piggybacking (runs when users are logged in)
+- The existing CLI: `php library/ajax/execute_background_services.php default oce_sinch_reminders 0`
+- Future: upstream REST API (openemr/openemr#11330) and CLI (openemr/openemr#11328)
+
+### Phase 2: Migrate to BackgroundServiceRegistry (when available)
+
+When openemr/openemr#11329 merges, replace raw SQL with:
+
+```php
+(new BackgroundServiceRegistry())->register(new BackgroundServiceDefinition(
+    name: 'oce_sinch_reminders',
+    title: 'Sinch Appointment Reminders',
+    function: 'oce_sinch_run_appointment_reminders',
+    requireOnce: '...path.../background_service_entry.php',
+    executeInterval: 15,
+    active: true,
+));
+```
+
+### Phase 3: Retire module-specific endpoint (when upstream API lands)
+
+When openemr/openemr#11330 merges, external callers (K8s CronJobs) use:
+
+```bash
+POST /apis/default/api/admin/background-services/oce_sinch_reminders/run
+Authorization: Bearer <oauth2-token>
+```
+
+No module-specific `cron.php` endpoint needed.
+
+## Implementation (Phase 1)
+
+### New Files
+
+#### `background_service_entry.php` (module root)
+
+Thin entry point that the background service system `require_once`s,
+then calls. Defines the function registered in the DB:
+
+```php
+function oce_sinch_run_appointment_reminders(): void
+{
+    // Bootstrap the module, get the service, call run()
+}
+```
+
+#### `tests/Unit/BackgroundServiceEntryTest.php`
+
+- Test that the function exists after requiring the file
+- Test that it delegates to `AppointmentReminderService::run()`
+
+### Modified Files
+
+#### `src/Module/Bootstrap.php`
+
+- Add `install()` method (or extend existing install hook) to INSERT
+  into `background_services` table
+- Add `uninstall()` / `disable()` to DELETE / set `active = 0`
+
+Registration SQL (following existing module patterns until
+openemr/openemr#11329 lands):
+
+```sql
+INSERT INTO `background_services`
+    (`name`, `title`, `active`, `running`, `next_run`,
+     `execute_interval`, `function`, `require_once`, `sort_order`)
+VALUES
+    ('oce_sinch_reminders', 'Sinch Appointment Reminders', 1, 0, NOW(),
+     15, 'oce_sinch_run_appointment_reminders',
+     '/interface/modules/custom_modules/oce-module-sinch-conversations/background_service_entry.php',
+     100)
+ON DUPLICATE KEY UPDATE `title` = VALUES(`title`),
+    `function` = VALUES(`function`),
+    `require_once` = VALUES(`require_once`)
+```
+
+#### `src/Module/Service/AppointmentReminderService.php`
+
+No changes needed. `run()` is already idempotent.
+
+### Module Lifecycle Hooks
+
+| Event | Action |
+|-------|--------|
+| Install | INSERT into `background_services` |
+| Enable | UPDATE `active = 1` |
+| Disable | UPDATE `active = 0` |
+| Uninstall | DELETE from `background_services` |
+
+## Triggering Options (all work with this approach)
+
+### Ajax piggybacking (built-in, no config)
+
+Works automatically when users are logged in. Unreliable for off-hours.
+
+### Existing CLI (works today)
+
+```bash
+php /path/to/openemr/library/ajax/execute_background_services.php \
+    default oce_sinch_reminders 0
+```
+
+Can be wired to system cron:
+
+```cron
+*/15 * * * *  php /path/to/library/ajax/execute_background_services.php default oce_sinch_reminders 0
+```
+
+### K8s CronJob (works today via CLI)
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sinch-appointment-reminders
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            image: openemr/openemr:latest
+            command:
+            - php
+            - /var/www/localhost/htdocs/openemr/library/ajax/execute_background_services.php
+            - default
+            - oce_sinch_reminders
+            - "0"
+```
+
+### Upstream REST API (future, openemr/openemr#11330)
+
+```bash
+curl -X POST https://emr.example.com/apis/default/api/admin/background-services/oce_sinch_reminders/run \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Out of Scope
+
+- No module-specific `cron.php` endpoint (upstream REST API will cover this)
+- No custom auth scheme (upstream uses OAuth2)
+- No changes to `AppointmentReminderService`
+
+## Upstream References
+
+- openemr/openemr#11325 — parent: modernize background service system
+- openemr/openemr#11326 — fix `OPENEMR__NO_BACKGROUND_TASKS` env var
+- openemr/openemr#11327 — extract `BackgroundServiceRunner`
+- openemr/openemr#11328 — CLI tooling
+- openemr/openemr#11329 — `BackgroundServiceRegistry` (replaces raw SQL)
+- openemr/openemr#11330 — REST API endpoints

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,8 @@
     <file>src</file>
     <file>public</file>
     <file>openemr.bootstrap.php</file>
+    <file>background_service_entry.php</file>
+    <file>ModuleManagerListener.php</file>
     <file>version.php</file>
 
     <!-- Exclude patterns -->

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,8 @@ parameters:
         - src
         - public
         - openemr.bootstrap.php
+        - background_service_entry.php
+        - ModuleManagerListener.php
         - version.php
 
     # PHP version

--- a/rector.php
+++ b/rector.php
@@ -33,6 +33,8 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/public',
+        __DIR__ . '/background_service_entry.php',
+        __DIR__ . '/ModuleManagerListener.php',
     ])
     ->withCache(
         cacheClass: FileCacheStorage::class,

--- a/src/Module/Console/ModuleInstaller.php
+++ b/src/Module/Console/ModuleInstaller.php
@@ -324,22 +324,24 @@ class ModuleInstaller
         try {
             $namespace = \ModuleManagerListener::getModuleNamespace();
             if (!empty($namespace)) {
+                $sourcePath = \ModuleManagerListener::getModuleSourcePath();
                 $classLoader = new \OpenEMR\Core\ModulesClassLoader($this->openemrPath);
-                $classLoader->registerNamespaceIfNotExists($namespace, $moduleDir . '/src');
+                $classLoader->registerNamespaceIfNotExists($namespace, $moduleDir . $sourcePath);
             }
 
             $instance = \ModuleManagerListener::initListenerSelf();
-            if (is_object($instance) && method_exists($instance, 'moduleManagerAction')) {
-                /** @var mixed $result */
-                $result = $instance->moduleManagerAction($action, $modId, 'Success');
-                if ($result !== 'Success') {
-                    $resultStr = is_scalar($result) ? (string) $result : 'error';
-                    $this->output->writeln("  <comment>ModuleManagerListener ($action): $resultStr</comment>");
-                }
+            $result = $instance->moduleManagerAction($action, $modId, 'Success');
+            if ($result !== 'Success') {
+                $this->output->writeln("  <comment>ModuleManagerListener ($action): $result</comment>");
             }
         } catch (\Throwable $e) {
+            $errorId = \OpenCoreEMR\Modules\SinchConversations\ErrorId::generate();
+            (new \OpenEMR\Common\Logging\SystemLogger())->error(
+                'ModuleManagerListener error',
+                ['errorId' => $errorId, 'action' => $action, 'exception' => $e]
+            );
             $this->output->writeln(
-                "  <comment>Warning: ModuleManagerListener error: " . $e->getMessage() . "</comment>"
+                "  <comment>ModuleManagerListener ($action) failed (ref: $errorId)</comment>"
             );
         }
     }

--- a/src/Module/Controller/ConversationController.php
+++ b/src/Module/Controller/ConversationController.php
@@ -12,6 +12,7 @@
 
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
+use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessagePollingService;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
@@ -146,7 +147,7 @@ class ConversationController
 
             $this->session->setFlash('conversation_message', "Message sent successfully");
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to send reply', [
                 'conversationId' => $conversationId,
                 'errorId' => $errorId,

--- a/src/Module/Controller/InboxController.php
+++ b/src/Module/Controller/InboxController.php
@@ -12,6 +12,7 @@
 
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
+use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessagePollingService;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
@@ -112,7 +113,7 @@ class InboxController
             }
             $this->session->setFlash('inbox_message', $flash);
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to refresh messages', [
                 'errorId' => $errorId,
                 'exception' => $e,

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -12,6 +12,7 @@
 
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
+use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
@@ -136,7 +137,7 @@ class SettingsController
 
             return $this->redirect($request);
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Error saving settings', [
                 'errorId' => $errorId,
                 'exception' => $e,
@@ -210,7 +211,7 @@ class SettingsController
             ];
             return new JsonResponse($result);
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('API connection test failed', [
                 'errorId' => $errorId,
                 'exception' => $e,
@@ -300,7 +301,7 @@ class SettingsController
                     (!empty($senderPhone) ? " from {$senderPhone}" : ''),
             ]);
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to send test SMS', [
                 'phone' => $phoneNumber,
                 'errorId' => $errorId,
@@ -368,7 +369,7 @@ class SettingsController
                 'details' => $results,
             ]);
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Template sync failed', [
                 'errorId' => $errorId,
                 'exception' => $e,

--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -13,6 +13,7 @@
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;
+use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenCoreEMR\Modules\SinchConversations\Service\KeywordHandlerService;
@@ -216,7 +217,7 @@ class WebhookController
 
             return new JsonResponse($responseBody, Response::HTTP_OK);
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to process inbound message', [
                 'messageId' => $messageId,
                 'errorId' => $errorId,
@@ -261,7 +262,7 @@ class WebhookController
                 Response::HTTP_OK
             );
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to process delivery report', [
                 'messageId' => $messageId,
                 'errorId' => $errorId,
@@ -334,7 +335,7 @@ class WebhookController
                 $this->consentService->optOut($patientId, $normalizedIdentity, $method, channel: $channelEnum);
             } catch (\Throwable $e) {
                 $failures++;
-                $errorId = bin2hex(random_bytes(4));
+                $errorId = ErrorId::generate();
                 $this->logger->error('Failed to process OPT_OUT for patient', [
                     'patientId' => $patientId,
                     'identity' => $identity,
@@ -413,7 +414,7 @@ class WebhookController
         try {
             $this->consentService->optIn($patientId, $normalizedIdentity, "sinch_{$channel}", channel: $channelEnum);
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to process OPT_IN', [
                 'identity' => $identity,
                 'errorId' => $errorId,
@@ -616,7 +617,7 @@ class WebhookController
                 new MessageOptions(templateKey: 'keyword_response', skipConsentCheck: true)
             );
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to send keyword response', [
                 'phone' => $normalized,
                 'errorId' => $errorId,

--- a/src/Module/ErrorId.php
+++ b/src/Module/ErrorId.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Traceable error ID generator
+ *
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @link      https://www.opencoreemr.com
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations;
+
+class ErrorId
+{
+    /**
+     * Generate a short, unique error reference ID
+     *
+     * Used to correlate user-facing error messages with log entries
+     * without exposing exception details. Returns an 8-character hex string.
+     */
+    public static function generate(): string
+    {
+        try {
+            return bin2hex(random_bytes(4));
+        } catch (\Throwable) {
+            return substr(md5(uniqid((string) microtime(true), true)), 0, 8);
+        }
+    }
+}

--- a/src/Module/Service/MessagePollingService.php
+++ b/src/Module/Service/MessagePollingService.php
@@ -12,6 +12,7 @@
 
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
+use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenEMR\Common\Database\QueryUtils;
@@ -164,7 +165,7 @@ class MessagePollingService
                 new MessageOptions(templateKey: 'keyword_response', skipConsentCheck: true)
             );
         } catch (\Throwable $e) {
-            $errorId = bin2hex(random_bytes(4));
+            $errorId = ErrorId::generate();
             $this->logger->error('Failed to send keyword response', [
                 'phone' => $phoneNumber,
                 'errorId' => $errorId,

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -12,6 +12,7 @@
 
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
+use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
@@ -102,7 +103,7 @@ class TemplateSyncService
                     $results['created']++;
                 }
             } catch (\Throwable $e) {
-                $errorId = bin2hex(random_bytes(4));
+                $errorId = ErrorId::generate();
                 $results['failed']++;
                 $results['errors'][] = [
                     'template_key' => $template['template_key'],

--- a/tests/Mocks/MockModulesClassLoader.php
+++ b/tests/Mocks/MockModulesClassLoader.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Mock ModulesClassLoader for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenEMR\Core;
+
+/**
+ * Mock ModulesClassLoader to avoid requiring a real vendor/autoload.php
+ *
+ * Replaces the real class so background_service_entry.php can be tested
+ * without a full OpenEMR installation.
+ */
+class ModulesClassLoader
+{
+    /** @var array<int, array{namespace: string, paths: string|string[]}> */
+    private static array $registered = [];
+
+    public function __construct(string $webRootPath)
+    {
+        // No-op: real class does require $webRootPath/vendor/autoload.php
+    }
+
+    /**
+     * @param string          $namespace
+     * @param string[]|string $paths
+     */
+    public function registerNamespaceIfNotExists(string $namespace, string|array $paths): bool
+    {
+        self::$registered[] = ['namespace' => $namespace, 'paths' => $paths];
+        return true;
+    }
+
+    /**
+     * @return array<int, array{namespace: string, paths: string|string[]}>
+     */
+    public static function getRegistered(): array
+    {
+        return self::$registered;
+    }
+
+    public static function clearRegistered(): void
+    {
+        self::$registered = [];
+    }
+}

--- a/tests/Mocks/MockQueryUtils.php
+++ b/tests/Mocks/MockQueryUtils.php
@@ -34,6 +34,11 @@ class QueryUtils
     private static array $mockResultQueue = [];
 
     /**
+     * Exception to throw on next sqlStatementThrowException call
+     */
+    private static ?\Throwable $nextException = null;
+
+    /**
      * @param string $sql
      * @param array<mixed> $binds
      * @return array<int, array<string, mixed>>
@@ -77,7 +82,20 @@ class QueryUtils
     public static function sqlStatementThrowException(string $sql, array $binds = []): mixed
     {
         self::$queries[] = ['sql' => $sql, 'binds' => $binds];
+        if (self::$nextException !== null) {
+            $e = self::$nextException;
+            self::$nextException = null;
+            throw $e;
+        }
         return true;
+    }
+
+    /**
+     * Set an exception to throw on the next sqlStatementThrowException call
+     */
+    public static function setNextException(\Throwable $e): void
+    {
+        self::$nextException = $e;
     }
 
     /**
@@ -119,6 +137,7 @@ class QueryUtils
     {
         self::$mockResults = [];
         self::$mockResultQueue = [];
+        self::$nextException = null;
     }
 
     /**

--- a/tests/Unit/BackgroundServiceEntryTest.php
+++ b/tests/Unit/BackgroundServiceEntryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Unit tests for background_service_entry.php
+ *
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @link      https://www.opencoreemr.com
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Core\ModulesClassLoader;
+use PHPUnit\Framework\TestCase;
+
+class BackgroundServiceEntryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../../background_service_entry.php';
+        QueryUtils::clearQueries();
+        QueryUtils::clearMockResults();
+        SystemLogger::clearLogs();
+        ModulesClassLoader::clearRegistered();
+
+        $GLOBALS['fileroot'] = '/var/www/localhost/htdocs/openemr';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['fileroot']);
+        unset($GLOBALS[GlobalConfig::CONFIG_OPTION_ENABLED]);
+    }
+
+    public function testFunctionExists(): void
+    {
+        $this->assertTrue(
+            function_exists('oce_sinch_run_appointment_reminders'),
+            'Expected function oce_sinch_run_appointment_reminders to be defined'
+        );
+    }
+
+    public function testReturnsEarlyWhenFilerootMissing(): void
+    {
+        unset($GLOBALS['fileroot']);
+
+        oce_sinch_run_appointment_reminders();
+
+        $registered = ModulesClassLoader::getRegistered();
+        $this->assertCount(0, $registered, 'Should not register namespaces without fileroot');
+    }
+
+    public function testRegistersNamespaces(): void
+    {
+        oce_sinch_run_appointment_reminders();
+
+        $registered = ModulesClassLoader::getRegistered();
+        $namespaces = array_column($registered, 'namespace');
+
+        $this->assertContains('OpenCoreEMR\\Sinch\\Conversation\\', $namespaces);
+        $this->assertContains('OpenCoreEMR\\Modules\\SinchConversations\\', $namespaces);
+    }
+
+    public function testReturnsEarlyWhenModuleDisabled(): void
+    {
+        oce_sinch_run_appointment_reminders();
+
+        $logs = SystemLogger::getLogs();
+        $debugMessages = array_column(
+            array_filter($logs, fn ($l) => $l['level'] === 'debug'),
+            'message'
+        );
+
+        // When disabled, Bootstrap is never constructed, so this log shouldn't appear
+        $this->assertNotContains(
+            'Sinch Conversations Bootstrap constructed',
+            $debugMessages,
+            'Bootstrap should not be constructed when module is disabled'
+        );
+    }
+
+    public function testDelegatesToAppointmentReminderServiceWhenEnabled(): void
+    {
+        $GLOBALS[GlobalConfig::CONFIG_OPTION_ENABLED] = '1';
+
+        // With SMS_NOTIFICATION_HOUR defaulting to 0, run() returns early.
+        // We verify it was called by checking the debug log it emits.
+        oce_sinch_run_appointment_reminders();
+
+        $logs = SystemLogger::getLogs();
+        $debugMessages = array_column(
+            array_filter($logs, fn ($l) => $l['level'] === 'debug'),
+            'message'
+        );
+
+        $this->assertContains(
+            'SMS notification hours is 0 or negative, skipping appointment reminders',
+            $debugMessages,
+            'Expected AppointmentReminderService::run() to have been called'
+        );
+    }
+}

--- a/tests/Unit/ModuleManagerListenerTest.php
+++ b/tests/Unit/ModuleManagerListenerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Unit tests for ModuleManagerListener
+ *
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @link      https://www.opencoreemr.com
+ */
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\TestCase;
+
+class ModuleManagerListenerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../../ModuleManagerListener.php';
+        QueryUtils::clearQueries();
+        QueryUtils::clearMockResults();
+    }
+
+    public function testGetModuleNamespace(): void
+    {
+        $this->assertSame(
+            'OpenCoreEMR\\Modules\\SinchConversations\\',
+            \ModuleManagerListener::getModuleNamespace()
+        );
+    }
+
+    public function testGetModuleSourcePath(): void
+    {
+        $this->assertSame(
+            '/src/Module',
+            \ModuleManagerListener::getModuleSourcePath()
+        );
+    }
+
+    public function testInitListenerSelfReturnsInstance(): void
+    {
+        $instance = \ModuleManagerListener::initListenerSelf();
+        $this->assertInstanceOf(\ModuleManagerListener::class, $instance);
+    }
+
+    public function testInstallRegistersBackgroundService(): void
+    {
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $result = $listener->moduleManagerAction('install', 1, 'Success');
+
+        $this->assertSame('Success', $result);
+
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(1, $queries);
+        $this->assertStringContainsString('INSERT INTO `background_services`', $queries[0]['sql']);
+        $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $queries[0]['sql']);
+        $this->assertSame('oce_sinch_reminders', $queries[0]['binds'][0]);
+    }
+
+    public function testEnableRegistersAndActivatesBackgroundService(): void
+    {
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $result = $listener->moduleManagerAction('enable', 1, 'Success');
+
+        $this->assertSame('Success', $result);
+
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(2, $queries);
+
+        // First: upsert to ensure the row exists
+        $this->assertStringContainsString('INSERT INTO `background_services`', $queries[0]['sql']);
+        $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $queries[0]['sql']);
+
+        // Second: activate
+        $this->assertStringContainsString('UPDATE `background_services` SET `active` = ?', $queries[1]['sql']);
+        $this->assertSame(1, $queries[1]['binds'][0]);
+        $this->assertSame('oce_sinch_reminders', $queries[1]['binds'][1]);
+    }
+
+    public function testDisableDeactivatesBackgroundService(): void
+    {
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $result = $listener->moduleManagerAction('disable', 1, 'Success');
+
+        $this->assertSame('Success', $result);
+
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(1, $queries);
+        $this->assertStringContainsString('UPDATE `background_services` SET `active` = ?', $queries[0]['sql']);
+        $this->assertSame(0, $queries[0]['binds'][0]);
+        $this->assertSame('oce_sinch_reminders', $queries[0]['binds'][1]);
+    }
+
+    public function testUnregisterDeletesBackgroundService(): void
+    {
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $result = $listener->moduleManagerAction('unregister', 1, 'Success');
+
+        $this->assertSame('Success', $result);
+
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(1, $queries);
+        $this->assertStringContainsString('DELETE FROM `background_services`', $queries[0]['sql']);
+        $this->assertSame('oce_sinch_reminders', $queries[0]['binds'][0]);
+    }
+
+    public function testDatabaseFailureReturnsErrorWithTraceableRef(): void
+    {
+        QueryUtils::setNextException(new \RuntimeException('connection lost'));
+
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $result = $listener->moduleManagerAction('install', 1, 'Success');
+
+        $this->assertNotSame('Success', $result);
+        $this->assertMatchesRegularExpression('/ref: [0-9a-f]{8}/', $result);
+        $this->assertStringNotContainsString('connection lost', $result);
+    }
+
+    public function testUnknownActionReturnsCurrentStatus(): void
+    {
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $result = $listener->moduleManagerAction('nonexistent_action', 1, 'Success');
+
+        $this->assertSame('Success', $result);
+
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(0, $queries);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,6 +25,7 @@ require_once __DIR__ . '/Mocks/MockSystemLogger.php';
 require_once __DIR__ . '/Mocks/MockQueryUtils.php';
 require_once __DIR__ . '/Mocks/MockCryptoGen.php';
 require_once __DIR__ . '/Mocks/MockCsrfUtils.php';
+require_once __DIR__ . '/Mocks/MockModulesClassLoader.php';
 
 // Define OpenEMR global functions used in controllers
 if (!function_exists('xlt')) {


### PR DESCRIPTION
## Summary

- Add `background_service_entry.php` as the `require_once` entry point for OpenEMR's background service system
- Add `ModuleManagerListener.php` to manage `background_services` table registration across module lifecycle (enable/disable/unregister)
- Extract `ErrorId::generate()` to centralize traceable error reference generation (replaces 15 inline call sites)
- Add tests for entry point, lifecycle hooks, and error paths

Phase 1 of the plan in `docs/plans/50-cron-api-endpoint.md` — register as a background service now using the existing table, aligned with upstream's modernization direction (openemr/openemr#11325). When the upstream REST API lands (openemr/openemr#11330), triggering comes for free.

Closes #50

## Test plan

- [ ] Verify `task check` passes (phpcs, phpstan, rector, require-checker)
- [ ] Verify all tests pass (`task test`)
- [ ] Install module and confirm `background_services` row is created
- [ ] Enable/disable module and confirm `active` flag toggles
- [ ] Unregister module and confirm row is deleted
- [ ] Trigger via CLI: `php library/ajax/execute_background_services.php default oce_sinch_reminders 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)