### PR TITLE
fix: consolidate settings to module page, remove globals duplicates

### DIFF
--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -85,123 +85,34 @@ class Bootstrap
                     $setting
                 );
 
+                $settingsPath = $this->globalsConfig->getWebroot()
+                    . '/interface/modules/custom_modules/' . self::MODULE_NAME
+                    . '/public/settings.php';
                 $setting = new GlobalSetting(
-                    xlt('Sinch Project ID'),
-                    'text',
+                    xlt('Module Settings'),
+                    GlobalSetting::DATA_TYPE_HTML_DISPLAY_SECTION,
                     '',
-                    xlt('Your Sinch project ID from the Sinch dashboard')
+                    xlt('Link to the module settings page')
+                );
+                $setting->addFieldOption(
+                    GlobalSetting::DATA_TYPE_OPTION_RENDER_CALLBACK,
+                    static function () use ($settingsPath): string {
+                        $url = attr($settingsPath);
+                        $label = xlt('Open Module Settings');
+                        $description = xlt(
+                            'API credentials, messaging configuration, and webhook settings'
+                            . ' are managed on the module settings page.'
+                        );
+                        return <<<HTML
+                            <p>{$description}</p>
+                            <a href="{$url}" class="btn btn-secondary btn-sm"
+                               onclick="top.restoreSession()">{$label}</a>
+                            HTML;
+                    }
                 );
                 $event->getGlobalsService()->appendToSection(
                     'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_PROJECT_ID,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Sinch App ID'),
-                    'text',
-                    '',
-                    xlt('Your Sinch app ID for the Conversations API')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_APP_ID,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Sinch API Key'),
-                    'text',
-                    '',
-                    xlt('Your Sinch API key')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_API_KEY,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Sinch API Secret'),
-                    'encrypted',
-                    '',
-                    xlt('Your Sinch API secret (will be encrypted)')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_API_SECRET,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Sinch API Region'),
-                    'text',
-                    'us',
-                    xlt('Enter your Sinch API region (us or eu)')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_REGION,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Default Channel'),
-                    'text',
-                    'SMS',
-                    xlt('Default messaging channel (SMS, WHATSAPP, or RCS)')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_DEFAULT_CHANNEL,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Clinic Name'),
-                    'text',
-                    '',
-                    xlt('Clinic name to appear in messages (e.g., "Example Clinic")')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_CLINIC_NAME,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Clinic Phone'),
-                    'text',
-                    '',
-                    xlt('Clinic phone number for message templates (e.g., "650-123-4567")')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_CLINIC_PHONE,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Webhook Secret'),
-                    'encrypted',
-                    '',
-                    xlt('Shared secret for HMAC-SHA256 webhook signature validation')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_WEBHOOK_SECRET,
-                    $setting
-                );
-
-                $setting = new GlobalSetting(
-                    xlt('Webhook IP Allowlist'),
-                    'text',
-                    '',
-                    xlt('Allowed IPs for webhooks (one per line, supports CIDR). Empty = allow all.')
-                );
-                $event->getGlobalsService()->appendToSection(
-                    'OpenCoreEMR Sinch Conversations',
-                    GlobalConfig::CONFIG_OPTION_WEBHOOK_IP_ALLOWLIST,
+                    'oce_sinch_conversations_settings_link',
                     $setting
                 );
             }

