### PR TITLE
fix: detect webhook event type by field presence, not trigger field

### DIFF
--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -256,31 +256,20 @@ class WebhookController
      */
     private function detectEventType(array $payload): ?string
     {
-        // Order matters only for readability; each payload has exactly one of these
-        $eventKeys = [
-            'message',
-            'message_delivery_report',
-            'event',
-            'opt_out_notification',
-            'opt_in_notification',
-            'contact_create_notification',
-            'contact_delete_notification',
-            'contact_merge_notification',
-            'contact_update_notification',
-            'conversation_start_notification',
-            'conversation_stop_notification',
-            'conversation_delete_notification',
-            'capability_notification',
-            'unsupported_callback',
-            'channel_event_notification',
-            'contact_identities_duplication_notification',
-            'smart_conversation',
-            'message_redaction',
-            'record_notification',
+        // Common metadata keys present in every Sinch callback.
+        // The event type is the single non-metadata key.
+        $metadataKeys = [
+            'app_id',
+            'project_id',
+            'accepted_time',
+            'event_time',
+            'message_metadata',
+            'correlation_id',
+            'channel_metadata',
         ];
 
-        foreach ($eventKeys as $key) {
-            if (array_key_exists($key, $payload)) {
+        foreach ($payload as $key => $value) {
+            if (!in_array($key, $metadataKeys, true)) {
                 return $key;
             }
         }
@@ -302,7 +291,6 @@ class WebhookController
     {
         /** @var string $content */
         $content = $request->getContent();
-        /** @var array<string, mixed>|scalar|null $data */
         $data = json_decode($content, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
@@ -310,7 +298,21 @@ class WebhookController
             return [];
         }
 
-        return is_array($data) ? $data : [];
+        if (!is_array($data) || array_is_list($data)) {
+            return [];
+        }
+
+        // json_decode with assoc=true produces string keys for JSON objects.
+        // PHPStan can't infer this after the is_array + !array_is_list checks,
+        // so filter to prove string keys.
+        $result = [];
+        foreach ($data as $key => $value) {
+            if (is_string($key)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Unit/Controller/WebhookControllerTest.php
+++ b/tests/Unit/Controller/WebhookControllerTest.php
@@ -363,6 +363,27 @@ class WebhookControllerTest extends TestCase
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
     }
 
+    public function testReturns400ForJsonArrayPayload(): void
+    {
+        $body = '[{"message": {}}]';
+        $timestamp = (string) time();
+        $nonce = bin2hex(random_bytes(16));
+        $signedData = $body . '.' . $nonce . '.' . $timestamp;
+        $signature = base64_encode(hash_hmac('sha256', $signedData, self::TEST_SECRET, true));
+
+        $request = Request::create('/webhook', 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_SINCH_WEBHOOK_SIGNATURE' => $signature,
+            'HTTP_X_SINCH_WEBHOOK_SIGNATURE_TIMESTAMP' => $timestamp,
+            'HTTP_X_SINCH_WEBHOOK_SIGNATURE_NONCE' => $nonce,
+            'HTTP_X_SINCH_WEBHOOK_SIGNATURE_ALGORITHM' => 'HmacSHA256',
+        ], $body);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
     public function testReturns400ForNoEventKey(): void
     {
         $request = $this->makeRequest('POST', ['app_id' => 'test', 'project_id' => 'test']);


### PR DESCRIPTION
## Summary

- Replace `$payload['trigger']` lookup with `detectEventType()` that checks which event-specific key is present in the payload
- The Sinch Conversation API uses discriminated union by field presence — there is no `trigger` field
- All real webhooks were returning 400 "Missing trigger type"
- Supports all documented callback types: `message`, `message_delivery_report`, `event`, `opt_out_notification`, `opt_in_notification`, `contact_create_notification`, and more

## Reference

[Sinch Callbacks documentation](https://developers.sinch.com/docs/conversation/callbacks.md)

## Test plan

- [x] All 309 unit tests pass
- [x] All 18 pre-commit checks pass
- [ ] Deploy to dev with Tailscale tunnel, send a text message, verify webhook processes successfully

Closes #90