### PR TITLE
chore: add declare(strict_types=1) to all PHP files

### DIFF
--- a/bin/install-module.php
+++ b/bin/install-module.php
@@ -20,6 +20,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 if (php_sapi_name() !== 'cli') {
     echo "This script can only be run from the command line.\n";
     exit(1);

--- a/cli.php
+++ b/cli.php
@@ -11,6 +11,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/vendor/autoload.php';
 
 use OpenCoreEMR\Modules\SinchConversations\Command\AppListCommand;

--- a/config/templates.php
+++ b/config/templates.php
@@ -13,6 +13,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 return [
     // Consent & Opt-in Templates
     [

--- a/docker/entrypoint.php
+++ b/docker/entrypoint.php
@@ -7,6 +7,8 @@
  * Avoids the slow chown operations in the standard openemr.sh entrypoint
  */
 
+declare(strict_types=1);
+
 echo "==> Simple OpenEMR Development Entrypoint\n";
 
 // Generate SSL certificates if they don't exist

--- a/openemr.bootstrap.php
+++ b/openemr.bootstrap.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 /**

--- a/public/conversation.php
+++ b/public/conversation.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchConversations\Bootstrap;

--- a/public/index.php
+++ b/public/index.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchConversations\Bootstrap;

--- a/public/settings.php
+++ b/public/settings.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchConversations\Bootstrap;

--- a/public/webhook.php
+++ b/public/webhook.php
@@ -13,6 +13,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 // Don't require session for webhooks - Sinch calls this endpoint directly
 $ignoreAuth = true;
 

--- a/sinch-infra/inspect.php
+++ b/sinch-infra/inspect.php
@@ -17,6 +17,8 @@
  *   SINCH_REGION (us or eu)
  */
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use GuzzleHttp\Client;

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use OpenEMR\Common\Logging\SystemLogger;

--- a/src/Module/Channel.php
+++ b/src/Module/Channel.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 enum Channel: string

--- a/src/Module/Command/AppListCommand.php
+++ b/src/Module/Command/AppListCommand.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Command;
 
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;

--- a/src/Module/Command/InspectCommand.php
+++ b/src/Module/Command/InspectCommand.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Command;
 
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;

--- a/src/Module/Command/StandaloneConfig.php
+++ b/src/Module/Command/StandaloneConfig.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Command;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/src/Module/Command/WebhookCreateCommand.php
+++ b/src/Module/Command/WebhookCreateCommand.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Command;
 
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;

--- a/src/Module/Command/WebhookListCommand.php
+++ b/src/Module/Command/WebhookListCommand.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Command;
 
 use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;

--- a/src/Module/ConfigAccessorInterface.php
+++ b/src/Module/ConfigAccessorInterface.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 /**

--- a/src/Module/ConfigFactory.php
+++ b/src/Module/ConfigFactory.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 /**

--- a/src/Module/Console/Command/AbstractModuleCommand.php
+++ b/src/Module/Console/Command/AbstractModuleCommand.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use OpenCoreEMR\Modules\SinchConversations\Console\ModuleInstaller;

--- a/src/Module/Console/Command/ModuleDisableCommand.php
+++ b/src/Module/Console/Command/ModuleDisableCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Module/Console/Command/ModuleEnableCommand.php
+++ b/src/Module/Console/Command/ModuleEnableCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Module/Console/Command/ModuleInstallCommand.php
+++ b/src/Module/Console/Command/ModuleInstallCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Module/Console/Command/ModuleInstallEnableCommand.php
+++ b/src/Module/Console/Command/ModuleInstallEnableCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Module/Console/Command/ModuleListCommand.php
+++ b/src/Module/Console/Command/ModuleListCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Module/Console/Command/ModuleRegisterCommand.php
+++ b/src/Module/Console/Command/ModuleRegisterCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Module/Console/Command/ModuleUnregisterCommand.php
+++ b/src/Module/Console/Command/ModuleUnregisterCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Module/Console/ModuleInstaller.php
+++ b/src/Module/Console/ModuleInstaller.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Console;
 
 use OpenEMR\Common\Database\QueryUtils;

--- a/src/Module/Controller/ConversationController.php
+++ b/src/Module/Controller/ConversationController.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;

--- a/src/Module/Controller/InboxController.php
+++ b/src/Module/Controller/InboxController.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;

--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;

--- a/src/Module/EnvironmentConfigAccessor.php
+++ b/src/Module/EnvironmentConfigAccessor.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use Symfony\Component\HttpFoundation\ParameterBag;

--- a/src/Module/FileConfigAccessor.php
+++ b/src/Module/FileConfigAccessor.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use Symfony\Component\HttpFoundation\ParameterBag;

--- a/src/Module/GlobalConfig.php
+++ b/src/Module/GlobalConfig.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use OpenEMR\Common\Crypto\CryptoGen;

--- a/src/Module/GlobalsAccessor.php
+++ b/src/Module/GlobalsAccessor.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use OpenEMR\Core\Kernel;

--- a/src/Module/ModuleAccessGuard.php
+++ b/src/Module/ModuleAccessGuard.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use OpenEMR\Common\Database\QueryUtils;

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -14,6 +14,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/src/Module/Service/ConsentService.php
+++ b/src/Module/Service/ConsentService.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;

--- a/src/Module/Service/KeywordHandlerService.php
+++ b/src/Module/Service/KeywordHandlerService.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/src/Module/Service/MessageOptions.php
+++ b/src/Module/Service/MessageOptions.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;

--- a/src/Module/Service/MessagePollingService.php
+++ b/src/Module/Service/MessagePollingService.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;

--- a/src/Module/Service/MessageService.php
+++ b/src/Module/Service/MessageService.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;

--- a/src/Module/Service/PhoneNormalizer.php
+++ b/src/Module/Service/PhoneNormalizer.php
@@ -13,6 +13,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 class PhoneNormalizer

--- a/src/Module/Service/TemplateService.php
+++ b/src/Module/Service/TemplateService.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;

--- a/src/Module/SessionAccessor.php
+++ b/src/Module/SessionAccessor.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 /**

--- a/src/Module/YamlConfigLoader.php
+++ b/src/Module/YamlConfigLoader.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use OpenCoreEMR\Sinch\Conversation\Exception\ConfigurationException;

--- a/src/Sinch/Conversation/Client/AppConfigurationClient.php
+++ b/src/Sinch/Conversation/Client/AppConfigurationClient.php
@@ -13,6 +13,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Client;
 
 use GuzzleHttp\Client;

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Client;
 
 use GuzzleHttp\Client;

--- a/src/Sinch/Conversation/Config/ConfigInterface.php
+++ b/src/Sinch/Conversation/Config/ConfigInterface.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Config;
 
 interface ConfigInterface

--- a/src/Sinch/Conversation/Config/StandaloneConfig.php
+++ b/src/Sinch/Conversation/Config/StandaloneConfig.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Config;
 
 class StandaloneConfig implements ConfigInterface

--- a/src/Sinch/Conversation/Exception/AccessDeniedException.php
+++ b/src/Sinch/Conversation/Exception/AccessDeniedException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 class AccessDeniedException extends BaseException

--- a/src/Sinch/Conversation/Exception/ApiException.php
+++ b/src/Sinch/Conversation/Exception/ApiException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 class ApiException extends BaseException

--- a/src/Sinch/Conversation/Exception/BaseException.php
+++ b/src/Sinch/Conversation/Exception/BaseException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 abstract class BaseException extends \RuntimeException implements ExceptionInterface

--- a/src/Sinch/Conversation/Exception/ConfigurationException.php
+++ b/src/Sinch/Conversation/Exception/ConfigurationException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 class ConfigurationException extends BaseException

--- a/src/Sinch/Conversation/Exception/ExceptionInterface.php
+++ b/src/Sinch/Conversation/Exception/ExceptionInterface.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 interface ExceptionInterface extends \Throwable

--- a/src/Sinch/Conversation/Exception/NotFoundException.php
+++ b/src/Sinch/Conversation/Exception/NotFoundException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 class NotFoundException extends BaseException

--- a/src/Sinch/Conversation/Exception/UnauthorizedException.php
+++ b/src/Sinch/Conversation/Exception/UnauthorizedException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 class UnauthorizedException extends BaseException

--- a/src/Sinch/Conversation/Exception/ValidationException.php
+++ b/src/Sinch/Conversation/Exception/ValidationException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Sinch\Conversation\Exception;
 
 class ValidationException extends BaseException

--- a/tests/Mocks/MockCryptoGen.php
+++ b/tests/Mocks/MockCryptoGen.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Crypto;
 
 /**

--- a/tests/Mocks/MockCsrfUtils.php
+++ b/tests/Mocks/MockCsrfUtils.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Csrf;
 
 /**

--- a/tests/Mocks/MockGlobalsAccessor.php
+++ b/tests/Mocks/MockGlobalsAccessor.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Mocks;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalsAccessor;

--- a/tests/Mocks/MockKernel.php
+++ b/tests/Mocks/MockKernel.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Core;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;

--- a/tests/Mocks/MockModulesClassLoader.php
+++ b/tests/Mocks/MockModulesClassLoader.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Core;
 
 /**

--- a/tests/Mocks/MockQueryUtils.php
+++ b/tests/Mocks/MockQueryUtils.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Database;
 
 /**

--- a/tests/Mocks/MockSystemLogger.php
+++ b/tests/Mocks/MockSystemLogger.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Logging;
 
 use Psr\Log\LoggerInterface;

--- a/tests/Mocks/MockTwigContainer.php
+++ b/tests/Mocks/MockTwigContainer.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Twig;
 
 use Twig\Environment;

--- a/tests/Unit/BackgroundServiceEntryTest.php
+++ b/tests/Unit/BackgroundServiceEntryTest.php
@@ -8,6 +8,8 @@
  * @link      https://www.opencoreemr.com
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\Bootstrap;

--- a/tests/Unit/ConfigFactoryTest.php
+++ b/tests/Unit/ConfigFactoryTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\ConfigFactory;

--- a/tests/Unit/Controller/ConversationControllerTest.php
+++ b/tests/Unit/Controller/ConversationControllerTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\Controller\ConversationController;

--- a/tests/Unit/Controller/InboxControllerTest.php
+++ b/tests/Unit/Controller/InboxControllerTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\Controller\InboxController;

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\Controller\SettingsController;

--- a/tests/Unit/Controller/WebhookControllerTest.php
+++ b/tests/Unit/Controller/WebhookControllerTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\Controller\WebhookController;

--- a/tests/Unit/EnvironmentConfigAccessorTest.php
+++ b/tests/Unit/EnvironmentConfigAccessorTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\EnvironmentConfigAccessor;

--- a/tests/Unit/FileConfigAccessorTest.php
+++ b/tests/Unit/FileConfigAccessorTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\FileConfigAccessor;

--- a/tests/Unit/GlobalConfigTest.php
+++ b/tests/Unit/GlobalConfigTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/GlobalsAccessorTest.php
+++ b/tests/Unit/GlobalsAccessorTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalsAccessor;

--- a/tests/Unit/ModuleAccessGuardTest.php
+++ b/tests/Unit/ModuleAccessGuardTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/ModuleManagerListenerTest.php
+++ b/tests/Unit/ModuleManagerListenerTest.php
@@ -8,6 +8,8 @@
  * @link      https://www.opencoreemr.com
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenEMR\Common\Database\QueryUtils;

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/Service/ConfigServiceTest.php
+++ b/tests/Unit/Service/ConfigServiceTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/Service/ConsentServiceTest.php
+++ b/tests/Unit/Service/ConsentServiceTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;

--- a/tests/Unit/Service/KeywordHandlerServiceTest.php
+++ b/tests/Unit/Service/KeywordHandlerServiceTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/Service/MessageOptionsTest.php
+++ b/tests/Unit/Service/MessageOptionsTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;

--- a/tests/Unit/Service/MessagePollingServiceTest.php
+++ b/tests/Unit/Service/MessagePollingServiceTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/Service/MessageServiceTest.php
+++ b/tests/Unit/Service/MessageServiceTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/Service/PhoneNormalizerTest.php
+++ b/tests/Unit/Service/PhoneNormalizerTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Service\PhoneNormalizer;

--- a/tests/Unit/Service/TemplateServiceTest.php
+++ b/tests/Unit/Service/TemplateServiceTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;

--- a/tests/Unit/YamlConfigLoaderTest.php
+++ b/tests/Unit/YamlConfigLoaderTest.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 
 use OpenCoreEMR\Modules\SinchConversations\YamlConfigLoader;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 // Load Composer autoloader
 require_once __DIR__ . '/../vendor/autoload.php';
 

--- a/version.php
+++ b/version.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 // Default version when not in a git repository
 // This is automatically updated by release-please
 const DEFAULT_VERSION = '0.9.0'; // x-release-please-version


### PR DESCRIPTION
## Summary

- Add `declare(strict_types=1)` to all 94 PHP files that were missing it
- Follows OCE coding convention: "Every PHP file starts with `declare(strict_types=1)`. No exceptions."
- Placement follows existing repo pattern: after the file-level docblock, before namespace/imports

Closes #69

## Test plan

- [x] All 378 tests pass (836 assertions) — no latent type coercion bugs surfaced
- [x] `task check` passes (PHPStan, PHPCS, Rector, CLI smoke test, etc.)
- [x] No PHP files remain without `declare(strict_types=1)` (`git grep -rL` returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)