### PR TITLE
feat: add ADR-0001, consent API client methods, and refutation condition CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ This document describes the architectural patterns and conventions for OpenEMR m
 | [Opt-Out Handling](docs/messaging/opt-out.md) | Opt-out keywords, flows (via text and chart), compliance notes |
 | [Testing Scenarios](docs/messaging/testing.md) | End-to-end testing scenarios for messaging functionality |
 
+### Architecture Decision Records
+
+| Document | Description |
+|----------|-------------|
+| [ADR-0001: Dispatch Mode + Consent Management](docs/adr/0001-dispatch-mode-consent-management.md) | Opt-out architecture: DISPATCH mode, Sinch Consent Management, consent API polling, multi-tenant |
+
 ### Regulatory
 
 | Document | Description |

--- a/cli.php
+++ b/cli.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/vendor/autoload.php';
 
 use OpenCoreEMR\Modules\SinchConversations\Command\AppListCommand;
+use OpenCoreEMR\Modules\SinchConversations\Command\ConsentCheckCommand;
 use OpenCoreEMR\Modules\SinchConversations\Command\InspectCommand;
 use OpenCoreEMR\Modules\SinchConversations\Command\WebhookCreateCommand;
 use OpenCoreEMR\Modules\SinchConversations\Command\WebhookListCommand;
@@ -28,5 +29,6 @@ $application->add(new InspectCommand());
 $application->add(new AppListCommand());
 $application->add(new WebhookListCommand());
 $application->add(new WebhookCreateCommand());
+$application->add(new ConsentCheckCommand());
 
 $application->run();

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ docs/
 │   ├── appointment-reminders.md # Phase 1 scope, templates, variables
 │   ├── opt-out.md          # Opt-out keywords, flows, compliance
 │   └── testing.md          # End-to-end testing scenarios
+├── adr/                     # Architecture Decision Records
+│   └── 0001-dispatch-mode-consent-management.md
 ├── regulatory.md            # TCPA, HIPAA, FCC, carrier requirements
 └── sinch/                   # Sinch platform documentation
     ├── api-reference.md    # API links and guidance

