### PR TITLE
chore: add periodic cleanup for appointment reminders table

### DIFF
--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -51,6 +51,8 @@ class AppointmentReminderService
             'errors' => [],
         ];
 
+        $this->purgeExpiredReminders();
+
         $hours = $this->config->getSmsNotificationHours();
         if ($hours <= 0) {
             $this->logger->debug('SMS notification hours is 0 or negative, skipping appointment reminders');
@@ -168,6 +170,22 @@ class AppointmentReminderService
                     (pc_eid, patient_id, sent_at, template_key)
                 VALUES (?, ?, NOW(), ?)";
         QueryUtils::sqlStatementThrowException($sql, [$pcEid, $patientId, $templateKey]);
+    }
+
+    /**
+     * Delete reminder records older than 90 days
+     *
+     * These records only serve as deduplication guards. Once the appointment
+     * date has long passed, they are no longer needed.
+     */
+    private function purgeExpiredReminders(): void
+    {
+        try {
+            $sql = "DELETE FROM oce_sinch_appointment_reminders WHERE sent_at < DATE_SUB(NOW(), INTERVAL 90 DAY)";
+            QueryUtils::sqlStatementThrowException($sql, []);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to purge expired appointment reminders', ['exception' => $e]);
+        }
     }
 
     /**

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -72,8 +72,19 @@ class AppointmentReminderServiceTest extends TestCase
         $this->assertSame(0, $results['sent']);
         $this->assertSame(0, $results['skipped']);
         $this->assertSame(0, $results['failed']);
-        // No DB queries should be made
-        $this->assertSame([], QueryUtils::getQueries());
+        // No appointment queries should run (purge still runs)
+        $queries = QueryUtils::getQueries();
+        $appointmentQueries = array_filter(
+            $queries,
+            static fn(array $q): bool => str_contains($q['sql'], 'openemr_postcalendar_events')
+        );
+        $this->assertCount(0, $appointmentQueries);
+
+        $purgeQueries = array_filter(
+            $queries,
+            static fn(array $q): bool => str_contains($q['sql'], 'DELETE FROM oce_sinch_appointment_reminders')
+        );
+        $this->assertNotEmpty($purgeQueries, 'Purge should still run even when notification hours is zero');
     }
 
     // --- no upcoming appointments ---
@@ -372,6 +383,23 @@ class AppointmentReminderServiceTest extends TestCase
         $results = $this->service->run();
 
         $this->assertSame(1, $results['sent']);
+    }
+
+    // --- cleanup ---
+
+    public function testRunPurgesExpiredReminders(): void
+    {
+        $this->mockUpcomingAppointments([]);
+
+        $this->service->run();
+
+        $queries = QueryUtils::getQueries();
+        $deleteQueries = array_filter(
+            $queries,
+            static fn(array $q): bool => str_contains($q['sql'], 'DELETE FROM oce_sinch_appointment_reminders')
+                && str_contains($q['sql'], 'INTERVAL 90 DAY')
+        );
+        $this->assertCount(1, $deleteQueries, 'Expected purge of expired reminders after run');
     }
 
     // --- Helpers ---


### PR DESCRIPTION
## Summary
- Add `purgeExpiredReminders()` to `AppointmentReminderService` that deletes records older than 90 days
- Run the purge at the start of each cron cycle, before checking for new appointments
- Piggybacks on the existing 15-minute background service — no separate task needed

## Test plan
- [x] `testRunPurgesExpiredReminders` — verifies DELETE query with 90-day interval runs during `run()`
- [x] `testRunReturnsEarlyWhenNotificationHoursIsZero` — updated to allow purge query while still verifying no appointment queries run

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)