### PR TITLE
fix: normalize phone in ConversationController::handleReply

### DIFF
--- a/src/Module/Controller/ConversationController.php
+++ b/src/Module/Controller/ConversationController.php
@@ -18,6 +18,7 @@ use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessagePollingService;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
+use OpenCoreEMR\Modules\SinchConversations\Service\PhoneNormalizer;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
@@ -140,10 +141,15 @@ class ConversationController
             throw new ValidationException("Patient phone number not found");
         }
 
+        $normalizedPhone = PhoneNormalizer::toE164($patient['phone_cell']);
+        if ($normalizedPhone === null) {
+            throw new ValidationException("Patient phone number is not a valid phone number");
+        }
+
         try {
             $this->messageService->sendToPatient(
                 (int) $conversation['patient_id'],
-                $patient['phone_cell'],
+                $normalizedPhone,
                 $messageBody
             );
 

--- a/tests/Unit/Controller/ConversationControllerTest.php
+++ b/tests/Unit/Controller/ConversationControllerTest.php
@@ -291,6 +291,57 @@ class ConversationControllerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $response);
     }
 
+    public function testReplyNormalizesPhoneToE164(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['csrf_token'] = 'valid';
+        $_POST['conversation_id'] = 'conv-1';
+        $_POST['message'] = 'Reply text';
+        CsrfUtils::setVerifyResult(true);
+
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_conversations WHERE conversation_id = ?",
+            ['conv-1'],
+            [['patient_id' => 42]]
+        );
+        QueryUtils::setMockResult(
+            "SELECT phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['phone_cell' => '(555) 999-9999']]
+        );
+
+        $this->messageService->expects($this->once())
+            ->method('sendToPatient')
+            ->with(42, '+15559999999', 'Reply text');
+
+        $this->controller->dispatch('reply');
+    }
+
+    public function testReplyThrowsWhenPhoneCannotBeNormalized(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['csrf_token'] = 'valid';
+        $_POST['conversation_id'] = 'conv-1';
+        $_POST['message'] = 'Reply text';
+        CsrfUtils::setVerifyResult(true);
+
+        QueryUtils::setMockResult(
+            "SELECT patient_id FROM oce_sinch_conversations WHERE conversation_id = ?",
+            ['conv-1'],
+            [['patient_id' => 42]]
+        );
+        QueryUtils::setMockResult(
+            "SELECT phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['phone_cell' => 'not-a-phone']]
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('not a valid phone number');
+
+        $this->controller->dispatch('reply');
+    }
+
     // --- Helpers ---
 
     private function mockConversationData(string $conversationId, int $messageCount = 0): void


### PR DESCRIPTION
## Summary
- Normalize `patient_data.phone_cell` with `PhoneNormalizer::toE164()` before passing to `sendToPatient()` in `handleReply()`
- Throw `ValidationException` if the phone number cannot be normalized to E.164
- Add regression tests for normalization of non-E.164 input and rejection of invalid numbers

## Test plan
- [x] `testReplyNormalizesPhoneToE164` — raw `(555) 999-9999` is normalized to `+15559999999` before sending
- [x] `testReplyThrowsWhenPhoneCannotBeNormalized` — invalid phone `not-a-phone` throws `ValidationException`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)