### PR TITLE
chore: migrate PHPUnit @dataProvider doc-comments to attributes

### DIFF
--- a/tests/Unit/Service/KeywordHandlerServiceTest.php
+++ b/tests/Unit/Service/KeywordHandlerServiceTest.php
@@ -22,6 +22,7 @@ use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class KeywordHandlerServiceTest extends TestCase
@@ -71,9 +72,7 @@ class KeywordHandlerServiceTest extends TestCase
 
     // --- STOP keywords ---
 
-    /**
-     * @dataProvider stopKeywordProvider
-     */
+    #[DataProvider('stopKeywordProvider')]
     public function testStopKeywordsOptOutAndRespond(string $keyword): void
     {
         $this->mockPatientLookup('+15559999999', [
@@ -140,9 +139,7 @@ class KeywordHandlerServiceTest extends TestCase
 
     // --- START keywords ---
 
-    /**
-     * @dataProvider startKeywordProvider
-     */
+    #[DataProvider('startKeywordProvider')]
     public function testStartKeywordsOptInAndRespond(string $keyword): void
     {
         $this->mockPatientLookup('+15559999999', [
@@ -196,9 +193,7 @@ class KeywordHandlerServiceTest extends TestCase
 
     // --- HELP keywords ---
 
-    /**
-     * @dataProvider helpKeywordProvider
-     */
+    #[DataProvider('helpKeywordProvider')]
     public function testHelpKeywordsRespond(string $keyword): void
     {
         $this->mockPatientLookup('+15559999999', [

--- a/tests/Unit/Service/PhoneNormalizerTest.php
+++ b/tests/Unit/Service/PhoneNormalizerTest.php
@@ -15,13 +15,12 @@ declare(strict_types=1);
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Service\PhoneNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class PhoneNormalizerTest extends TestCase
 {
-    /**
-     * @dataProvider validPhoneProvider
-     */
+    #[DataProvider('validPhoneProvider')]
     public function testNormalizesToE164(string $input, string $expected): void
     {
         $this->assertSame($expected, PhoneNormalizer::toE164($input));
@@ -49,9 +48,7 @@ class PhoneNormalizerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidPhoneProvider
-     */
+    #[DataProvider('invalidPhoneProvider')]
     public function testReturnsNullForInvalidInput(string $input): void
     {
         $this->assertNull(PhoneNormalizer::toE164($input));


### PR DESCRIPTION
## Summary
- Replace 5 deprecated `@dataProvider` doc-comment annotations with `#[DataProvider]` PHP 8 attributes in `KeywordHandlerServiceTest` and `PhoneNormalizerTest`
- Prepares for PHPUnit 12 which will drop support for doc-comment metadata

Closes #65

## Test plan
- [x] All 378 tests pass
- [x] All pre-commit checks pass (phpstan, phpcs, rector, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)