### PR TITLE
refactor: add patient-id-aware keyword handler entry point

### DIFF
--- a/src/Module/Service/KeywordHandlerService.php
+++ b/src/Module/Service/KeywordHandlerService.php
@@ -31,7 +31,10 @@ class KeywordHandlerService
     }
 
     /**
-     * Process inbound message for keywords
+     * Process inbound message for keywords (webhook path)
+     *
+     * Use this when patient ID is not known upfront. Finds patients by
+     * phone number lookup.
      *
      * STOP/START/HELP operate at the phone-number level, not the patient level.
      * A phone number can belong to multiple patients (e.g. parent with children).
@@ -68,7 +71,52 @@ class KeywordHandlerService
             'STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT' =>
                 $this->handleStop($normalized, $patients),
             'START', 'UNSTOP', 'SUBSCRIBE' =>
-                $this->handleStart($normalized, $patients[0]),
+                $this->handleStart($normalized, (int) $patients[0]['pid']),
+            'HELP', 'INFO' =>
+                $this->handleHelp(),
+            default => null,
+        };
+    }
+
+    /**
+     * Process inbound message for keywords with a known patient ID (polling path)
+     *
+     * Use this when the caller already has the authoritative patient ID
+     * (e.g. from the conversation record). Skips the phone-number-based
+     * patient lookup for START, and guarantees the known patient is included
+     * in STOP even if the phone format doesn't match the database.
+     *
+     * STOP still applies to ALL patients sharing the number (carrier-level),
+     * plus the known patient as a guarantee.
+     * START applies to the known patient directly (no first-match ambiguity).
+     *
+     * @param int $patientId Known patient ID from the conversation record
+     * @param string $phoneNumber E.164 phone number
+     * @param string $messageBody
+     * @return string|null Response message, or null if not a keyword
+     */
+    public function handleInboundMessageForPatient(
+        int $patientId,
+        string $phoneNumber,
+        string $messageBody
+    ): ?string {
+        $keyword = $this->detectKeyword($messageBody);
+
+        if ($keyword === null) {
+            return null;
+        }
+
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Could not normalize phone number', ['phone' => $phoneNumber]);
+            return null;
+        }
+
+        return match (strtoupper($keyword)) {
+            'STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT' =>
+                $this->handleStopWithKnownPatient($normalized, $patientId),
+            'START', 'UNSTOP', 'SUBSCRIBE' =>
+                $this->handleStart($normalized, $patientId),
             'HELP', 'INFO' =>
                 $this->handleHelp(),
             default => null,
@@ -125,19 +173,55 @@ class KeywordHandlerService
     }
 
     /**
-     * Handle START keyword -- opt-in only the first matched patient
+     * Handle STOP keyword with a known patient guarantee
      *
-     * START cannot disambiguate which patient the sender means, so only
-     * the first match is opted in. Staff can opt in additional patients
-     * via the web form.
+     * Opt out all patients found by phone lookup (carrier-level), plus
+     * ensure the known patient is opted out even if the phone lookup
+     * missed them due to format mismatches or missing phone_cell.
      *
      * @param string $phoneNumber E.164
-     * @param array<string, mixed> $patient
+     * @param int $knownPatientId Authoritative patient ID from the conversation
      * @return string Response message
      */
-    private function handleStart(string $phoneNumber, array $patient): string
+    private function handleStopWithKnownPatient(string $phoneNumber, int $knownPatientId): string
     {
-        $this->consentService->optIn((int) $patient['pid'], $phoneNumber, 'sms_start', null);
+        $patients = $this->findPatientsByPhone($phoneNumber);
+
+        $knownPatientFound = false;
+        foreach ($patients as $patient) {
+            $pid = (int) $patient['pid'];
+            $this->consentService->optOut($pid, $phoneNumber, 'sms_stop');
+            if ($pid === $knownPatientId) {
+                $knownPatientFound = true;
+            }
+        }
+
+        if (!$knownPatientFound) {
+            $this->consentService->optOut($knownPatientId, $phoneNumber, 'sms_stop');
+        }
+
+        $variables = [
+            'clinic_name' => $this->config->getClinicName(),
+            'phone' => $this->config->getClinicPhone(),
+        ];
+
+        return $this->templateService->render('keyword_stop', $variables);
+    }
+
+    /**
+     * Handle START keyword -- opt-in the given patient
+     *
+     * From the webhook path this is the first phone-lookup match (since
+     * a keyword alone cannot disambiguate). From the polling path this
+     * is the authoritative patient from the conversation record.
+     *
+     * @param string $phoneNumber E.164
+     * @param int $patientId Patient to opt in
+     * @return string Response message
+     */
+    private function handleStart(string $phoneNumber, int $patientId): string
+    {
+        $this->consentService->optIn($patientId, $phoneNumber, 'sms_start', null);
 
         $variables = [
             'clinic_name' => $this->config->getClinicName(),

--- a/src/Module/Service/MessagePollingService.php
+++ b/src/Module/Service/MessagePollingService.php
@@ -154,7 +154,7 @@ class MessagePollingService
             return null;
         }
 
-        $response = $this->keywordHandler->handleInboundMessage($phoneNumber, $messageBody);
+        $response = $this->keywordHandler->handleInboundMessageForPatient($patientId, $phoneNumber, $messageBody);
         if ($response === null) {
             return null;
         }

--- a/tests/Unit/Service/KeywordHandlerServiceTest.php
+++ b/tests/Unit/Service/KeywordHandlerServiceTest.php
@@ -299,6 +299,124 @@ class KeywordHandlerServiceTest extends TestCase
         $this->assertNull($result);
     }
 