--- a/src/Module/GlobalConfig.php
+++ b/src/Module/GlobalConfig.php
@@ -128,6 +128,14 @@ class GlobalConfig
     }
 
     /**
+     * Get the OpenEMR web root path (empty string for root installs, e.g. '/openemr' for subdirectory)
+     */
+    public function getWebroot(): string
+    {
+        return $this->configAccessor->getString('webroot', '');
+    }
+
+    /**
      * Check if the patient portal is enabled
      */
     public function isPortalEnabled(): bool

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -158,8 +158,12 @@ class ConfigService
      */
     private function saveSetting(string $key, string $value): void
     {
-        $sql = "UPDATE globals SET gl_value = ? WHERE gl_name = ?";
-        QueryUtils::sqlStatementThrowException($sql, [$value, $key]);
+        $sql = <<<'SQL'
+            INSERT INTO `globals` (`gl_name`, `gl_index`, `gl_value`)
+            VALUES (?, 0, ?)
+            ON DUPLICATE KEY UPDATE `gl_value` = VALUES(`gl_value`)
+            SQL;
+        QueryUtils::sqlStatementThrowException($sql, [$key, $value]);
     }
 
     /**

--- a/templates/settings/config.html.twig
+++ b/templates/settings/config.html.twig
@@ -63,11 +63,6 @@
             <strong>{{ 'External Configuration Active'|xlt }}</strong>
             {{ 'All configuration is managed via environment variables or configuration files. Fields below are read-only.'|xlt }}
         </div>
-        {% else %}
-        <div class="alert alert-info" role="alert">
-            <strong>{{ 'Note:'|xlt }}</strong>
-            {{ 'The Sinch API Configuration (Project ID, App ID, API Key, API Secret, Region) can also be configured via Administration > Globals > OpenCoreEMR Sinch Conversations. The Messaging Configuration settings are only available here.'|xlt }}
-        </div>
         {% endif %}
 
         <form method="post" action="?action=save">

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -30,7 +30,10 @@ use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Globals\GlobalsInitializedEvent;
 use OpenEMR\Menu\MenuEvent;
+use OpenEMR\Services\Globals\GlobalSetting;
+use OpenEMR\Services\Globals\GlobalsService;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -282,5 +285,81 @@ class BootstrapTest extends TestCase
 
         $menu = $event->getMenu();
         $this->assertEmpty($menu[0]->children);
+    }
+
+    // --- Globals registration ---
+
+    public function testGlobalsRegistersOnlyEnabledToggleAndSettingsLink(): void
+    {
+        $this->bootstrap->subscribeToEvents();
+
+        $globalsService = new GlobalsService([], [], []);
+        $event = new GlobalsInitializedEvent($globalsService);
+        $this->eventDispatcher->dispatch($event, GlobalsInitializedEvent::EVENT_HANDLE);
+
+        $metadata = $globalsService->getGlobalsMetadata();
+        $section = $metadata['OpenCoreEMR Sinch Conversations'] ?? [];
+        $keys = array_keys($section);
+
+        $this->assertSame(
+            [GlobalConfig::CONFIG_OPTION_ENABLED, 'oce_sinch_conversations_settings_link'],
+            $keys,
+            'Globals section should only contain the enabled toggle and settings link'
+        );
+    }
+
+    public function testGlobalsDoesNotRegisterCredentialFields(): void
+    {
+        $this->bootstrap->subscribeToEvents();
+
+        $globalsService = new GlobalsService([], [], []);
+        $event = new GlobalsInitializedEvent($globalsService);
+        $this->eventDispatcher->dispatch($event, GlobalsInitializedEvent::EVENT_HANDLE);
+
+        $metadata = $globalsService->getGlobalsMetadata();
+        $section = $metadata['OpenCoreEMR Sinch Conversations'] ?? [];
+        $keys = array_keys($section);
+
+        $forbiddenKeys = [
+            GlobalConfig::CONFIG_OPTION_PROJECT_ID,
+            GlobalConfig::CONFIG_OPTION_APP_ID,
+            GlobalConfig::CONFIG_OPTION_API_KEY,
+            GlobalConfig::CONFIG_OPTION_API_SECRET,
+            GlobalConfig::CONFIG_OPTION_REGION,
+            GlobalConfig::CONFIG_OPTION_DEFAULT_CHANNEL,
+            GlobalConfig::CONFIG_OPTION_CLINIC_NAME,
+            GlobalConfig::CONFIG_OPTION_CLINIC_PHONE,
+            GlobalConfig::CONFIG_OPTION_WEBHOOK_SECRET,
+            GlobalConfig::CONFIG_OPTION_WEBHOOK_IP_ALLOWLIST,
+        ];
+
+        foreach ($forbiddenKeys as $key) {
+            $this->assertNotContains(
+                $key,
+                $keys,
+                "Credential/config field '{$key}' should not be registered in globals"
+            );
+        }
+    }
+
+    public function testGlobalsSettingsLinkUsesHtmlDisplaySection(): void
+    {
+        $this->bootstrap->subscribeToEvents();
+
+        $globalsService = new GlobalsService([], [], []);
+        $event = new GlobalsInitializedEvent($globalsService);
+        $this->eventDispatcher->dispatch($event, GlobalsInitializedEvent::EVENT_HANDLE);
+
+        $metadata = $globalsService->getGlobalsMetadata();
+        $section = $metadata['OpenCoreEMR Sinch Conversations'] ?? [];
+        $linkEntry = $section['oce_sinch_conversations_settings_link'] ?? null;
+
+        $this->assertNotNull($linkEntry, 'Settings link entry should exist');
+        // GlobalSetting::format() returns [label, dataType, default, description, ?fieldOptions]
+        $this->assertSame(
+            GlobalSetting::DATA_TYPE_HTML_DISPLAY_SECTION,
+            $linkEntry[1],
+            'Settings link should use html_display_section type'
+        );
     }
 }

--- a/tests/Unit/Service/ConfigServiceTest.php
+++ b/tests/Unit/Service/ConfigServiceTest.php
@@ -105,9 +105,9 @@ class ConfigServiceTest extends TestCase
         ]);
 
         $queries = QueryUtils::getQueries();
-        $updateQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'UPDATE globals'));
-        // Should have 7 updates (project_id, app_id, api_key, region, channel, name, phone)
-        $this->assertCount(7, $updateQueries);
+        $upsertQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'INSERT INTO `globals`'));
+        // Should have 7 upserts (project_id, app_id, api_key, region, channel, name, phone)
+        $this->assertCount(7, $upsertQueries);
     }
 
     public function testSaveSettingsAcceptsValidRegions(): void
@@ -140,7 +140,7 @@ class ConfigServiceTest extends TestCase
         $this->service->saveSettings(['clinic_name' => 'Test']);
 
         $queries = QueryUtils::getQueries();
-        $updateQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'UPDATE globals'));
-        $this->assertCount(1, $updateQueries);
+        $upsertQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'INSERT INTO `globals`'));
+        $this->assertCount(1, $upsertQueries);
     }
 }


### PR DESCRIPTION
## Summary
- Replace 10 duplicate global setting registrations with a single "Open Module Settings" link via `html_display_section`, keeping only the enable/disable toggle in globals
- Add `GlobalConfig::getWebroot()` to avoid direct `$GLOBALS` access in the render callback
- Change `ConfigService::saveSetting()` to upsert so settings work on fresh installs without prior globals registration
- Remove settings template note directing users to the globals page
- Add regression tests verifying globals only registers the enabled toggle and settings link

## Test plan
- [ ] Verify `Admin > Config > OpenCoreEMR Sinch Conversations` shows only the enable toggle and the "Open Module Settings" link
- [ ] Click the "Open Module Settings" link — should navigate to the module settings page
- [ ] Verify the inbox Settings button still navigates to the module settings page
- [ ] In env config mode, verify the settings page shows "External Configuration Active" with actual values
- [ ] In database config mode, verify saving settings works (upsert creates rows on fresh install)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)