### PR TITLE
chore: adopt openemr-phpstan-rules for custom static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
   "require-dev": {
     "ergebnis/composer-normalize": "^2.44",
     "maglnet/composer-require-checker": "^4.0",
+    "opencoreemr/openemr-phpstan-rules": "^0.9",
     "openemr/openemr": ">=8.0.0 || 8.1.0.x-dev || dev-master",
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^11.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,8 @@
+includes:
+    - vendor/spaze/phpstan-disallowed-calls/extension.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - vendor/opencoreemr/openemr-phpstan-rules/extension.neon
+
 parameters:
     level: 9
     paths:
@@ -28,6 +33,14 @@ parameters:
 
     # Ignore errors for unused properties and legacy OpenEMR functions
     ignoreErrors:
+        # Entry-point scripts that bootstrap OpenEMR must access $GLOBALS
+        # before OEGlobalsBag is available
+        -
+            identifier: openemr.forbiddenGlobalsAccess
+            paths:
+                - background_service_entry.php
+                - src/Module/Console/Command/AbstractModuleCommand.php
+
         # OpenEMR global functions not available for static analysis
         - '#Function (xl|xlt|xla|xlj|text|attr) not found#'
 

--- a/src/Module/GlobalsAccessor.php
+++ b/src/Module/GlobalsAccessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Central accessor for OpenEMR globals
+ * Central accessor for OpenEMR globals via OEGlobalsBag
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
@@ -15,98 +15,67 @@ declare(strict_types=1);
 namespace OpenCoreEMR\Modules\SinchConversations;
 
 use OpenEMR\Core\Kernel;
+use OpenEMR\Core\OEGlobalsBag;
 
 /**
- * Provides centralized access to OpenEMR globals.
- * This class serves as a single point of abstraction for globals access,
- * making it easier to update or refactor in the future.
+ * Delegates configuration reads to OEGlobalsBag, OpenEMR's typed wrapper
+ * around $GLOBALS. This eliminates direct superglobal access from module code.
  *
  * @internal Use ConfigFactory::createConfigAccessor() instead of instantiating directly
  */
 class GlobalsAccessor implements ConfigAccessorInterface
 {
-    /**
-     * Get a value from globals
-     */
+    private readonly OEGlobalsBag $bag;
+
+    public function __construct()
+    {
+        $this->bag = OEGlobalsBag::getInstance();
+    }
+
     public function get(string $key, mixed $default = null): mixed
     {
-        return $GLOBALS[$key] ?? $default;
+        return $this->bag->get($key, $default) ?? $default;
     }
 
-    /**
-     * Set a value in globals
-     */
     public function set(string $key, mixed $value): void
     {
-        $GLOBALS[$key] = $value;
+        $this->bag->set($key, $value);
     }
 
-    /**
-     * Check if a key exists in globals
-     */
     public function has(string $key): bool
     {
-        return isset($GLOBALS[$key]);
+        return $this->bag->has($key);
     }
 
-    /**
-     * Get a string value from globals
-     */
     public function getString(string $key, string $default = ''): string
     {
-        $value = $this->get($key, $default);
-        if (is_string($value)) {
-            return $value;
-        }
-        return is_scalar($value) || $value === null ? (string)$value : $default;
+        return $this->bag->getString($key, $default);
     }
 
-    /**
-     * Get a boolean value from globals
-     */
     public function getBoolean(string $key, bool $default = false): bool
     {
-        $value = $this->get($key, $default);
-        if (is_bool($value)) {
-            return $value;
-        }
-        // Handle string/numeric boolean values
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        return $this->bag->getBoolean($key, $default);
     }
 
-    /**
-     * Get an integer value from globals
-     */
     public function getInt(string $key, int $default = 0): int
     {
-        $value = $this->get($key, $default);
-        if (is_int($value)) {
-            return $value;
-        }
-        return is_numeric($value) ? (int)$value : $default;
+        return $this->bag->getInt($key, $default);
     }
 
     /**
      * Get the OpenEMR Kernel instance from globals
      *
+     * OEGlobalsBag doesn't have a typed kernel accessor, so we
+     * narrow the type manually here.
+     *
      * @throws \RuntimeException If the kernel is not available
      */
     public function getKernel(): Kernel
     {
-        $kernel = $this->get('kernel');
+        $kernel = $this->bag->get('kernel');
         if (!$kernel instanceof Kernel) {
             throw new \RuntimeException('OpenEMR Kernel not available');
         }
         return $kernel;
-    }
-
-    /**
-     * Get all globals
-     *
-     * @return array<string, mixed>
-     */
-    public function all(): array
-    {
-        return $GLOBALS;
     }
 }

--- a/tests/Unit/GlobalsAccessorTest.php
+++ b/tests/Unit/GlobalsAccessorTest.php
@@ -74,10 +74,16 @@ class GlobalsAccessorTest extends TestCase
         $this->assertFalse($this->accessor->has('nonexistent'));
     }
 
-    public function testHasReturnsFalseForNull(): void
+    public function testHasReturnsTrueForNull(): void
     {
-        // isset() returns false for null values
-        $this->assertFalse($this->accessor->has('test_null'));
+        // OEGlobalsBag uses array_key_exists, which returns true for null values
+        $this->assertTrue($this->accessor->has('test_null'));
+    }
+
+    public function testGetReturnsDefaultForNullValue(): void
+    {
+        // Null values are treated as missing — default is returned (matches old $GLOBALS[$key] ?? $default behavior)
+        $this->assertSame('fallback', $this->accessor->get('test_null', 'fallback'));
     }
 
     public function testGetString(): void
@@ -127,15 +133,6 @@ class GlobalsAccessorTest extends TestCase
         $GLOBALS['test_int_string'] = '123';
         $this->assertEquals(123, $this->accessor->getInt('test_int_string'));
         unset($GLOBALS['test_int_string']);
-    }
-
-    public function testAll(): void
-    {
-        $all = $this->accessor->all();
-
-        $this->assertIsArray($all);
-        $this->assertArrayHasKey('test_string', $all);
-        $this->assertEquals('hello', $all['test_string']);
     }
 
     public function testGetKernelReturnsKernel(): void


### PR DESCRIPTION
## Summary
- Add `opencoreemr/openemr-phpstan-rules` ^0.9 as a dev dependency with its transitive deps (`spaze/phpstan-disallowed-calls`, `phpstan/phpstan-deprecation-rules`)
- Include the extension and its prerequisites in `phpstan.neon`
- Rewrite `GlobalsAccessor` to delegate to `OEGlobalsBag::getInstance()` instead of accessing `$GLOBALS` directly
- Allowlist entry-point scripts (`background_service_entry.php`, `AbstractModuleCommand`) that must access `$GLOBALS` before OEGlobalsBag is available
- Remove unused `GlobalsAccessor::all()` method and its test
- Update `has()` test to match `OEGlobalsBag` semantics (`array_key_exists` vs `isset`)

## Test plan
- [x] All existing tests pass (383 tests, 854 assertions)
- [x] PHPStan reports no errors with the new rules enabled
- [x] All 18 pre-commit checks pass

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)