### PR TITLE
fix: use #[AsCommand] attribute for CLI command names

### DIFF
--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -1,0 +1,40 @@
+name: CLI Smoke Test
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  cli-smoke-test:
+    name: CLI boots successfully
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+        extensions: json, curl
+        coverage: none
+        tools: composer:v2
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@v5
+      with:
+        path: vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-interaction
+
+    - name: Verify CLI boots
+      run: php cli.php list --short

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,3 +90,10 @@ repos:
     language: system
     files: ^(composer\.json|src/.+\.php)$
     pass_filenames: false
+
+  - id: cli-smoke-test
+    name: CLI Smoke Test
+    entry: php cli.php list --short
+    language: system
+    always_run: true
+    pass_filenames: false

--- a/src/Module/Command/AppListCommand.php
+++ b/src/Module/Command/AppListCommand.php
@@ -15,20 +15,22 @@ namespace OpenCoreEMR\Modules\SinchConversations\Command;
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;
 use OpenCoreEMR\Sinch\Conversation\Config\StandaloneConfig;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'sinch:app:list',
+    description: 'List all Sinch Conversation apps in your project',
+)]
 class AppListCommand extends Command
 {
-    protected static ?string $defaultName = 'sinch:app:list';
-
     protected function configure(): void
     {
         $this
-            ->setDescription('List all Sinch Conversation apps in your project')
             ->setHelp('Lists all Sinch Conversation apps configured in your project.')
             ->addOption('project-id', 'p', InputOption::VALUE_REQUIRED, 'Sinch Project ID')
             ->addOption('api-key', 'k', InputOption::VALUE_REQUIRED, 'Sinch API Key ID')

--- a/src/Module/Command/InspectCommand.php
+++ b/src/Module/Command/InspectCommand.php
@@ -15,20 +15,22 @@ namespace OpenCoreEMR\Modules\SinchConversations\Command;
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;
 use OpenCoreEMR\Sinch\Conversation\Config\StandaloneConfig;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'sinch:inspect',
+    description: 'Inspect Sinch Conversations API configuration',
+)]
 class InspectCommand extends Command
 {
-    protected static ?string $defaultName = 'sinch:inspect';
-
     protected function configure(): void
     {
         $this
-            ->setDescription('Inspect Sinch Conversations API configuration')
             ->setHelp('Fetches and displays your Sinch app configuration, including channels and senders.')
             ->addOption(
                 'project-id',

--- a/src/Module/Command/WebhookCreateCommand.php
+++ b/src/Module/Command/WebhookCreateCommand.php
@@ -15,6 +15,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Command;
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;
 use OpenCoreEMR\Sinch\Conversation\Config\StandaloneConfig;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,14 +23,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'sinch:webhook:create',
+    description: 'Create a webhook for a Sinch app',
+)]
 class WebhookCreateCommand extends Command
 {
-    protected static ?string $defaultName = 'sinch:webhook:create';
-
     protected function configure(): void
     {
         $this
-            ->setDescription('Create a webhook for a Sinch app')
             ->setHelp('Creates a new webhook to receive message events and delivery receipts.')
             ->addArgument('url', InputArgument::REQUIRED, 'Webhook target URL (e.g., https://example.com/webhook)')
             ->addOption('project-id', 'p', InputOption::VALUE_REQUIRED, 'Sinch Project ID')

--- a/src/Module/Command/WebhookListCommand.php
+++ b/src/Module/Command/WebhookListCommand.php
@@ -15,20 +15,22 @@ namespace OpenCoreEMR\Modules\SinchConversations\Command;
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;
 use OpenCoreEMR\Sinch\Conversation\Config\StandaloneConfig;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'sinch:webhook:list',
+    description: 'List webhooks for a Sinch app',
+)]
 class WebhookListCommand extends Command
 {
-    protected static ?string $defaultName = 'sinch:webhook:list';
-
     protected function configure(): void
     {
         $this
-            ->setDescription('List webhooks for a Sinch app')
             ->setHelp('Lists all webhooks configured for a Sinch Conversation app.')
             ->addOption('project-id', 'p', InputOption::VALUE_REQUIRED, 'Sinch Project ID')
             ->addOption('app-id', 'a', InputOption::VALUE_REQUIRED, 'Sinch App ID')


### PR DESCRIPTION
## Summary

- Replace deprecated `$defaultName` static property with `#[AsCommand]` attribute on all four Sinch CLI commands (`InspectCommand`, `AppListCommand`, `WebhookListCommand`, `WebhookCreateCommand`)
- Add CLI smoke test as both a pre-commit hook and CI workflow to catch boot-time regressions

Symfony Console 7.x dropped support for `$defaultName`, causing every CLI invocation to crash with "cannot have an empty name."

Closes #59

## Test plan

- [x] `php cli.php list` boots and shows all four `sinch:*` commands
- [x] `php cli.php sinch:inspect --help` displays correct name and description
- [x] `task check` passes (all checks including new CLI smoke test)
- [x] Verified old `$defaultName` pattern crashes on Symfony Console 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)