### PR TITLE
feat: add webhook nonce tracking for replay protection

### DIFF
--- a/cleanup.sql
+++ b/cleanup.sql
@@ -16,3 +16,4 @@ DROP TABLE IF EXISTS `oce_sinch_message_templates`;
 DROP TABLE IF EXISTS `oce_sinch_keyword_responses`;
 DROP TABLE IF EXISTS `oce_sinch_services`;
 DROP TABLE IF EXISTS `oce_sinch_appointment_reminders`;
+DROP TABLE IF EXISTS `oce_sinch_webhook_nonces`;

--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -75,6 +75,17 @@ class WebhookController
                 ['error' => $e->getMessage()],
                 Response::HTTP_UNAUTHORIZED
             );
+        } catch (\Throwable $e) {
+            $errorId = ErrorId::generate();
+            $this->logger->error('Webhook authentication error', [
+                'errorId' => $errorId,
+                'clientIp' => $clientIp,
+                'exception' => $e,
+            ]);
+            return new JsonResponse(
+                ['error' => 'Internal error', 'errorId' => $errorId],
+                Response::HTTP_INTERNAL_SERVER_ERROR
+            );
         }
 
         $payload = $this->parsePayload($request);
@@ -89,7 +100,9 @@ class WebhookController
 
         $eventTypeRaw = $payload['trigger'] ?? null;
         if (!is_string($eventTypeRaw) || $eventTypeRaw === '') {
-            $this->logger->error("Webhook missing trigger type");
+            $this->logger->error("Webhook missing trigger type", [
+                'payload_keys' => array_keys($payload),
+            ]);
             return new JsonResponse(
                 ['error' => 'Missing trigger type'],
                 Response::HTTP_BAD_REQUEST
@@ -139,6 +152,11 @@ class WebhookController
             throw new AccessDeniedException("Missing webhook signature headers");
         }
 
+        if (strlen($nonce) > 255) {
+            $this->logger->warning('Webhook request with oversized nonce', ['clientIp' => $clientIp]);
+            throw new AccessDeniedException("Invalid webhook signature headers");
+        }
+
         if (strcasecmp($algorithm, 'HmacSHA256') !== 0) {
             $this->logger->warning(
                 'Webhook request with unsupported signature algorithm',
@@ -171,6 +189,56 @@ class WebhookController
             $this->logger->warning('Webhook request with invalid HMAC signature', ['clientIp' => $clientIp]);
             throw new UnauthorizedException("Invalid webhook signature");
         }
+
+        // Atomically record the nonce; duplicate means replay
+        if (!$this->recordNonce($nonce, (int) $timestamp)) {
+            $this->logger->warning('Webhook request with replayed nonce', ['clientIp' => $clientIp]);
+            throw new UnauthorizedException("Invalid webhook signature");
+        }
+    }
+
+    /**
+     * Atomically record a nonce and prune expired entries
+     *
+     * Uses INSERT (not INSERT IGNORE) so a duplicate key error signals
+     * replay. This eliminates the race condition of check-then-insert.
+     * Uses FROM_UNIXTIME for DB-side timestamp conversion to avoid
+     * PHP/MySQL timezone mismatches.
+     *
+     * @return bool False when the nonce already exists (replay detected)
+     */
+    private function recordNonce(string $nonce, int $timestamp): bool
+    {
+        $expiresAtUnix = $timestamp + self::TIMESTAMP_TOLERANCE_SECONDS;
+
+        try {
+            QueryUtils::sqlStatementThrowException(
+                "INSERT INTO `oce_sinch_webhook_nonces` (`nonce`, `expires_at`) VALUES (?, FROM_UNIXTIME(?))",
+                [$nonce, $expiresAtUnix]
+            );
+        } catch (\Throwable $e) {
+            $isDuplicate = str_contains($e->getMessage(), 'Duplicate entry')
+                || (string) $e->getCode() === '23000';
+            if ($isDuplicate) {
+                return false;
+            }
+            throw $e;
+        }
+
+        // Prune expired nonces opportunistically. Failures must not cause
+        // the request to fail after the nonce is recorded, otherwise retries
+        // would be incorrectly rejected as replays.
+        try {
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM `oce_sinch_webhook_nonces` WHERE `expires_at` < NOW()"
+            );
+        } catch (\Throwable $e) {
+            $this->logger->warning('Failed to prune expired webhook nonces', [
+                'exception' => $e,
+            ]);
+        }
+
+        return true;
     }
 
     /**

--- a/table.sql
+++ b/table.sql
@@ -166,3 +166,12 @@ CREATE TABLE IF NOT EXISTS `oce_sinch_appointment_reminders` (
   INDEX `idx_patient_id` (`patient_id`),
   INDEX `idx_sent_at` (`sent_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Webhook nonce tracking for replay protection.
+-- Store each nonce after successful HMAC verification and reject duplicates.
+-- Rows are pruned when expires_at has passed.
+CREATE TABLE IF NOT EXISTS `oce_sinch_webhook_nonces` (
+  `nonce` VARCHAR(255) COLLATE utf8mb4_bin NOT NULL PRIMARY KEY COMMENT 'Nonce from x-sinch-webhook-signature-nonce header',
+  `expires_at` DATETIME NOT NULL COMMENT 'When this nonce can be pruned (timestamp + tolerance window)',
+  INDEX `idx_expires_at` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/tests/Unit/Controller/WebhookControllerTest.php
+++ b/tests/Unit/Controller/WebhookControllerTest.php
@@ -231,6 +231,94 @@ class WebhookControllerTest extends TestCase
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
 
+    public function testRejects401WhenNonceReplayed(): void
+    {
+        // Simulate a duplicate key error from the nonce INSERT
+        QueryUtils::setNextException(
+            new \RuntimeException('Duplicate entry \'abc123\' for key \'PRIMARY\'')
+        );
+
+        $request = $this->makeRequest('POST', ['trigger' => 'MESSAGE_INBOUND']);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testRecordsNonceOnSuccessfulAuth(): void
+    {
+        $request = $this->makeRequest('POST', ['trigger' => 'UNKNOWN_EVENT']);
+
+        $this->controller->dispatch($request);
+
+        $queries = QueryUtils::getQueries();
+        $nonceInserts = array_filter(
+            $queries,
+            fn (array $q): bool => str_contains($q['sql'], 'oce_sinch_webhook_nonces') && str_contains($q['sql'], 'INSERT')
+        );
+        $this->assertNotEmpty($nonceInserts, 'Nonce should be recorded after successful auth');
+    }
+
+    public function testPrunesExpiredNonces(): void
+    {
+        $request = $this->makeRequest('POST', ['trigger' => 'UNKNOWN_EVENT']);
+
+        $this->controller->dispatch($request);
+
+        $queries = QueryUtils::getQueries();
+        $pruneQueries = array_filter(
+            $queries,
+            fn (array $q): bool => str_contains($q['sql'], 'oce_sinch_webhook_nonces') && str_contains($q['sql'], 'DELETE')
+        );
+        $this->assertNotEmpty($pruneQueries, 'Expired nonces should be pruned after successful auth');
+    }
+
+    public function testFailedHmacDoesNotTouchNonceTable(): void
+    {
+        $mockConfig = $this->createMock(GlobalConfig::class);
+        $mockConfig->method('isIpInAllowlist')->willReturn(true);
+        $mockConfig->method('isWebhookAuthConfigured')->willReturn(true);
+        $mockConfig->method('verifyWebhookSignature')->willReturn(false);
+
+        $controller = new WebhookController(
+            $mockConfig,
+            $this->mockKeywordHandler,
+            $this->mockMessageService,
+            $this->mockConsentService
+        );
+
+        QueryUtils::clearQueries();
+
+        $request = $this->makeRequest('POST', ['trigger' => 'MESSAGE_INBOUND'], 'wrong_secret');
+        $controller->dispatch($request);
+
+        $nonceQueries = array_filter(
+            QueryUtils::getQueries(),
+            fn (array $q): bool => str_contains($q['sql'], 'oce_sinch_webhook_nonces')
+        );
+        $this->assertEmpty($nonceQueries, 'Failed HMAC should not touch nonce table');
+    }
+
+    public function testReturns500OnNonceDbError(): void
+    {
+        // Simulate a non-duplicate DB exception during nonce insert
+        QueryUtils::setNextException(
+            new \RuntimeException('Connection lost during query')
+        );
+
+        $request = $this->makeRequest('POST', ['trigger' => 'MESSAGE_INBOUND']);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getContent(), true);
+        $this->assertArrayHasKey('errorId', $body);
+        $this->assertEquals('Internal error', $body['error']);
+        // Ensure no internal details are leaked
+        $this->assertStringNotContainsString('Connection lost', (string) $response->getContent());
+    }
+
     // --- Payload parsing tests ---
 
     public function testReturns400ForEmptyPayload(): void


### PR DESCRIPTION
## Summary

- Add `oce_sinch_webhook_nonces` table to track seen nonces with expiration
- Reject webhook requests with previously-seen nonces after HMAC verification passes
- Prune expired nonces opportunistically on each request
- Closes the replay attack window within the 5-minute timestamp tolerance

## Design

Nonce check runs after HMAC signature verification succeeds, so invalid requests never touch the database. The INSERT itself is the replay detection mechanism — a duplicate key error (checked by SQLSTATE `23000` and message substring) signals a replayed nonce. This is atomic and avoids the race condition of a separate check-then-insert.

Each nonce is stored with an `expires_at` computed via `FROM_UNIXTIME()` on the DB side. Expired entries are pruned with `NOW()` on every successful request. Both functions use the DB session timezone consistently. Pruning is best-effort — failures are logged but don't prevent the request from succeeding.

DB errors during nonce operations are caught in `dispatch()` and return a generic 500 with a traceable `error_id`.

The nonce column uses `utf8mb4_bin` collation for case-sensitive bytewise comparison of cryptographic values.

## Test plan

- [x] Existing webhook tests pass (308/308)
- [x] New tests: replay rejection (401), nonce recording, pruning, HMAC failure skips nonce table
- [x] Curl-based replay test against live Docker instance passed all 3 cases
- [ ] Deploy to dev, verify with real Sinch webhooks

Closes #67