### PR TITLE
chore: bump minimum OpenEMR version to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ A HIPAA-compliant, omnichannel patient communication module for OpenEMR using th
 
 ## Requirements
 
-- OpenEMR 7.0.0 or later
+- OpenEMR 8.0.0 or later
 - PHP 8.2 or later
-- MySQL 5.7 or later / MariaDB 10.2 or later
+- MariaDB 10.6 or later
 - **Sinch Conversations API account with BAA** (see Legal Requirements below)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
   "require-dev": {
     "ergebnis/composer-normalize": "^2.44",
     "maglnet/composer-require-checker": "^4.0",
-    "openemr/openemr": ">=7.0.3.4 || 7.0.4.x-dev || dev-master",
+    "openemr/openemr": ">=8.0.0 || 8.1.0.x-dev || dev-master",
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^11.0",
     "rector/rector": "^2.0",
@@ -57,7 +57,7 @@
       "type": "package",
       "package": {
         "name": "openemr/openemr",
-        "version": "7.0.3.4",
+        "version": "8.0.0",
         "autoload": {
           "psr-4": {
             "OpenEMR\\": "src/"
@@ -66,7 +66,7 @@
         "source": {
           "type": "git",
           "url": "https://github.com/openemr/openemr.git",
-          "reference": "v7_0_3_4"
+          "reference": "v8_0_0"
         }
       }
     },
@@ -74,7 +74,7 @@
       "type": "package",
       "package": {
         "name": "openemr/openemr",
-        "version": "7.0.4.x-dev",
+        "version": "8.1.0.x-dev",
         "autoload": {
           "psr-4": {
             "OpenEMR\\": "src/"
@@ -83,7 +83,7 @@
         "source": {
           "type": "git",
           "url": "https://github.com/openemr/openemr.git",
-          "reference": "rel-704"
+          "reference": "rel-810"
         }
       }
     },

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -171,11 +171,6 @@ class ConfigService
     {
         $cryptoGen = new CryptoGen();
         $encrypted = $cryptoGen->encryptStandard($value);
-
-        if ($encrypted === false) {
-            throw new ValidationException("Failed to encrypt API secret");
-        }
-
         $this->saveSetting($key, $encrypted);
     }
 }

--- a/src/Module/Service/KeywordHandlerService.php
+++ b/src/Module/Service/KeywordHandlerService.php
@@ -175,7 +175,6 @@ class KeywordHandlerService
         $national = substr((string) $digits, -10);
 
         // Strip common formatting chars and compare last 10 digits.
-        // Use chained REPLACE instead of REGEXP_REPLACE for MySQL 5.7 compatibility.
         $stripPhone = "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE("
             . "phone_cell, '-', ''), ' ', ''), '(', ''), ')', ''), '.', '')";
         $sql = "SELECT pid, fname, lname, phone_cell


### PR DESCRIPTION
## Summary

- Update `composer.json` constraint and package repositories from OpenEMR 7.x to 8.x
- Remove dead `encryptStandard() === false` check (`encryptStandard` returns `string` in OpenEMR 8, never `false`)
- Remove MySQL 5.7 compatibility comment (OpenEMR 8 ships MariaDB 11.8)
- Update README requirements to OpenEMR 8.0.0 and MariaDB 10.6

## Test plan

- [x] All 378 unit tests pass
- [x] All pre-commit checks pass (PHPStan, PHPCS, Rector, require-checker)
- [x] Verify module installs and enables on OpenEMR 8

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)