--- a/docs/adr/0001-dispatch-mode-consent-management.md
+++ b/docs/adr/0001-dispatch-mode-consent-management.md
@@ -1,0 +1,155 @@
+# ADR-0001: DISPATCH mode with Sinch Consent Management handles opt-out without webhooks or inbound message processing
+
+- **Status:** Proposed
+- **Date:** 2026-03-28
+- **Decision-Makers:** Michael A. Smith
+
+## 1. Context (The Problem)
+
+The Sinch Conversations module is a **message dispatch agent** — it sends outbound SMS (appointment reminders, notifications) on behalf of clinics. It does not need to receive or process arbitrary inbound messages. However, US carrier regulations and the TCPA require that patients can opt out of receiving messages by texting STOP, and that the opt-out is honored immediately.
+
+This creates disproportionate architectural complexity for a send-only tool:
+
+**Three independent opt-out authorities.** When a patient texts STOP, the opt-out is enforced at three layers — the carrier (network-level block), Sinch (platform-level block), and OpenEMR (application-level consent records). Each layer has different update mechanisms, different authorities, and can desynchronize.
+
+**Inbound message delivery.** Sinch delivers inbound events (including STOP keywords) via webhooks — push notifications to a registered URL. In DISPATCH mode, there is no message storage and no polling API for messages. The only way to learn about inbound events is via webhooks.
+
+**Multi-tenant webhook routing.** In our Kubernetes deployment, multiple clinic tenants share a single Sinch app and phone number. Sinch sends webhooks to one URL per app. There is no built-in mechanism to route an inbound STOP notification to the correct tenant's OpenEMR instance.
+
+**UI consistency.** Clinic staff need to see accurate opt-out status in the patient chart. Stale consent records cause either unnecessary send failures (patient opted back in but OpenEMR still shows opted-out) or compliance-violating send attempts (patient opted out but OpenEMR doesn't know yet).
+
+## 2. Hypothesis
+
+*Enabling Sinch Consent Management in Primary mode and polling the Sinch Consent API to reconcile OpenEMR's records will correctly handle opt-out and re-subscribe flows in DISPATCH mode, without requiring webhooks or inbound message processing, for both single-tenant and multi-tenant deployments sharing a Sinch app.*
+
+### 2.1. Refutation Conditions
+
+- **Condition 1: Sinch Consent API does not expose per-number opt-out status.**
+  - **Validation Metric:** If the Sinch Consent Management API does not provide an endpoint to query whether a specific phone number is opted out (or to list all opted-out numbers for an app), the polling-based reconciliation strategy cannot work. Verify by calling the API with a test number that has opted out.
+
+- **Condition 2: Consent Management does not process START keywords in DISPATCH mode.**
+  - **Validation Metric:** If a patient texts START to the 10DLC number and Sinch does not remove them from the opt-out list (verifiable via the Consent API), then re-subscribe cannot be detected without webhooks. Test by texting START from a previously opted-out number and querying the API.
+
+- **Condition 3: Carrier-level block prevents Sinch from seeing START messages.**
+  - **Validation Metric:** If the carrier blocks START messages from reaching Sinch (because the number is on the carrier's block list), then Sinch never processes the opt-in and the Consent API never updates. Test by texting START from a carrier-blocked number and checking whether Sinch's consent status changes.
+
+- **Condition 4: Per-send consent API calls create unacceptable API volume or latency.** *(Withdrawn — unfalsifiable)*
+  - **Validation Metric:** If a batch reminder job for N patients requires N sequential Sinch API calls and the total time exceeds the batch window, or the call volume exceeds Sinch's rate limits, the query-on-demand approach needs a caching layer.
+  - **Withdrawn:** The consent API query volume is bounded by the SMS TPS rate (10 messages/second on this service plan), which is itself bounded by carrier throughput. A consent query cannot create volume that exceeds the send volume — the bottleneck is always the carrier, not the API. This condition cannot be meaningfully tested in isolation.
+
+- **Condition 5: Sinch Consent Management (Primary mode) fails to block a send to an opted-out number.**
+  - **Validation Metric:** The entire "use cached value on API failure" design depends on the invariant that Sinch blocks opted-out sends at the platform level regardless of our application state. If a message is delivered to a number that Sinch's own consent list shows as opted out, this invariant is broken and the architecture requires a fail-closed consent check (abort send on API failure). Test by sending to a known opted-out number and verifying Sinch rejects it.
+
+- **Condition 6: Consent API latency degrades the admin UI experience.**
+  - **Validation Metric:** If the live consent query adds more than 2 seconds of latency to the patient chart view (including timeout), the UX is unacceptable. The fallback (show cached value immediately, update asynchronously) mitigates this, but if the API is consistently slow, the cached-with-timestamp experience becomes the norm rather than the exception.
+
+## 3. Considered Options & Rationale for Refutation
+
+- **Webhooks (current implementation):**
+  - **Refutation:** Sinch's webhook URL parser rejects HTTP Basic Auth credentials in URLs. The alternative auth methods (HMAC secret token, OAuth2) work, but webhooks create a multi-tenant routing problem — all tenants share one Sinch app, so all webhooks go to one URL. Routing requires either a shared webhook receiver service (additional infrastructure) or one Sinch app per tenant (additional cost/complexity). For a send-only tool that needs to handle one inbound case (STOP), this is disproportionate.
+
+- **CONVERSATION mode with tenant-side polling:**
+  - **Refutation:** CONVERSATION mode stores messages server-side and supports polling via the Messages API. Each tenant could poll for inbound STOP messages. However, CONVERSATION mode is designed for bidirectional messaging with persistent conversation state — unnecessary overhead for a dispatch-only tool. It also changes the app's processing semantics (conversations are created, contacts are managed server-side) which adds complexity without benefit. Finally, polling for messages still requires filtering by phone number per-tenant, with the same eventual-consistency trade-offs as consent API polling.
+
+- **One Sinch app per tenant:**
+  - **Refutation:** Clean isolation — each tenant has their own app, phone number, and webhook URL. But each app requires its own 10DLC campaign registration ($15+/month per number, days for approval), its own provisioning flow, and its own webhook management. For tenants that send a few dozen reminders per month, this cost and complexity is not justified. This option remains viable as a fallback if the shared-app approach is refuted.
+
+- **Reactive sync (detect opt-out from delivery failures only):**
+  - **Refutation:** When Sinch blocks a send (Primary mode), the API returns a delivery failure. We could detect this and update records retroactively. However, this only works for STOP (opt-out) — there is no equivalent signal for START (opt-in). A patient who re-subscribes would remain marked as opted-out in OpenEMR indefinitely, since we'd never attempt to send to them again. The consent API polling approach handles both directions.
+
+## 4. Decision & Rationale for Corroboration
+
+**DISPATCH mode + Sinch Consent Management (Primary) + Consent API polling.**
+
+The architecture uses **query-on-demand** — consent status is checked at the two moments it matters, not on a schedule:
+
+1. **Send path (asynchronous).** The appointment reminder job queries the Sinch Consent API for each patient's phone number before sending. If opted out, update OpenEMR's local record and skip the send. If the consent API call fails (timeout, network error, Sinch outage), **use the cached local value and proceed** — but this is a degraded mode, not a safe default. Testing revealed that Sinch Consent Management (Primary mode) does NOT block sends to opted-out numbers via the Conversation API (see RC-5 refutation). The application is the sole enforcer of opt-out. A stale cache that says "opted in" when the patient actually opted out will result in a delivered message. This risk is bounded by the query-on-demand model: the cache is refreshed on every send attempt, so staleness only occurs if the consent API is unreachable.
+
+2. **Admin UI path (synchronous).** When clinic staff view a patient's consent status in the chart, query the Sinch Consent API live for that phone number. Show the cached local value immediately as a fallback, then update the display if the live query returns a different status. If the API is unavailable or times out, show the cached value with an "as of [timestamp]" indicator. No blocking spinner, no broken page if Sinch is down.
+
+3. **Admin opt-out (manual).** Admin marks a patient as opted out in OpenEMR → update local record only. The Sinch Consent API is read-only (see [consent API findings](../sinch/consent-api-findings.md)) — there is no write endpoint to propagate the opt-out to Sinch. The application must enforce the admin opt-out by skipping the send before calling the Sinch API. If a message is sent despite the local opt-out (bug), Sinch will still deliver it — the platform-level block only applies to STOP-keyword opt-outs, not application-level ones.
+
+4. **Admin opt-in attempt.** If the patient previously texted STOP, the carrier block is immutable from our side. Even if we remove the Sinch-level block via API, the carrier still blocks delivery. The UI must communicate this clearly: "Patient opted out via SMS. Patient must text START to [number] to re-subscribe." Do not present an opt-in toggle that silently fails on the next send.
+
+5. **Opt-out handling (STOP).** Patient texts STOP → carrier blocks at network level. Sinch Consent Management (Primary mode) records the opt-out and exposes it via the Consent API but does not prevent sends made via the Conversations `messages:send` endpoint. OpenEMR must enforce the opt-out by consulting the Consent API and skipping the send before calling Sinch. OpenEMR learns about the opt-out on the next send attempt or the next time an admin views the patient's chart — whichever comes first.
+
+6. **Re-subscribe handling (START).** Patient texts START → carrier unblocks and Sinch Consent Management updates its consent list to reflect the new opt-in. OpenEMR detects the change on the next query-on-demand (send attempt or admin chart view) and may resume sending via `messages:send`, subject to its own consent rules.
+
+7. **Multi-tenant.** All tenants share one Sinch app and phone number. Each tenant independently queries the Consent API for their own patients' phone numbers. No webhook routing, no shared infrastructure, no scheduled reconciliation jobs.
+
+No periodic polling. No cron jobs. No webhooks. Consent is queried at the moment of action and cached locally for display purposes.
+
+This approach survives the considered refutations because:
+
+- It requires zero webhook infrastructure and zero background jobs.
+- It works in DISPATCH mode without conversation storage.
+- It handles both STOP and START through the same query-on-demand mechanism.
+- Compliance is enforced at the application level: OpenEMR MUST query Sinch Consent Management before every send and block messages to opted-out numbers, because Primary mode does not block Conversation API sends.
+- The admin UI degrades gracefully when the API is unavailable (cached value + timestamp).
+- Multi-tenant works without routing — each tenant queries independently.
+
+**Pending validation:** Refutation condition RC-3 remains to be tested against the live Sinch API before this ADR is accepted. RC-1 and RC-2 were validated on 2026-04-01 (see table below). Specifically for RC-3, we need to confirm the Consent API exposes queryable per-number opt-out status and that START keywords are processed in DISPATCH mode.
+
+### 4.2. Validation Progress
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-03-28 | Switched app to DISPATCH mode via API | Confirmed: `PATCH /apps/{id}` with `{"processing_mode": "DISPATCH"}` works |
+| 2026-03-28 | Probed consent API endpoints (pre-enablement) | All returned 404 — Consent Management not yet enabled on the app |
+| 2026-03-28 | Enabled Consent Management in Sinch dashboard | Primary mode, accepted T&C |
+| 2026-03-28 | Discovered correct endpoint: `GET /consents/{list_type}` | Endpoint exists. Returns 404 when list is empty (lazily created). Valid types: OPT_OUT_ALL, OPT_OUT_MARKETING, OPT_OUT_NOTIFICATION |
+| 2026-03-28 | Attempted programmatic opt-out registration | **All write endpoints return 501 UNIMPLEMENTED.** Consent API is read-only. Numbers are added only when a real person texts STOP. |
+| 2026-03-28 | Tested admin opt-out propagation | **Cannot sync OpenEMR → Sinch.** Admin opt-out is local-only; application must enforce it before calling Sinch send API. |
+| 2026-04-01 | Fixed credentials: parent project keys required for Sinch Test app | Subproject credentials authenticate but cannot access parent project apps. |
+| 2026-04-01 | Set Default Originator on SMS service plan | Messages were silently dropped without it. Set a campaign-registered number as default originator for US. |
+| 2026-04-01 | Sent test message | **Delivered.** First successful end-to-end send via Conversation API. |
+| 2026-04-01 | Texted STOP, queried consent API | **RC-1 PASSED.** STOP processed, auto-reply sent, `GET /consents/OPT_OUT_ALL` returns the number. |
+| 2026-04-01 | Sent to opted-out number (twice) | **RC-5 REFUTED.** Both messages delivered despite number being in OPT_OUT_ALL list. Primary mode does NOT block sends via the Conversation API. |
+| 2026-04-01 | Texted START, queried consent API | **RC-2 PASSED.** START processed in DISPATCH mode, number removed from OPT_OUT_ALL list. |
+| 2026-04-01 | Added CTIA keywords | Updated English keywords: opt-out (Stop, End, Cancel, Quit, Unsubscribe), opt-in (Start, Unstop, Subscribe). |
+| 2026-04-01 | Evaluated RC-4 | **RC-4 WITHDRAWN.** Consent query volume bounded by SMS TPS rate (10/s). Cannot exceed send volume. Unfalsifiable. |
+
+**RC-5 refutation impact:** The fail-open send design is not safe. Sinch Consent Management (Primary mode) records opt-outs and sends auto-replies, but does not enforce blocking on outbound sends via the Conversation API. The application must check consent status before every send and enforce the block itself. See [consent API findings](../sinch/consent-api-findings.md) for full details.
+
+## 5. Consequences (Positive and Negative Predictions)
+
+- **Positive:** No webhook infrastructure, no background jobs, no cron. The module is a pure API client — it sends messages and queries consent status on demand. Multi-tenant deployment requires no additional services. Consent Management in Primary mode records opt-outs and provides a queryable API, but the application must enforce blocking (Primary mode does not block Conversation API sends — see RC-5 refutation).
+
+- **Positive:** Admin UI shows live consent status when the API is reachable, with graceful fallback to cached status plus timestamp when it isn't. No ambiguity about whether the displayed status is current.
+
+- **Positive:** The admin cannot accidentally re-enable SMS for a carrier-blocked patient. The UI explains the situation and directs the patient to text START — preventing a class of compliance errors where staff believe they've re-enabled consent but sends silently fail.
+
+- **Negative:** The local consent record is a cache, not a source of truth. Between a patient texting STOP and the next query-on-demand, OpenEMR's record is stale. For appointment reminders (sent hours/days in advance), staleness is bounded by the send schedule. For the admin UI, staleness is bounded by the next chart view. In both cases, the application must enforce opt-out by checking Sinch consent state before sending via the Conversation API, while carrier-level blocks may still apply independently.
+
+- **Negative:** If refutation condition 3 holds (carriers block START from reaching Sinch), patients who opt out via carrier STOP may be unable to re-subscribe through the same channel. This would require an alternative opt-in mechanism (web form, in-person consent). This is a carrier/regulatory constraint, not an architectural one.
+
+- **Negative:** Each send and each admin chart view makes a Sinch API call. For batch sends, this is N API calls per batch (one per patient). For the admin UI, this is one call per chart view. Monitor API usage against Sinch rate limits. If rate limits become a concern, introduce a short TTL cache (e.g., 5 minutes) on consent status per number.
+
+## 6. Data Localization and Compliance
+
+The [Sinch Conversation API terms](https://sinch.com/legal/conversation-api/) include a data localization clause:
+
+> **Data Localisation.** Services provisioned through Conversation API may be hosted in various locations. During implementation, Customer will configure its hosting location(s) through either the Sinch Dashboard or its Sinch account manager at service setup. If Customer wishes to change the hosting location after setup, Customer must contact Sinch. Changes to the hosting location after setup may incur additional fees.
+
+Our app is configured with `region=us`, which routes API traffic through `us.conversation.api.sinch.com`. The terms state that the hosting location is chosen at setup and persists unless explicitly changed.
+
+The [Consent Management terms](https://sinch.com/legal/conversation-api-old/consent-management-feature/) do not add any data localization constraints beyond the general Conversation API terms. The consent service is free of charge and governed by the same Terms of Service.
+
+**PHI exposure is minimal by design.** Outbound messages use templates with no patient names or clinical details — only clinic name, appointment time, and opt-out instructions. Inbound messages are expected to consist only of STOP/START keywords; we do not solicit or encourage freeform messaging. The only data Sinch stores in the consent list is "this phone number opted out of messages from this app" — no clinical content.
+
+Phone numbers linked to a healthcare provider could technically constitute PHI under HIPAA, but the risk profile is low: the consent list reveals only that a phone number interacted with a healthcare-associated messaging app, not any clinical information about the person.
+
+**Open questions for product/legal review:**
+- Does "US region" guarantee all data (including consent lists) stays in US data centers?
+- Is a BAA (Business Associate Agreement) required or available from Sinch? (Given minimal PHI exposure, this may not be necessary — but confirm with counsel.)
+
+## References
+
+- [Sinch Consent Management](https://developers.sinch.com/docs/conversation/consent-management) — Platform-level opt-out handling for the Conversation API
+- [CTIA Messaging Principles and Best Practices (May 2023)](https://api.ctia.org/wp-content/uploads/2023/05/230523-CTIA-Messaging-Principles-and-Best-Practices-FINAL.pdf) — Industry standard for A2P messaging compliance
+- [FCC TCPA Consent Revocation Order (2024)](https://talk-q.com/sms-messaging-regulation-in-the-us) — Updated rules on consent revocation, effective April 2025
+- [Sinch US SMS Compliance Guide](https://sinch.com/wp-content/uploads/pdf/Sinch-SMS-US%20Compliance%20Guide-240213.pdf) — Sinch-specific compliance guidance
+- [10DLC Opt-Ins and Opt-Outs](https://www.10dlc.org/en/home/Opt-Ins) — Campaign Registry requirements
+- [Sinch Conversation API Terms](https://sinch.com/legal/conversation-api/) — Data localization, retention, and service terms
+- [Sinch Consent Management Terms](https://sinch.com/legal/conversation-api-old/consent-management-feature/) — Consent service terms (free, governed by general ToS)
+- [RFC #83](https://github.com/openCoreEMR/oce-module-sinch-conversations/issues/83) — Original discussion of the opt-out architecture options

--- a/docs/sinch/consent-api-findings.md
+++ b/docs/sinch/consent-api-findings.md
@@ -1,0 +1,187 @@
+# Sinch Consent Management API: Empirical Findings
+
+Findings from live API testing against the Sinch Conversation API (2026-03-28 to 2026-04-01). These supplement the [official documentation](https://developers.sinch.com/docs/conversation/consent-management) which lacks endpoint-level detail.
+
+## Prerequisites
+
+Consent Management must be enabled in the Sinch dashboard (Conversation API > Apps > [app] > Consent management > Edit). This requires accepting [terms and conditions](https://sinch.com/legal/conversation-api-old/consent-management-feature/). Without this step, all consent endpoints return 404.
+
+## Confirmed Endpoint Structure
+
+```
+GET /v1/projects/{project_id}/apps/{app_id}/consents/{list_type}
+```
+
+### Valid list types
+
+- `OPT_OUT_ALL` — standard opt-out, blocks all message types
+- `OPT_OUT_MARKETING` — blocks marketing messages only
+- `OPT_OUT_NOTIFICATION` — blocks notification messages only
+
+### Invalid list types (return 400)
+
+- `OPT_IN` — not a valid list type
+- `identities`, `audit` — not valid list type values (these appear in the docs as sub-resources but are actually query parameters or separate endpoints)
+
+## Consent Lists Are Lazily Created
+
+Querying a list type that has no entries returns 404 with:
+
+```json
+{
+  "error": {
+    "code": 404,
+    "message": "ListType for projectId '{pid}', appId '{aid}' and type 'OPT_OUT_ALL' does not exist",
+    "status": "NOT_FOUND"
+  }
+}
+```
+
+This means the list only exists after at least one person has opted out via that list type. A 404 on a list type does NOT mean the API is unavailable — it means nobody has opted out yet.
+
+## The Consent API Is Read-Only
+
+**You cannot programmatically add or remove numbers from consent lists.** All write attempts return 501:
+
+```json
+{
+  "error": {
+    "code": 501,
+    "message": "Method Not Allowed",
+    "status": "UNIMPLEMENTED"
+  }
+}
+```
+
+Tested and confirmed unimplemented:
+- `POST /consents/OPT_OUT_ALL` (501)
+- `PUT /consents/OPT_OUT_ALL` (501)
+- `POST /consents/OPT_OUT_ALL:add` (501)
+- `POST /consents/OPT_OUT_ALL:register` (501)
+- `POST /consents:register` (404)
+- `POST /consents:opt-out` (404)
+
+Numbers are added to consent lists **only** when a real person texts a STOP keyword to the number. There is no API to simulate or inject opt-outs.
+
+## Implications for Our Architecture
+
+### Admin opt-out cannot sync to Sinch
+
+If an admin manually marks a patient as opted out in OpenEMR, we cannot propagate that to Sinch's consent list. Sinch will still attempt to deliver messages to that number. The admin opt-out is local-only.
+
+This means:
+- **Sinch → OpenEMR sync works** (query the consent API to learn about STOP events)
+- **OpenEMR → Sinch sync does NOT work** (no write API)
+- Admin opt-out must be enforced at the application level (skip the send before calling Sinch)
+
+### Testing requires real phones
+
+There is no way to create test opt-out data programmatically. To test the consent query flow end-to-end, someone must text STOP from a real phone number to the Sinch-linked number. The opt-out list will then be queryable.
+
+### A 404 on the consent list is not an error
+
+Application code must treat a 404 on `GET /consents/OPT_OUT_ALL` as "no one has opted out" (equivalent to an empty list), not as an API failure.
+
+## Processing Mode
+
+The app's processing mode can be switched via API:
+
+```
+PATCH /v1/projects/{project_id}/apps/{app_id}
+{"processing_mode": "DISPATCH"}
+```
+
+Confirmed: switching between CONVERSATION and DISPATCH works and takes effect immediately.
+
+## Default Originator Required for Message Delivery
+
+Messages sent via the Conversation API were silently dropped (accepted with 200 but never delivered) until a **Default Originator** was configured on the SMS service plan.
+
+**Root cause:** The Conversation API sends via the SMS service plan (OpenCoreEMR_RA), which has two numbers assigned (+1XXXXXXXXXX and +1YYYYYYYYYY). Both are registered to 10DLC campaign CO07D9V. However, without a Default Originator set, Sinch may attempt to send from a number not linked to the campaign, causing carrier-level rejection.
+
+**Fix:** SMS > Service APIs > OpenCoreEMR_RA > Set Default Originators > United States > select +1XXXXXXXXXX > Configure.
+
+**Key lesson:** The Sinch API returns 200 (accepted) even when the message will never be delivered. There is no synchronous delivery error — you must check delivery reports or the SMS analytics dashboard to diagnose failures. This makes debugging silent: the send appears to succeed.
+
+**Documentation note:** The provisioning guide must include setting a Default Originator as a required step, not optional.
+
+## Credential Configuration
+
+The Sinch Conversations app used for Consent Management resides in the **parent project**, not in a subproject. The API credentials must belong to the same (parent) project as the app — credentials scoped to a different project or subproject can authenticate but silently fail to access the parent project's apps.
+
+In practice, this means:
+- Verify which Sinch project owns the Conversations app you are targeting.
+- Ensure the API key/secret you configure for Consent Management are issued for that same project.
+- Avoid reusing subproject-specific credentials if the app is attached to the parent project.
+
+Details about where these credentials are stored (e.g., vault names, item labels, CLI commands) should be documented in an internal runbook or secret-management guide, not in this repository.
+
+## Refutation Condition 5: REFUTED — Primary Mode Does Not Block Sends
+
+**Tested 2026-04-01.** Consent Management in Primary mode does NOT block outbound messages sent via the Conversation API to opted-out numbers.
+
+Test sequence:
+1. Sent message to +1XXXXXXXXXX — delivered ✓
+2. +1XXXXXXXXXX replied STOP — auto-reply received: "You have opted out of all communications."
+3. Verified `GET /consents/OPT_OUT_ALL` shows `1XXXXXXXXXX` in the list ✓
+4. Sent "This message should be BLOCKED by Consent Management" — **delivered** ✗
+5. Waited, re-verified opt-out still in list, sent again — **delivered** ✗
+
+**Conclusion:** The consent list is correctly populated by STOP keywords, and the auto-reply works, but **Primary mode does not enforce blocking on sends via the Conversation API**. The block may only apply to sends via the SMS REST API (not routed through the Conversation API), or "Primary" may only mean Sinch sends the auto-reply and records the opt-out — not that it blocks subsequent sends.
+
+**Impact on ADR-0001:** The fail-open send design ("use cached value on API failure because Sinch blocks anyway") is **not safe**. The application must enforce opt-out checks before every send. The consent API remains valuable for querying opt-out status, but enforcement is our responsibility.
+
+## Refutation Condition 1: PASSED — Consent API Queries Work
+
+**Tested 2026-04-01.** After a real STOP message, the consent list is queryable:
+
+```
+GET /v1/projects/{pid}/apps/{aid}/consents/OPT_OUT_ALL
+{
+  "identities": [{"identity": "1XXXXXXXXXX"}],
+  "next_page_token": ""
+}
+```
+
+The endpoint returns identities without the `+` prefix (e.g., `1XXXXXXXXXX` not `+1XXXXXXXXXX`).
+
+## Missing CTIA Keywords
+
+The default English keyword configuration only has "stop" for opt-out and "start" for opt-in. CTIA Messaging Principles require honoring additional keywords:
+
+**Required opt-out keywords:** STOP, END, CANCEL, QUIT, UNSUBSCRIBE
+**Required opt-in keywords:** START, UNSTOP, SUBSCRIBE
+
+The FCC's April 2025 order further broadened this to "any reasonable means" of revocation. At minimum, add the CTIA-required keywords in the Sinch dashboard under Consent management > Keywords > English.
+
+Note: Sinch keyword matching is case-insensitive and exact-match only (the keyword must be the entire message, not a substring).
+
+## Open Questions
+
+- **Why doesn't Primary mode block sends?** The dashboard and docs both say "any subsequent mobile terminated messages will be blocked by Sinch" in Primary mode, but our testing shows messages are delivered to opted-out numbers. Possible explanations: (a) blocking only applies via the SMS REST API, not the Conversation API `messages:send` endpoint; (b) there's propagation delay longer than our test window; (c) there's an additional configuration step not documented. **This needs to be raised with Sinch support.**
+- Does the consent list store channel identity with or without the `+` prefix? (Our test showed `1XXXXXXXXXX` without `+` — need to confirm this is consistent.)
+- How does pagination work for large consent lists? (`next_page_token` was empty in our test.)
+- Does `GET /consents/OPT_OUT_ALL` support pagination? Query parameters for filtering by channel or identity?
+- Are there separate "get identities" and "get audit records" sub-endpoints, as the docs suggest? What are the exact paths?
+- Does the consent list update when someone texts START? Does the entry get removed, or is a separate OPT_IN event recorded?
+
+## Dashboard Note
+
+The Consent Management settings page shows an "Additional fees/message" badge. The [T&C](https://sinch.com/legal/conversation-api-old/consent-management-feature/) says "the Service is free of charge" and the [developer docs](https://developers.sinch.com/docs/conversation/consent-management) say "no extra charges for MO messages processed." The auto-reply messages (STOP/START confirmations) are charged as normal MT messages. Clarify the badge meaning with Sinch.
+
+## Validation Progress — Condition 2: PASSED
+
+**Tested 2026-04-01.** After texting START:
+- Auto-reply received: "You have opted in to all communications. To stop, send STOP to this number."
+- `GET /consents/OPT_OUT_ALL` returns `{"identities": [], "next_page_token": ""}` — number removed from list
+
+START keywords ARE processed in DISPATCH mode. The consent list correctly updates in both directions.
+
+## CTIA Keywords Updated
+
+Added missing CTIA-required keywords to the Sinch dashboard (2026-04-01):
+
+**Opt-out (was: Stop only):** Stop, End, Cancel, Quit, Unsubscribe
+**Opt-in (was: Start only):** Start, Unstop, Subscribe
+
+Dashboard path: Conversation API > Apps > Sinch Test > Consent management > Keywords > English > Edit (⋮ menu)

--- a/src/Module/Command/ConsentCheckCommand.php
+++ b/src/Module/Command/ConsentCheckCommand.php
@@ -1,0 +1,375 @@
+<?php
+
+/**
+ * Consent Check Command - Test ADR-0001 refutation conditions
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com/
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Command;
+
+use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;
+use OpenCoreEMR\Sinch\Conversation\Config\StandaloneConfig;
+use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'sinch:consent:check',
+    description: 'Test ADR-0001 refutation conditions against the live Sinch API',
+)]
+class ConsentCheckCommand extends Command
+{
+    private const STATUS_PASSED = 'PASSED';
+    private const STATUS_REFUTED = 'REFUTED';
+    private const STATUS_INCONCLUSIVE = 'INCONCLUSIVE';
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Test ADR-0001 refutation conditions against the live Sinch API')
+            ->setHelp(
+                'Run diagnostic checks against the Sinch Consent Management API to validate ' .
+                'assumptions in ADR-0001 (Dispatch Mode Consent Management). Each check maps to ' .
+                'a refutation condition in the ADR.'
+            )
+            ->addOption('project-id', 'p', InputOption::VALUE_REQUIRED, 'Sinch Project ID')
+            ->addOption('api-key', 'k', InputOption::VALUE_REQUIRED, 'Sinch API Key ID')
+            // Known limitation: AppConfigurationClient hard-codes the US base URL.
+            // The region option is captured here for future use but does not yet
+            // affect the API endpoint. See #62 for planned API client improvements.
+            ->addOption('region', 'r', InputOption::VALUE_REQUIRED, 'Sinch Region (us or eu)', 'us')
+            ->addOption('app-id', 'a', InputOption::VALUE_REQUIRED, 'Sinch App ID')
+            ->addOption('phone', null, InputOption::VALUE_REQUIRED, 'Phone number to test (E.164 format)')
+            ->addOption('test-send', null, InputOption::VALUE_NONE, 'Actually send a test message (costs money)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('ADR-0001 Refutation Condition Check');
+
+        $config = $this->getConfiguration($input);
+
+        $missing = [];
+        foreach (['project_id', 'api_key', 'api_secret'] as $key) {
+            if ($config[$key] === '') {
+                $missing[] = $key;
+            }
+        }
+
+        if (count($missing) > 0) {
+            $message = 'Missing required configuration: ' . implode(', ', $missing);
+            if (in_array('api_secret', $missing, true)) {
+                $message .= PHP_EOL
+                    . 'Note: SINCH_API_SECRET must be set in the environment; it is not accepted as a CLI option.';
+            }
+            $io->error($message);
+            return Command::FAILURE;
+        }
+
+        if ($config['app_id'] === '') {
+            $io->error('App ID is required. Use --app-id or set SINCH_APP_ID env var.');
+            return Command::FAILURE;
+        }
+
+        $apiClient = new AppConfigurationClient(new StandaloneConfig($config));
+        $appId = $config['app_id'];
+        $phone = $input->getOption('phone');
+        $testSend = $input->getOption('test-send');
+
+        /** @var array<int, array{check: string, condition: string, status: string, detail: string}> $results */
+        $results = [];
+
+        // Check 1: App Configuration
+        $results[] = $this->checkAppConfiguration($io, $apiClient, $appId);
+
+        // Check 2: Consent API Discovery (Refutation Condition 1)
+        $results = array_merge($results, $this->checkConsentApiDiscovery($io, $apiClient, $appId, $phone));
+
+        // Check 3: Send to Opted-Out Number (Refutation Condition 5)
+        if (is_string($phone) && $phone !== '' && $testSend) {
+            $results[] = $this->checkSendToOptedOut($io, $apiClient, $phone);
+        } elseif (is_string($phone) && $phone !== '' && !$testSend) {
+            $results[] = [
+                'check' => 'Send to Opted-Out',
+                'condition' => 'RC-5: Platform blocks opted-out sends',
+                'status' => self::STATUS_INCONCLUSIVE,
+                'detail' => 'Skipped: use --test-send to enable (costs money)',
+            ];
+        } else {
+            $results[] = [
+                'check' => 'Send to Opted-Out',
+                'condition' => 'RC-5: Platform blocks opted-out sends',
+                'status' => self::STATUS_INCONCLUSIVE,
+                'detail' => 'Skipped: --phone not provided',
+            ];
+        }
+
+        // Print results table
+        $io->newLine();
+        $io->section('Results');
+
+        $rows = [];
+        foreach ($results as $result) {
+            $status = $result['status'];
+            $formatted = match ($status) {
+                self::STATUS_PASSED => "<info>{$status}</info>",
+                self::STATUS_REFUTED => "<error>{$status}</error>",
+                default => "<comment>{$status}</comment>",
+            };
+            $rows[] = [$result['check'], $result['condition'], $formatted, $result['detail']];
+        }
+
+        $io->table(['Check', 'Condition', 'Status', 'Detail'], $rows);
+
+        $refuted = array_filter($results, fn(array $r): bool => $r['status'] === self::STATUS_REFUTED);
+        if (count($refuted) > 0) {
+            $io->warning(sprintf('%d condition(s) refuted. Review ADR-0001 assumptions.', count($refuted)));
+            return Command::FAILURE;
+        }
+
+        $io->success('All testable conditions passed or were inconclusive.');
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Check 1: Verify app configuration and consent management status
+     *
+     * @return array{check: string, condition: string, status: string, detail: string}
+     */
+    private function checkAppConfiguration(
+        SymfonyStyle $io,
+        AppConfigurationClient $apiClient,
+        string $appId
+    ): array {
+        $io->section('Check 1: App Configuration');
+
+        try {
+            $app = $apiClient->getApp($appId);
+        } catch (ApiException $e) {
+            $io->error('Failed to fetch app: ' . $e->getMessage());
+            return [
+                'check' => 'App Config',
+                'condition' => 'App is accessible',
+                'status' => self::STATUS_REFUTED,
+                'detail' => 'API call failed: ' . $e->getMessage(),
+            ];
+        }
+
+        $processingMode = $app['processing_mode'] ?? 'UNKNOWN';
+        $io->text("App ID: {$appId}");
+        $displayName = is_string($app['display_name'] ?? null) ? $app['display_name'] : 'N/A';
+        $io->text("Display Name: {$displayName}");
+        $io->text("Processing Mode: {$processingMode}");
+
+        // Look for consent-related fields in the response
+        $consentFields = [];
+        foreach (['consent_management', 'opt_in', 'opt_out', 'consent'] as $field) {
+            if (isset($app[$field])) {
+                $consentFields[$field] = $app[$field];
+            }
+        }
+
+        if (count($consentFields) > 0) {
+            $io->text('Consent-related fields found: ' . implode(', ', array_keys($consentFields)));
+            if ($io->isVerbose()) {
+                try {
+                    $json = json_encode($consentFields, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+                } catch (\JsonException $e) {
+                    $json = 'Failed to encode consent fields to JSON: ' . $e->getMessage();
+                }
+                $io->text($json);
+            }
+        } else {
+            $io->text('No consent-related fields found in app response.');
+        }
+
+        $detail = sprintf(
+            'mode=%s, consent_fields=%s',
+            $processingMode,
+            count($consentFields) > 0 ? implode(',', array_keys($consentFields)) : 'none'
+        );
+
+        $status = self::STATUS_PASSED;
+        if ($processingMode !== 'DISPATCH') {
+            $status = self::STATUS_REFUTED;
+            $detail .= ', expected_mode=DISPATCH';
+        }
+
+        return [
+            'check' => 'App Config',
+            'condition' => 'App is accessible and in DISPATCH mode',
+            'status' => $status,
+            'detail' => $detail,
+        ];
+    }
+
+    /**
+     * Check 2: Discover which consent API endpoints exist
+     *
+     * @param ?string $phone Phone number to test per-number consent query
+     * @return array<int, array{check: string, condition: string, status: string, detail: string}>
+     */
+    private function checkConsentApiDiscovery(
+        SymfonyStyle $io,
+        AppConfigurationClient $apiClient,
+        string $appId,
+        ?string $phone
+    ): array {
+        $io->section('Check 2: Consent API Discovery (RC-1)');
+        $results = [];
+
+        // Test listOptOuts
+        $io->text('Testing listOptOuts endpoint...');
+        try {
+            $optOuts = $apiClient->listOptOuts($appId);
+            $count = count($optOuts);
+            $io->text("listOptOuts returned {$count} entries.");
+
+            $results[] = [
+                'check' => 'List Opt-Outs',
+                'condition' => 'RC-1: Consent API exists',
+                'status' => self::STATUS_PASSED,
+                'detail' => $count > 0
+                    ? "{$count} opt-out entries returned"
+                    : 'Endpoint reachable, but consent list is empty (0 opt-out entries)',
+            ];
+        } catch (ApiException $e) {
+            $io->text('listOptOuts failed: ' . $e->getMessage());
+
+            $results[] = [
+                'check' => 'List Opt-Outs',
+                'condition' => 'RC-1: Consent API exists',
+                'status' => self::STATUS_INCONCLUSIVE,
+                'detail' => 'Endpoint returned error: ' . $e->getMessage(),
+            ];
+        }
+
+        // Test getConsentStatus per-number (if phone provided)
+        if (is_string($phone) && $phone !== '') {
+            $io->text("Testing getConsentStatus for {$phone}...");
+            try {
+                $consent = $apiClient->getConsentStatus($appId, $phone);
+                $hasData = count($consent) > 0;
+                $io->text($hasData ? 'Consent data returned.' : 'No consent data (empty response).');
+
+                if ($hasData && $io->isVerbose()) {
+                    try {
+                        $io->text(json_encode($consent, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+                    } catch (\JsonException $e) {
+                        $io->warning('Failed to JSON-encode consent payload: ' . $e->getMessage());
+                    }
+                }
+
+                $results[] = [
+                    'check' => 'Per-Number Consent',
+                    'condition' => 'RC-1: Per-number consent queryable',
+                    'status' => self::STATUS_PASSED,
+                    'detail' => $hasData
+                        ? 'Number ' . $phone . ' is opted out'
+                        : 'Number ' . $phone . ' is not opted out (not in consent list)',
+                ];
+            } catch (ApiException $e) {
+                $io->text('getConsentStatus failed: ' . $e->getMessage());
+                $results[] = [
+                    'check' => 'Per-Number Consent',
+                    'condition' => 'RC-1: Per-number consent queryable',
+                    'status' => self::STATUS_INCONCLUSIVE,
+                    'detail' => 'Endpoint returned error: ' . $e->getMessage(),
+                ];
+            }
+        } else {
+            $results[] = [
+                'check' => 'Per-Number Consent',
+                'condition' => 'RC-1: Per-number consent queryable',
+                'status' => self::STATUS_INCONCLUSIVE,
+                'detail' => 'Skipped: --phone not provided',
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Check 3: Attempt to send a message and observe behavior
+     *
+     * @return array{check: string, condition: string, status: string, detail: string}
+     */
+    private function checkSendToOptedOut(
+        SymfonyStyle $io,
+        AppConfigurationClient $apiClient,
+        string $phone
+    ): array {
+        $io->section('Check 3: Send to Opted-Out Number (RC-5)');
+        $io->text("Sending test message to {$phone}...");
+
+        try {
+            $result = $apiClient->sendMessageByChannelIdentity(
+                $phone,
+                'ADR-0001 consent refutation test. Please disregard.'
+            );
+
+            $messageId = $result['id'] ?? $result['message_id'] ?? 'unknown';
+            $io->text("Message accepted by API. Message ID: {$messageId}");
+            $io->text('Check delivery status in Sinch dashboard to determine if it was blocked.');
+
+            return [
+                'check' => 'Send to Opted-Out',
+                'condition' => 'RC-5: Platform blocks opted-out sends',
+                'status' => self::STATUS_INCONCLUSIVE,
+                'detail' => "Message accepted (id={$messageId}). Check dashboard for delivery status.",
+            ];
+        } catch (ApiException $e) {
+            $message = $e->getMessage();
+            // If the API explicitly rejects due to consent/opt-out, that validates RC-5
+            $isConsentBlock = str_contains(strtolower($message), 'consent')
+                || str_contains(strtolower($message), 'opt')
+                || str_contains(strtolower($message), 'block');
+
+            if ($isConsentBlock) {
+                $io->text('API rejected message (likely consent block): ' . $message);
+                return [
+                    'check' => 'Send to Opted-Out',
+                    'condition' => 'RC-5: Platform blocks opted-out sends',
+                    'status' => self::STATUS_PASSED,
+                    'detail' => 'API rejected with consent-related error',
+                ];
+            }
+
+            $io->text('API rejected message: ' . $message);
+            return [
+                'check' => 'Send to Opted-Out',
+                'condition' => 'RC-5: Platform blocks opted-out sends',
+                'status' => self::STATUS_INCONCLUSIVE,
+                'detail' => 'API error (not clearly consent-related): ' . $message,
+            ];
+        }
+    }
+
+    /**
+     * Build configuration from CLI options and env vars
+     *
+     * @return array<string, string>
+     */
+    private function getConfiguration(InputInterface $input): array
+    {
+        return [
+            'project_id' => $input->getOption('project-id') ?: getenv('SINCH_PROJECT_ID') ?: '',
+            'app_id' => $input->getOption('app-id') ?: getenv('SINCH_APP_ID') ?: '',
+            'api_key' => $input->getOption('api-key') ?: getenv('SINCH_API_KEY') ?: '',
+            'api_secret' => getenv('SINCH_API_SECRET') ?: '',
+            'region' => $input->getOption('region') ?: getenv('SINCH_REGION') ?: 'us',
+        ];
+    }
+}

--- a/src/Sinch/Conversation/Client/AppConfigurationClient.php
+++ b/src/Sinch/Conversation/Client/AppConfigurationClient.php
@@ -309,6 +309,164 @@ class AppConfigurationClient
     }
 
     /**
+     * Get the consent status for a phone number
+     *
+     * Queries the Sinch Consent Management API using the validated
+     * `/consents/{list_type}` endpoint structure. Queries the OPT_OUT_ALL
+     * list and searches for the given identity in the response.
+     *
+     * @return array<string, mixed> Consent data or empty array if not found
+     * @throws ApiException
+     */
+    public function getConsentStatus(string $appId, string $channelIdentity): array
+    {
+        if ($appId === '') {
+            throw new ApiException('App ID is required to get consent status');
+        }
+
+        $projectId = $this->config->getSinchProjectId();
+        $listType = 'OPT_OUT_ALL';
+
+        $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
+
+        try {
+            $response = $this->httpClient->get(
+                $endpoint,
+                ['headers' => $this->getHeaders()]
+            );
+
+            $statusCode = $response->getStatusCode();
+
+            // 404 can mean lazily-created empty list OR misconfiguration
+            if ($statusCode === 404) {
+                $body = (string) $response->getBody();
+                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                    return [];
+                }
+                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+            }
+
+            $data = $this->handleResponse($response);
+
+            // Filter to the requested identity (API returns full list, no per-number query)
+            $normalized = ltrim($channelIdentity, '+');
+            foreach ($data['identities'] ?? [] as $entry) {
+                if (is_array($entry) && ($entry['identity'] ?? '') === $normalized) {
+                    return $entry;
+                }
+            }
+
+            return [];
+        } catch (GuzzleException $e) {
+            throw new ApiException('Failed to get consent status', 0, $e);
+        }
+    }
+
+    /**
+     * List all opted-out numbers for an app
+     *
+     * Queries the Sinch Consent Management API using the validated
+     * `/consents/OPT_OUT_ALL` endpoint and parses the `identities` field.
+     *
+     * @return array<int, array<string, mixed>>
+     * @throws ApiException
+     */
+    public function listOptOuts(string $appId): array
+    {
+        if ($appId === '') {
+            throw new ApiException('App ID is required to list opt-outs');
+        }
+
+        $projectId = $this->config->getSinchProjectId();
+        $listType = 'OPT_OUT_ALL';
+
+        $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
+
+        try {
+            $response = $this->httpClient->get(
+                $endpoint,
+                ['headers' => $this->getHeaders()]
+            );
+
+            $statusCode = $response->getStatusCode();
+
+            // 404 can mean lazily-created empty list OR misconfiguration
+            if ($statusCode === 404) {
+                $body = (string) $response->getBody();
+                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                    return [];
+                }
+                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+            }
+
+            $data = $this->handleResponse($response);
+            return $data['identities'] ?? [];
+        } catch (GuzzleException $e) {
+            throw new ApiException('Failed to list opt-outs', 0, $e);
+        }
+    }
+
+    /**
+     * Send a message using channel identity
+     *
+     * Used by consent check to test send behavior for opted-out numbers.
+     *
+     * Note: this duplicates ConversationApiClient::sendMessageByChannelIdentity().
+     * A shared message-sending helper should be extracted to eliminate drift risk.
+     *
+     * @param string $channelIdentity Phone number
+     * @param string $message Message text
+     * @param string $channel SMS, WHATSAPP, etc
+     * @return array<string, mixed> Response data
+     * @throws ApiException
+     */
+    public function sendMessageByChannelIdentity(
+        string $channelIdentity,
+        string $message,
+        string $channel = 'SMS'
+    ): array {
+        $projectId = $this->config->getSinchProjectId();
+        $appId = $this->config->getSinchAppId();
+
+        if ($appId === '') {
+            throw new ApiException('Sinch app ID is not configured');
+        }
+
+        $payload = [
+            'app_id' => $appId,
+            'recipient' => [
+                'identified_by' => [
+                    'channel_identities' => [
+                        [
+                            'channel' => $channel,
+                            'identity' => $channelIdentity,
+                        ],
+                    ],
+                ],
+            ],
+            'message' => [
+                'text_message' => [
+                    'text' => $message,
+                ],
+            ],
+        ];
+
+        try {
+            $response = $this->httpClient->post(
+                "/v1/projects/{$projectId}/messages:send",
+                [
+                    'headers' => $this->getHeaders(),
+                    'json' => $payload,
+                ]
+            );
+
+            return $this->handleResponse($response);
+        } catch (GuzzleException $e) {
+            throw new ApiException('Failed to send message', 0, $e);
+        }
+    }
+
+    /**
      * Get request headers with authentication
      *
      * @return array<string, string>

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -704,6 +704,141 @@ class ConversationApiClient
     }
 
     /**
+     * Get the consent status for a phone number
+     *
+     * Queries the Sinch Consent Management API using the validated
+     * `/consents/{list_type}` endpoint structure. Queries the OPT_OUT_ALL
+     * list and searches for the given identity in the response.
+     *
+     * @return array<string, mixed> Consent data or empty array if not found
+     * @throws ApiException
+     */
+    public function getConsentStatus(string $appId, string $channelIdentity): array
+    {
+        if ($appId === '') {
+            throw new ApiException('App ID is required to get consent status');
+        }
+
+        $projectId = $this->config->getSinchProjectId();
+        $listType = 'OPT_OUT_ALL';
+
+        $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
+
+        try {
+            $this->logger->debug(
+                'Querying consent status',
+                [
+                    'endpoint' => $endpoint,
+                    'channel_identity' => $channelIdentity,
+                    'list_type' => $listType,
+                ]
+            );
+
+            $response = $this->httpClient->get(
+                $endpoint,
+                ['headers' => $this->getHeaders()]
+            );
+
+            $this->logger->debug(
+                'Consent status response',
+                [
+                    'endpoint' => $endpoint,
+                    'status_code' => $response->getStatusCode(),
+                    'list_type' => $listType,
+                ]
+            );
+
+            $statusCode = $response->getStatusCode();
+
+            // 404 can mean lazily-created empty list OR misconfiguration
+            if ($statusCode === 404) {
+                $body = (string) $response->getBody();
+                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                    return [];
+                }
+                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+            }
+
+            $data = $this->handleResponse($response);
+
+            // Filter to the requested identity (API returns full list)
+            $normalized = ltrim($channelIdentity, '+');
+            foreach ($data['identities'] ?? [] as $entry) {
+                if (is_array($entry) && ($entry['identity'] ?? '') === $normalized) {
+                    return $entry;
+                }
+            }
+
+            return [];
+        } catch (GuzzleException $e) {
+            $this->logger->error(
+                'Consent status request failed',
+                [
+                    'endpoint' => $endpoint,
+                    'channel_identity' => $channelIdentity,
+                    'exception' => $e,
+                ]
+            );
+
+            throw new ApiException('Failed to get consent status', 0, $e);
+        }
+    }
+
+    /**
+     * List all opted-out numbers for an app
+     *
+     * Queries the Sinch Consent Management API using the validated
+     * `/consents/OPT_OUT_ALL` endpoint and parses the `identities` field.
+     *
+     * @return array<int, array<string, mixed>>
+     * @throws ApiException
+     */
+    public function listOptOuts(string $appId): array
+    {
+        $projectId = $this->config->getSinchProjectId();
+        $listType = 'OPT_OUT_ALL';
+
+        $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
+
+        try {
+            $this->logger->debug(
+                'Listing opt-outs',
+                ['endpoint' => $endpoint, 'app_id' => $appId]
+            );
+
+            $response = $this->httpClient->get(
+                $endpoint,
+                ['headers' => $this->getHeaders()]
+            );
+
+            $this->logger->debug(
+                'Opt-out list response',
+                ['endpoint' => $endpoint, 'status_code' => $response->getStatusCode()]
+            );
+
+            $statusCode = $response->getStatusCode();
+
+            // 404 can mean lazily-created empty list OR misconfiguration
+            if ($statusCode === 404) {
+                $body = (string) $response->getBody();
+                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                    return [];
+                }
+                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+            }
+
+            $data = $this->handleResponse($response);
+            return $data['identities'] ?? [];
+        } catch (GuzzleException $e) {
+            $this->logger->error(
+                'Opt-out list request failed',
+                ['endpoint' => $endpoint, 'exception' => $e]
+            );
+            throw new ApiException('Failed to list opt-outs', 0, $e);
+        }
+    }
+
+    /**
      * Get authorization headers with OAuth2 token
      *
      * @return array<string, string>


### PR DESCRIPTION
## Summary

Add the first Architecture Decision Record documenting how the module handles SMS opt-out in DISPATCH mode with Sinch Consent Management.

The ADR follows the Popperian falsifiability format from ocemr-docs, with explicit refutation conditions that must be validated against the live Sinch API before the ADR is accepted.

Key decision: DISPATCH mode + Sinch Consent Management (Primary) + Consent API polling. No webhooks needed for the core opt-out flow.

Closes #83

## Test plan

- [ ] Review ADR for completeness and accuracy
- [ ] Validate refutation conditions 1–3 against live Sinch API