+    // --- handleInboundMessageForPatient: STOP ---
+
+    public function testForPatientStopOptsOutAllPlusSelf(): void
+    {
+        $this->mockPatientLookup('+15559999999', [
+            ['pid' => 10, 'fname' => 'Parent', 'lname' => 'Smith', 'phone_cell' => '555-999-9999'],
+            ['pid' => 11, 'fname' => 'Child', 'lname' => 'Smith', 'phone_cell' => '555-999-9999'],
+        ]);
+
+        $optedOut = [];
+        $this->consentService->expects($this->exactly(2))
+            ->method('optOut')
+            ->willReturnCallback(function (int $pid, string $phone, string $method) use (&$optedOut): void {
+                $this->assertSame('+15559999999', $phone);
+                $this->assertSame('sms_stop', $method);
+                $optedOut[] = $pid;
+            });
+
+        $this->templateService->method('render')->willReturn('Unsubscribed.');
+
+        $result = $this->service->handleInboundMessageForPatient(10, '+15559999999', 'STOP');
+
+        $this->assertSame('Unsubscribed.', $result);
+        $this->assertSame([10, 11], $optedOut);
+    }
+
+    public function testForPatientStopGuaranteesKnownPatientWhenPhoneLookupMisses(): void
+    {
+        // Phone lookup returns different patients (format mismatch scenario)
+        $this->mockPatientLookup('+15559999999', [
+            ['pid' => 20, 'fname' => 'Other', 'lname' => 'Person', 'phone_cell' => '555-999-9999'],
+        ]);
+
+        $optedOut = [];
+        $this->consentService->expects($this->exactly(2))
+            ->method('optOut')
+            ->willReturnCallback(function (int $pid, string $phone, string $method) use (&$optedOut): void {
+                $this->assertSame('+15559999999', $phone);
+                $this->assertSame('sms_stop', $method);
+                $optedOut[] = $pid;
+            });
+
+        $this->templateService->method('render')->willReturn('Unsubscribed.');
+
+        // Known patient 42 is NOT in the phone lookup results
+        $result = $this->service->handleInboundMessageForPatient(42, '+15559999999', 'STOP');
+
+        $this->assertSame('Unsubscribed.', $result);
+        $this->assertSame([20, 42], $optedOut);
+    }
+
+    public function testForPatientStopWorksEvenWithNoPhoneLookupResults(): void
+    {
+        $this->mockPatientLookup('+15559999999', []);
+
+        $this->consentService->expects($this->once())
+            ->method('optOut')
+            ->with(42, '+15559999999', 'sms_stop');
+
+        $this->templateService->method('render')->willReturn('Unsubscribed.');
+
+        $result = $this->service->handleInboundMessageForPatient(42, '+15559999999', 'STOP');
+
+        $this->assertSame('Unsubscribed.', $result);
+    }
+
+    // --- handleInboundMessageForPatient: START ---
+
+    public function testForPatientStartUsesKnownPatientId(): void
+    {
+        // No phone lookup mock needed — START skips it
+
+        $this->consentService->expects($this->once())
+            ->method('optIn')
+            ->with(42, '+15559999999', 'sms_start', null);
+
+        $this->templateService->expects($this->once())
+            ->method('render')
+            ->with('keyword_start', ['clinic_name' => 'Test Clinic'])
+            ->willReturn('Re-subscribed.');
+
+        $result = $this->service->handleInboundMessageForPatient(42, '+15559999999', 'START');
+
+        $this->assertSame('Re-subscribed.', $result);
+    }
+
+    // --- handleInboundMessageForPatient: HELP ---
+
+    public function testForPatientHelpResponds(): void
+    {
+        $this->templateService->expects($this->once())
+            ->method('render')
+            ->with('keyword_help', [
+                'clinic_name' => 'Test Clinic',
+                'phone' => '+15551234567',
+            ])
+            ->willReturn('For help, call us.');
+
+        $result = $this->service->handleInboundMessageForPatient(42, '+15559999999', 'HELP');
+
+        $this->assertSame('For help, call us.', $result);
+    }
+
+    // --- handleInboundMessageForPatient: non-keyword / edge cases ---
+
+    public function testForPatientReturnsNullForNonKeyword(): void
+    {
+        $this->assertNull(
+            $this->service->handleInboundMessageForPatient(42, '+15559999999', 'Hello doctor')
+        );
+    }
+
+    public function testForPatientReturnsNullForUnparseablePhone(): void
+    {
+        $result = $this->service->handleInboundMessageForPatient(42, 'abc', 'STOP');
+        $this->assertNull($result);
+    }
+
     // --- Helpers ---
 
     /**


### PR DESCRIPTION
Closes #41.

## Summary

- Add `handleInboundMessageForPatient(int $patientId, string $phoneNumber, string $messageBody)` to `KeywordHandlerService` for callers that already know the patient ID (polling path)
- STOP still opts out all patients sharing the number (carrier-level), but guarantees the known patient is included even if the phone lookup misses them due to format mismatches
- START uses the known patient ID directly, eliminating first-match ambiguity
- Update `MessagePollingService::handleKeywordIfPresent()` to call the new method
- Existing `handleInboundMessage()` unchanged for the webhook path

## Test plan

- [x] 32 unit tests pass (7 new tests for the new method)
- [x] 100% line coverage on `KeywordHandlerService`
- [x] All pre-commit checks pass (PHPStan, PHPCS, Rector, etc.)