### PR TITLE
feat: add pagination support to consent API client methods

### DIFF
--- a/docs/sinch/consent-api-findings.md
+++ b/docs/sinch/consent-api-findings.md
@@ -107,12 +107,14 @@ Messages sent via the Conversation API were silently dropped (accepted with 200 
 
 ## Credential Configuration
 
-The Sinch Conversations app used for Consent Management resides in the **parent project**, not in a subproject. The API credentials must belong to the same (parent) project as the app — credentials scoped to a different project or subproject can authenticate but silently fail to access the parent project's apps.
+The API credentials must belong to the same Sinch project as the Conversations app. Credentials from a different project can authenticate but silently fail to access the target project's apps.
+
+Note: Sinch "parent" and "sub" projects are effectively independent projects — there is no real hierarchy. A subproject's credentials grant no access to a parent project's resources, and vice versa. The naming is misleading.
 
 In practice, this means:
 - Verify which Sinch project owns the Conversations app you are targeting.
-- Ensure the API key/secret you configure for Consent Management are issued for that same project.
-- Avoid reusing subproject-specific credentials if the app is attached to the parent project.
+- Ensure the API key/secret you configure are issued for that same project.
+- Do not assume credentials from one project (parent or sub) work for another.
 
 Details about where these credentials are stored (e.g., vault names, item labels, CLI commands) should be documented in an internal runbook or secret-management guide, not in this repository.
 

--- a/src/Sinch/Conversation/Client/AppConfigurationClient.php
+++ b/src/Sinch/Conversation/Client/AppConfigurationClient.php
@@ -25,6 +25,7 @@ use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 class AppConfigurationClient
 {
     private const BASE_URL = 'https://us.conversation.api.sinch.com';
+    private const CONSENT_MAX_PAGES = 100;
     private readonly Client $httpClient;
     private ?string $cachedAccessToken = null;
 
@@ -313,7 +314,7 @@ class AppConfigurationClient
      *
      * Queries the Sinch Consent Management API using the validated
      * `/consents/{list_type}` endpoint structure. Queries the OPT_OUT_ALL
-     * list and searches for the given identity in the response.
+     * list page-by-page, returning early when the identity is found.
      *
      * @return array<string, mixed> Consent data or empty array if not found
      * @throws ApiException
@@ -326,47 +327,73 @@ class AppConfigurationClient
 
         $projectId = $this->config->getSinchProjectId();
         $listType = 'OPT_OUT_ALL';
-
         $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
+        $normalized = ltrim($channelIdentity, '+');
+
+        $pageToken = '';
+        $maxPages = self::CONSENT_MAX_PAGES;
 
         try {
-            $response = $this->httpClient->get(
-                $endpoint,
-                ['headers' => $this->getHeaders()]
-            );
-
-            $statusCode = $response->getStatusCode();
-
-            // 404 can mean lazily-created empty list OR misconfiguration
-            if ($statusCode === 404) {
-                $body = (string) $response->getBody();
-                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
-                    return [];
+            for ($page = 0; $page < $maxPages; $page++) {
+                $query = [];
+                if ($pageToken !== '') {
+                    $query['page_token'] = $pageToken;
                 }
-                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
-            }
 
-            $data = $this->handleResponse($response);
+                $response = $this->httpClient->get(
+                    $endpoint,
+                    [
+                        'headers' => $this->getHeaders(),
+                        'query' => $query,
+                    ]
+                );
 
-            // Filter to the requested identity (API returns full list, no per-number query)
-            $normalized = ltrim($channelIdentity, '+');
-            foreach ($data['identities'] ?? [] as $entry) {
-                if (is_array($entry) && ($entry['identity'] ?? '') === $normalized) {
-                    return $entry;
+                $statusCode = $response->getStatusCode();
+
+                if ($statusCode === 404) {
+                    $body = (string) $response->getBody();
+                    if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                        return [];
+                    }
+                    throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+                }
+
+                $data = $this->handleResponse($response);
+
+                $rawIdentities = $data['identities'] ?? [];
+                if (is_array($rawIdentities)) {
+                    foreach ($rawIdentities as $entry) {
+                        if (is_array($entry) && ($entry['identity'] ?? '') === $normalized) {
+                            return $entry;
+                        }
+                    }
+                }
+
+                $nextPageToken = $data['next_page_token'] ?? '';
+                $pageToken = is_string($nextPageToken) ? $nextPageToken : '';
+                if ($pageToken === '') {
+                    break;
                 }
             }
-
-            return [];
         } catch (GuzzleException $e) {
             throw new ApiException('Failed to get consent status', 0, $e);
         }
+
+        if ($pageToken !== '') {
+            throw new ApiException(
+                sprintf('Consent list requires more than %d pages; refusing partial results', $maxPages)
+            );
+        }
+
+        return [];
     }
 
     /**
      * List all opted-out numbers for an app
      *
      * Queries the Sinch Consent Management API using the validated
-     * `/consents/OPT_OUT_ALL` endpoint and parses the `identities` field.
+     * `/consents/OPT_OUT_ALL` endpoint and collects identities across
+     * all pages.
      *
      * @return array<int, array<string, mixed>>
      * @throws ApiException
@@ -377,33 +404,82 @@ class AppConfigurationClient
             throw new ApiException('App ID is required to list opt-outs');
         }
 
+        return $this->fetchAllConsentIdentities($appId);
+    }
+
+    /**
+     * Fetch all consent identities, following pagination
+     *
+     * Iterates through all pages of the consent list using
+     * `next_page_token` until the full list is retrieved.
+     *
+     * @return list<array<mixed, mixed>>
+     * @throws ApiException
+     */
+    private function fetchAllConsentIdentities(string $appId): array
+    {
         $projectId = $this->config->getSinchProjectId();
         $listType = 'OPT_OUT_ALL';
-
         $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
 
+        $allIdentities = [];
+        $pageToken = '';
+        $maxPages = self::CONSENT_MAX_PAGES;
+
         try {
-            $response = $this->httpClient->get(
-                $endpoint,
-                ['headers' => $this->getHeaders()]
-            );
-
-            $statusCode = $response->getStatusCode();
-
-            // 404 can mean lazily-created empty list OR misconfiguration
-            if ($statusCode === 404) {
-                $body = (string) $response->getBody();
-                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
-                    return [];
+            for ($page = 0; $page < $maxPages; $page++) {
+                $query = [];
+                if ($pageToken !== '') {
+                    $query['page_token'] = $pageToken;
                 }
-                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
-            }
 
-            $data = $this->handleResponse($response);
-            return $data['identities'] ?? [];
+                $response = $this->httpClient->get(
+                    $endpoint,
+                    [
+                        'headers' => $this->getHeaders(),
+                        'query' => $query,
+                    ]
+                );
+
+                $statusCode = $response->getStatusCode();
+
+                // 404 can mean lazily-created empty list OR misconfiguration
+                if ($statusCode === 404) {
+                    $body = (string) $response->getBody();
+                    if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                        return [];
+                    }
+                    throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+                }
+
+                $data = $this->handleResponse($response);
+
+                $rawIdentities = $data['identities'] ?? [];
+                if (is_array($rawIdentities)) {
+                    foreach ($rawIdentities as $entry) {
+                        if (is_array($entry)) {
+                            $allIdentities[] = $entry;
+                        }
+                    }
+                }
+
+                $nextPageToken = $data['next_page_token'] ?? '';
+                $pageToken = is_string($nextPageToken) ? $nextPageToken : '';
+                if ($pageToken === '') {
+                    break;
+                }
+            }
         } catch (GuzzleException $e) {
-            throw new ApiException('Failed to list opt-outs', 0, $e);
+            throw new ApiException('Failed to fetch consent identities', 0, $e);
         }
+
+        if ($pageToken !== '') {
+            throw new ApiException(
+                sprintf('Consent list requires more than %d pages; refusing partial results', $maxPages)
+            );
+        }
+
+        return $allIdentities;
     }
 
     /**

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -23,6 +23,7 @@ use OpenEMR\Common\Logging\SystemLogger;
 class ConversationApiClient
 {
     private const BASE_URL = 'https://us.conversation.api.sinch.com';
+    private const CONSENT_MAX_PAGES = 100;
     private readonly Client $httpClient;
     private readonly SystemLogger $logger;
     private ?string $cachedAccessToken = null;
@@ -708,7 +709,7 @@ class ConversationApiClient
      *
      * Queries the Sinch Consent Management API using the validated
      * `/consents/{list_type}` endpoint structure. Queries the OPT_OUT_ALL
-     * list and searches for the given identity in the response.
+     * list and searches for the given identity across all pages.
      *
      * @return array<string, mixed> Consent data or empty array if not found
      * @throws ApiException
@@ -721,55 +722,63 @@ class ConversationApiClient
 
         $projectId = $this->config->getSinchProjectId();
         $listType = 'OPT_OUT_ALL';
-
         $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
+        $normalized = ltrim($channelIdentity, '+');
+
+        $pageToken = '';
+        $maxPages = self::CONSENT_MAX_PAGES;
 
         try {
-            $this->logger->debug(
-                'Querying consent status',
-                [
-                    'endpoint' => $endpoint,
-                    'channel_identity' => $channelIdentity,
-                    'list_type' => $listType,
-                ]
-            );
-
-            $response = $this->httpClient->get(
-                $endpoint,
-                ['headers' => $this->getHeaders()]
-            );
-
-            $this->logger->debug(
-                'Consent status response',
-                [
-                    'endpoint' => $endpoint,
-                    'status_code' => $response->getStatusCode(),
-                    'list_type' => $listType,
-                ]
-            );
-
-            $statusCode = $response->getStatusCode();
-
-            // 404 can mean lazily-created empty list OR misconfiguration
-            if ($statusCode === 404) {
-                $body = (string) $response->getBody();
-                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
-                    return [];
+            for ($page = 0; $page < $maxPages; $page++) {
+                $query = [];
+                if ($pageToken !== '') {
+                    $query['page_token'] = $pageToken;
                 }
-                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
-            }
 
-            $data = $this->handleResponse($response);
+                $this->logger->debug(
+                    'Searching consent identities for match',
+                    [
+                        'endpoint' => $endpoint,
+                        'page' => $page,
+                        'channel_identity' => $channelIdentity,
+                    ]
+                );
 
-            // Filter to the requested identity (API returns full list)
-            $normalized = ltrim($channelIdentity, '+');
-            foreach ($data['identities'] ?? [] as $entry) {
-                if (is_array($entry) && ($entry['identity'] ?? '') === $normalized) {
-                    return $entry;
+                $response = $this->httpClient->get(
+                    $endpoint,
+                    [
+                        'headers' => $this->getHeaders(),
+                        'query' => $query,
+                    ]
+                );
+
+                $statusCode = $response->getStatusCode();
+
+                if ($statusCode === 404) {
+                    $body = (string) $response->getBody();
+                    if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                        return [];
+                    }
+                    throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+                }
+
+                $data = $this->handleResponse($response);
+
+                $rawIdentities = $data['identities'] ?? [];
+                if (is_array($rawIdentities)) {
+                    foreach ($rawIdentities as $entry) {
+                        if (is_array($entry) && ($entry['identity'] ?? '') === $normalized) {
+                            return $entry;
+                        }
+                    }
+                }
+
+                $nextPageToken = $data['next_page_token'] ?? '';
+                $pageToken = is_string($nextPageToken) ? $nextPageToken : '';
+                if ($pageToken === '') {
+                    break;
                 }
             }
-
-            return [];
         } catch (GuzzleException $e) {
             $this->logger->error(
                 'Consent status request failed',
@@ -779,63 +788,140 @@ class ConversationApiClient
                     'exception' => $e,
                 ]
             );
-
             throw new ApiException('Failed to get consent status', 0, $e);
         }
+
+        if ($pageToken !== '') {
+            $this->logger->warning(
+                'Consent status pagination limit reached',
+                ['endpoint' => $endpoint, 'max_pages' => $maxPages]
+            );
+            throw new ApiException(
+                sprintf('Consent list requires more than %d pages; refusing partial results', $maxPages)
+            );
+        }
+
+        return [];
     }
 
     /**
      * List all opted-out numbers for an app
      *
      * Queries the Sinch Consent Management API using the validated
-     * `/consents/OPT_OUT_ALL` endpoint and parses the `identities` field.
+     * `/consents/OPT_OUT_ALL` endpoint and collects identities across
+     * all pages.
      *
      * @return array<int, array<string, mixed>>
      * @throws ApiException
      */
     public function listOptOuts(string $appId): array
     {
+        if ($appId === '') {
+            throw new ApiException('App ID is required to list opt-outs');
+        }
+
+        return $this->fetchAllConsentIdentities($appId);
+    }
+
+    /**
+     * Fetch all consent identities, following pagination
+     *
+     * Iterates through all pages of the consent list using
+     * `next_page_token` until the full list is retrieved.
+     *
+     * @return list<array<mixed, mixed>>
+     * @throws ApiException
+     */
+    private function fetchAllConsentIdentities(string $appId): array
+    {
         $projectId = $this->config->getSinchProjectId();
         $listType = 'OPT_OUT_ALL';
-
         $endpoint = "/v1/projects/{$projectId}/apps/{$appId}/consents/{$listType}";
 
+        $allIdentities = [];
+        $pageToken = '';
+        $maxPages = self::CONSENT_MAX_PAGES;
+
         try {
-            $this->logger->debug(
-                'Listing opt-outs',
-                ['endpoint' => $endpoint, 'app_id' => $appId]
-            );
-
-            $response = $this->httpClient->get(
-                $endpoint,
-                ['headers' => $this->getHeaders()]
-            );
-
-            $this->logger->debug(
-                'Opt-out list response',
-                ['endpoint' => $endpoint, 'status_code' => $response->getStatusCode()]
-            );
-
-            $statusCode = $response->getStatusCode();
-
-            // 404 can mean lazily-created empty list OR misconfiguration
-            if ($statusCode === 404) {
-                $body = (string) $response->getBody();
-                if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
-                    return [];
+            for ($page = 0; $page < $maxPages; $page++) {
+                $query = [];
+                if ($pageToken !== '') {
+                    $query['page_token'] = $pageToken;
                 }
-                throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
-            }
 
-            $data = $this->handleResponse($response);
-            return $data['identities'] ?? [];
+                $this->logger->debug(
+                    'Fetching consent identities',
+                    [
+                        'endpoint' => $endpoint,
+                        'page' => $page,
+                        'has_page_token' => $pageToken !== '',
+                    ]
+                );
+
+                $response = $this->httpClient->get(
+                    $endpoint,
+                    [
+                        'headers' => $this->getHeaders(),
+                        'query' => $query,
+                    ]
+                );
+
+                $statusCode = $response->getStatusCode();
+
+                $this->logger->debug(
+                    'Consent identities response',
+                    [
+                        'endpoint' => $endpoint,
+                        'status_code' => $statusCode,
+                        'page' => $page,
+                    ]
+                );
+
+                // 404 can mean lazily-created empty list OR misconfiguration
+                if ($statusCode === 404) {
+                    $body = (string) $response->getBody();
+                    if (str_contains($body, 'ListType') && str_contains($body, 'does not exist')) {
+                        return [];
+                    }
+                    throw new ApiException('Consent API returned 404: ' . $body, $statusCode);
+                }
+
+                $data = $this->handleResponse($response);
+
+                $rawIdentities = $data['identities'] ?? [];
+                if (is_array($rawIdentities)) {
+                    foreach ($rawIdentities as $entry) {
+                        if (is_array($entry)) {
+                            $allIdentities[] = $entry;
+                        }
+                    }
+                }
+
+                $nextPageToken = $data['next_page_token'] ?? '';
+                $pageToken = is_string($nextPageToken) ? $nextPageToken : '';
+                if ($pageToken === '') {
+                    break;
+                }
+            }
         } catch (GuzzleException $e) {
             $this->logger->error(
-                'Opt-out list request failed',
+                'Consent identities request failed',
                 ['endpoint' => $endpoint, 'exception' => $e]
             );
-            throw new ApiException('Failed to list opt-outs', 0, $e);
+            throw new ApiException('Failed to fetch consent identities', 0, $e);
         }
+
+        if ($pageToken !== '') {
+            $this->logger->warning(
+                'Consent identities pagination limit reached',
+                ['endpoint' => $endpoint, 'max_pages' => $maxPages]
+            );
+            throw new ApiException(
+                sprintf('Consent list requires more than %d pages; refusing partial results', $maxPages)
+            );
+        }
+
+        return $allIdentities;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Extract `fetchAllConsentIdentities()` in both `ConversationApiClient` and `AppConfigurationClient` to iterate through all pages using `next_page_token`
- `getConsentStatus()` and `listOptOuts()` now return results across all pages instead of only the first page
- Prevents a compliance risk where `getConsentStatus()` could report "not opted out" if the identity is on a later page

## Test plan

- [ ] Run `ConsentCheckCommand` against Sinch with a known opted-out number to verify `getConsentStatus()` still returns the correct result
- [ ] Run `ConsentCheckCommand` `listOptOuts` to verify the full list is returned
- [ ] Verify pagination loop terminates correctly when `next_page_token` is empty (current behavior for small lists)

Closes #87