### PR TITLE
fix: move kernel resolution inside try/catch in public entry points

### DIFF
--- a/public/conversation.php
+++ b/public/conversation.php
@@ -23,17 +23,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 $logger = new SystemLogger();
 
-$kernel = OEGlobalsBag::getInstance()->get('kernel');
-if (!$kernel instanceof Kernel) {
-    throw new \RuntimeException('OpenEMR Kernel not available');
-}
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
-
-$controller = $bootstrap->getConversationController();
-
 $action = (string)($_GET['action'] ?? $_POST['action'] ?? 'view');
 
 try {
+    $kernel = OEGlobalsBag::getInstance()->get('kernel');
+    if (!$kernel instanceof Kernel) {
+        throw new \RuntimeException('OpenEMR Kernel not available');
+    }
+    $bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
+    $controller = $bootstrap->getConversationController();
     $response = $controller->dispatch($action);
     $response->send();
 } catch (ExceptionInterface $e) {

--- a/public/index.php
+++ b/public/index.php
@@ -23,17 +23,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 $logger = new SystemLogger();
 
-$kernel = OEGlobalsBag::getInstance()->get('kernel');
-if (!$kernel instanceof Kernel) {
-    throw new \RuntimeException('OpenEMR Kernel not available');
-}
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
-
-$controller = $bootstrap->getInboxController();
-
 $action = (string)($_GET['action'] ?? $_POST['action'] ?? 'list');
 
 try {
+    $kernel = OEGlobalsBag::getInstance()->get('kernel');
+    if (!$kernel instanceof Kernel) {
+        throw new \RuntimeException('OpenEMR Kernel not available');
+    }
+    $bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
+    $controller = $bootstrap->getInboxController();
     $response = $controller->dispatch($action);
     $response->send();
 } catch (ExceptionInterface $e) {

--- a/public/settings.php
+++ b/public/settings.php
@@ -24,14 +24,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 $logger = new SystemLogger();
 
-$kernel = OEGlobalsBag::getInstance()->get('kernel');
-if (!$kernel instanceof Kernel) {
-    throw new \RuntimeException('OpenEMR Kernel not available');
-}
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
-
-$controller = $bootstrap->getSettingsController();
-
 $action = (string)($_GET['action'] ?? $_POST['action'] ?? 'show');
 
 // Actions that expect JSON responses
@@ -39,6 +31,12 @@ $jsonActions = ['test', 'test-sms', 'sync-templates'];
 $expectsJson = in_array($action, $jsonActions, true);
 
 try {
+    $kernel = OEGlobalsBag::getInstance()->get('kernel');
+    if (!$kernel instanceof Kernel) {
+        throw new \RuntimeException('OpenEMR Kernel not available');
+    }
+    $bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
+    $controller = $bootstrap->getSettingsController();
     $response = $controller->dispatch($action);
     $response->send();
 } catch (ExceptionInterface $e) {


### PR DESCRIPTION
## Summary
Move kernel resolution from `OEGlobalsBag` inside the existing try/catch blocks in `index.php`, `conversation.php`, and `settings.php`. Previously, a missing kernel threw a `RuntimeException` before the error handler, potentially leaking a stack trace.

`webhook.php` already had this pattern — now all four entry points are consistent.

Closes #82

## Test plan
- [x] All 305 tests pass
- [x] All pre-commit hooks pass (phpcs, phpstan, rector)