### PR TITLE
feat: detect carrier-level opt-outs via delivery failures and consent API polling

### DIFF
--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -225,6 +225,18 @@ class Bootstrap
     }
 
     /**
+     * Get Consent Sync Service
+     */
+    public function getConsentSyncService(): Service\ConsentSyncService
+    {
+        return new Service\ConsentSyncService(
+            $this->globalsConfig,
+            $this->getConversationApiClient(),
+            $this->getConsentService()
+        );
+    }
+
+    /**
      * Get Webhook Controller
      */
     public function getWebhookController(): Controller\WebhookController

--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -34,6 +34,9 @@ class WebhookController
 {
     private const TIMESTAMP_TOLERANCE_SECONDS = 300;
 
+    /** SMPP error codes that indicate carrier-level opt-out / block */
+    private const CARRIER_BLOCK_SMPP_CODES = [61, 151, 255];
+
     private readonly SystemLogger $logger;
 
     public function __construct(
@@ -408,13 +411,6 @@ class WebhookController
 
         try {
             $this->updateMessageDeliveryStatus($messageId, $status);
-
-            $this->logger->info('Successfully processed delivery report', ['messageId' => $messageId]);
-
-            return new JsonResponse(
-                ['status' => 'success', 'messageId' => $messageId],
-                Response::HTTP_OK
-            );
         } catch (\Throwable $e) {
             $errorId = ErrorId::generate();
             $this->logger->error('Failed to process delivery report', [
@@ -428,6 +424,27 @@ class WebhookController
                 Response::HTTP_INTERNAL_SERVER_ERROR
             );
         }
+
+        // Carrier block detection runs after the delivery status is persisted.
+        // Failures here must not cause the webhook to return 500 — the delivery
+        // status is already recorded and Sinch should not retry.
+        try {
+            $this->handleCarrierBlockDetection($messageId, $status, $deliveryReport);
+        } catch (\Throwable $e) {
+            $errorId = ErrorId::generate();
+            $this->logger->error('Carrier block detection failed (delivery status already recorded)', [
+                'messageId' => $messageId,
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
+        }
+
+        $this->logger->info('Successfully processed delivery report', ['messageId' => $messageId]);
+
+        return new JsonResponse(
+            ['status' => 'success', 'messageId' => $messageId],
+            Response::HTTP_OK
+        );
     }
 
     /**
@@ -443,7 +460,10 @@ class WebhookController
      */
     private function handleOptOut(array $payload): Response
     {
-        $notification = $payload['opt_out_notification'] ?? [];
+        /** @var array<string, mixed> $notification */
+        $notification = is_array($payload['opt_out_notification'] ?? null)
+            ? $payload['opt_out_notification']
+            : [];
         $identity = $this->extractString($notification, 'identity', '');
         $channel = $this->extractString($notification, 'channel', '');
         $status = $this->extractString($notification, 'status', '');
@@ -525,7 +545,10 @@ class WebhookController
      */
     private function handleOptIn(array $payload): Response
     {
-        $notification = $payload['opt_in_notification'] ?? [];
+        /** @var array<string, mixed> $notification */
+        $notification = is_array($payload['opt_in_notification'] ?? null)
+            ? $payload['opt_in_notification']
+            : [];
         $identity = $this->extractString($notification, 'identity', '');
         $channel = $this->extractString($notification, 'channel', '');
         $status = $this->extractString($notification, 'status', '');
@@ -622,6 +645,120 @@ class WebhookController
         }
 
         return [];
+    }
+
+    /**
+     * Detect carrier blocks from SMPP error codes in failed deliveries,
+     * and clear carrier blocks when delivery succeeds
+     *
+     * @param array<string, mixed> $deliveryReport
+     */
+    private function handleCarrierBlockDetection(
+        string $messageId,
+        string $status,
+        array $deliveryReport
+    ): void {
+        $recipients = $this->lookupMessageRecipients($messageId);
+        if ($recipients === []) {
+            return;
+        }
+
+        if ($status === 'FAILED') {
+            $smppCode = $this->extractSmppErrorCode($deliveryReport);
+            if ($smppCode !== null && in_array($smppCode, self::CARRIER_BLOCK_SMPP_CODES, true)) {
+                $reason = "SMPP error {$smppCode}";
+                foreach ($recipients as $recipient) {
+                    $patientId = $recipient['patient_id'];
+                    $phoneNumber = $recipient['phone_number'];
+                    $this->logger->info('Carrier block detected from delivery failure', [
+                        'messageId' => $messageId,
+                        'patientId' => $patientId,
+                        'smppCode' => $smppCode,
+                    ]);
+                    $this->consentService->setCarrierBlock($patientId, $phoneNumber, $reason);
+                    // SMPP error codes are SMS-specific, so pass the channel explicitly
+                    $this->consentService->optOut($patientId, $phoneNumber, 'carrier_block', Channel::SMS);
+                }
+            }
+            return;
+        }
+
+        if ($status === 'DELIVERED') {
+            foreach ($recipients as $recipient) {
+                $patientId = $recipient['patient_id'];
+                $phoneNumber = $recipient['phone_number'];
+                $block = $this->consentService->getCarrierBlock($patientId, $phoneNumber);
+                if ($block !== null) {
+                    $this->logger->info('Clearing carrier block after successful delivery', [
+                        'messageId' => $messageId,
+                        'patientId' => $patientId,
+                    ]);
+                    $this->consentService->clearCarrierBlock($patientId, $phoneNumber);
+                }
+            }
+        }
+    }
+
+    /**
+     * Look up all recipient patients for an outbound message
+     *
+     * A carrier block applies to the phone number, not a specific patient,
+     * so return all patients sharing the recipient number (same pattern as
+     * lookupPatientsByContactOrIdentity for opt-out webhooks).
+     *
+     * @return list<array{patient_id: int, phone_number: string}>
+     */
+    private function lookupMessageRecipients(string $messageId): array
+    {
+        $sql = "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'";
+        $message = QueryUtils::querySingleRow($sql, [$messageId]);
+        if (!$message || ($message['to_identifier'] ?? '') === '') {
+            return [];
+        }
+
+        $toIdentifier = (string) $message['to_identifier'];
+        $normalized = PhoneNormalizer::toE164($toIdentifier) ?? $toIdentifier;
+
+        $sql = "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?";
+        $contacts = QueryUtils::fetchRecords($sql, [$normalized]);
+        if ($contacts === []) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn(array $row): array => [
+                'patient_id' => (int) $row['patient_id'],
+                'phone_number' => $normalized,
+            ],
+            $contacts
+        ));
+    }
+
+    /**
+     * Extract SMPP error code from a delivery report
+     *
+     * Sinch delivery reports include error codes in reason_code or nested
+     * channel_identity.channel_error_code fields.
+     *
+     * @param array<string, mixed> $deliveryReport
+     */
+    private function extractSmppErrorCode(array $deliveryReport): ?int
+    {
+        // Try reason_code first (common location).
+        // Match digits only — is_numeric() would accept floats like "255.0"
+        // and cause a false positive carrier block.
+        $reasonCode = $this->extractString($deliveryReport, 'reason_code', '');
+        if (preg_match('/^\d+$/', $reasonCode) === 1) {
+            return (int) $reasonCode;
+        }
+
+        // Try nested channel identity error code
+        $channelErrorCode = $this->extractString($deliveryReport, 'channel_identity.channel_error_code', '');
+        if (preg_match('/^\d+$/', $channelErrorCode) === 1) {
+            return (int) $channelErrorCode;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Module/Service/ConsentService.php
+++ b/src/Module/Service/ConsentService.php
@@ -43,7 +43,14 @@ class ConsentService
      */
     public function hasConsent(int $patientId, string $phoneNumber): bool
     {
-        $normalized = PhoneNormalizer::toE164($phoneNumber) ?? $phoneNumber;
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Cannot check consent with unparseable phone number', [
+                'patientId' => $patientId,
+                'phone' => $phoneNumber,
+            ]);
+            return false;
+        }
 
         $sql = "SELECT opted_in, opted_out
                 FROM oce_sinch_patient_consent
@@ -187,13 +194,129 @@ class ConsentService
      */
     public function getConsent(int $patientId, string $phoneNumber): ?array
     {
-        $normalized = PhoneNormalizer::toE164($phoneNumber) ?? $phoneNumber;
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Cannot get consent with unparseable phone number', [
+                'patientId' => $patientId,
+                'phone' => $phoneNumber,
+            ]);
+            return null;
+        }
 
         $sql = "SELECT * FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?";
         $result = QueryUtils::querySingleRow($sql, [$patientId, $normalized]);
 
         return $result ?: null;
+    }
+
+    /**
+     * Record a carrier-level block on a patient's phone number
+     *
+     * Set when a delivery failure contains an SMPP error code indicating the
+     * carrier has blocked the number (255, 61, 151), or when the Sinch consent
+     * API reports an opt-out we did not see via webhook.
+     */
+    public function setCarrierBlock(int $patientId, string $phoneNumber, string $reason): void
+    {
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Cannot set carrier block with unparseable phone number', [
+                'patientId' => $patientId,
+                'phone' => $phoneNumber,
+            ]);
+            return;
+        }
+
+        // Use INSERT ... ON DUPLICATE KEY UPDATE so the block is recorded even
+        // when no consent record exists yet (e.g. the patient received a message
+        // through an external path and was never formally opted in).
+        $sql = "INSERT INTO oce_sinch_patient_consent (
+                    patient_id, phone_number, opted_in, opted_out,
+                    carrier_blocked, carrier_blocked_at, carrier_block_reason,
+                    created_at, updated_at
+                ) VALUES (?, ?, FALSE, FALSE, TRUE, NOW(), ?, NOW(), NOW())
+                ON DUPLICATE KEY UPDATE
+                    carrier_blocked = TRUE,
+                    carrier_blocked_at = NOW(),
+                    carrier_block_reason = VALUES(carrier_block_reason),
+                    updated_at = NOW()";
+
+        QueryUtils::sqlStatementThrowException($sql, [$patientId, $normalized, $reason]);
+
+        $this->logger->info('Carrier block set', [
+            'patientId' => $patientId,
+            'phone' => $normalized,
+            'reason' => $reason,
+        ]);
+    }
+
+    /**
+     * Clear a carrier block after a successful delivery confirms the block is lifted
+     *
+     * Intentionally does NOT re-opt-in the patient. The carrier block flow
+     * calls optOut(), so the patient remains opted out until staff manually
+     * re-opts them in. This matches the issue spec: "When staff re-opts-in
+     * a carrier-blocked patient" is an explicit human action.
+     */
+    public function clearCarrierBlock(int $patientId, string $phoneNumber): void
+    {
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Cannot clear carrier block with unparseable phone number', [
+                'patientId' => $patientId,
+                'phone' => $phoneNumber,
+            ]);
+            return;
+        }
+
+        $sql = "UPDATE oce_sinch_patient_consent
+                SET carrier_blocked = FALSE,
+                    carrier_blocked_at = NULL,
+                    carrier_block_reason = NULL,
+                    updated_at = NOW()
+                WHERE patient_id = ? AND phone_number = ?";
+
+        QueryUtils::sqlStatementThrowException($sql, [$patientId, $normalized]);
+
+        $this->logger->info('Carrier block cleared', [
+            'patientId' => $patientId,
+            'phone' => $normalized,
+        ]);
+    }
+
+    /**
+     * Check if a patient's phone number is carrier-blocked
+     *
+     * @return array{carrier_blocked_at: ?string, carrier_block_reason: ?string}|null
+     */
+    public function getCarrierBlock(int $patientId, string $phoneNumber): ?array
+    {
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Cannot check carrier block with unparseable phone number', [
+                'patientId' => $patientId,
+                'phone' => $phoneNumber,
+            ]);
+            return null;
+        }
+
+        $sql = "SELECT carrier_blocked_at, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ? AND carrier_blocked = TRUE";
+        $result = QueryUtils::querySingleRow($sql, [$patientId, $normalized]);
+
+        if (!$result) {
+            return null;
+        }
+
+        $blockedAt = $result['carrier_blocked_at'] ?? null;
+        $blockReason = $result['carrier_block_reason'] ?? null;
+
+        return [
+            'carrier_blocked_at' => is_string($blockedAt) ? $blockedAt : null,
+            'carrier_block_reason' => is_string($blockReason) ? $blockReason : null,
+        ];
     }
 
     /**

--- a/src/Module/Service/ConsentSyncService.php
+++ b/src/Module/Service/ConsentSyncService.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Consent Sync Service - reconcile Sinch consent API with local records
+ *
+ * Polls the Sinch Consent Management API for opted-out identities and
+ * reconciles with local consent records. This catches opt-outs that
+ * bypassed webhooks entirely (e.g. carrier-intercepted STOP messages).
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\ErrorId;
+use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+
+class ConsentSyncService
+{
+    private readonly SystemLogger $logger;
+
+    public function __construct(
+        private readonly GlobalConfig $config,
+        private readonly ConversationApiClient $apiClient,
+        private readonly ConsentService $consentService
+    ) {
+        $this->logger = new SystemLogger();
+    }
+
+    /**
+     * Sync opt-outs from Sinch consent API with local consent records
+     *
+     * Two-way reconciliation:
+     * 1. Block patients who appear in the Sinch opt-out list but aren't locally blocked
+     * 2. Clear blocks for patients who are locally blocked but no longer appear in Sinch
+     *
+     * @return array{blocked: int, cleared: int, already_blocked: int, errors: int}
+     */
+    public function syncOptOuts(): array
+    {
+        $appId = $this->config->getSinchAppId();
+        $this->logger->info('Starting consent sync from Sinch API', ['appId' => $appId]);
+
+        $optOuts = $this->apiClient->listOptOuts($appId);
+
+        // Collect all opted-out phone numbers from Sinch for the reverse check
+        $sinchOptedOutPhones = [];
+
+        $blocked = 0;
+        $alreadyBlocked = 0;
+        $errors = 0;
+
+        foreach ($optOuts as $entry) {
+            $identity = (string) ($entry['identity'] ?? '');
+            if ($identity === '') {
+                continue;
+            }
+
+            // Sinch stores identities without the + prefix
+            $phoneNumber = '+' . ltrim($identity, '+');
+            $normalized = PhoneNormalizer::toE164($phoneNumber);
+            if ($normalized === null) {
+                $this->logger->warning('Skipping unparseable identity from consent API', [
+                    'identity' => $identity,
+                ]);
+                continue;
+            }
+
+            $sinchOptedOutPhones[$normalized] = true;
+
+            $patients = $this->findPatientsByPhone($normalized);
+            if ($patients === []) {
+                continue;
+            }
+
+            foreach ($patients as $patientId) {
+                try {
+                    $block = $this->consentService->getCarrierBlock($patientId, $normalized);
+                    if ($block !== null) {
+                        $alreadyBlocked++;
+                        continue;
+                    }
+
+                    $this->consentService->setCarrierBlock($patientId, $normalized, 'consent_api_sync');
+                    // The consent API opt-out list is cross-channel; skip hipaa_allowsms
+                    // sync since we don't know which channel triggered the opt-out.
+                    $this->consentService->optOut($patientId, $normalized, 'consent_api_sync', channel: null);
+                    $blocked++;
+                } catch (\Throwable $e) {
+                    $errors++;
+                    $errorId = ErrorId::generate();
+                    $this->logger->error('Failed to sync consent for patient', [
+                        'patientId' => $patientId,
+                        'phone' => $normalized,
+                        'errorId' => $errorId,
+                        'exception' => $e,
+                    ]);
+                }
+            }
+        }
+
+        // Clear local carrier blocks that no longer appear in the Sinch opt-out list.
+        // Only clear blocks that were set by a previous consent_api_sync, not blocks
+        // from SMPP delivery failures (those are cleared by successful delivery).
+        $cleared = $this->clearLiftedBlocks($sinchOptedOutPhones);
+
+        $this->logger->info('Consent sync completed', [
+            'blocked' => $blocked,
+            'cleared' => $cleared,
+            'already_blocked' => $alreadyBlocked,
+            'errors' => $errors,
+        ]);
+
+        return [
+            'blocked' => $blocked,
+            'cleared' => $cleared,
+            'already_blocked' => $alreadyBlocked,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * Check a single phone number against the Sinch consent API
+     *
+     * @return array<string, mixed> Consent status data, or empty array if not opted out
+     */
+    public function checkIdentity(string $phoneNumber): array
+    {
+        $appId = $this->config->getSinchAppId();
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Cannot check consent for unparseable phone', [
+                'phone' => $phoneNumber,
+            ]);
+            return [];
+        }
+
+        return $this->apiClient->getConsentStatus($appId, $normalized);
+    }
+
+    /**
+     * Clear carrier blocks that were set by consent_api_sync but no longer
+     * appear in the Sinch opt-out list (block was lifted upstream)
+     *
+     * @param array<string, true> $sinchOptedOutPhones Normalized phones still opted out in Sinch
+     */
+    private function clearLiftedBlocks(array $sinchOptedOutPhones): int
+    {
+        $sql = "SELECT patient_id, phone_number
+                FROM oce_sinch_patient_consent
+                WHERE carrier_blocked = TRUE AND carrier_block_reason = 'consent_api_sync'";
+        $localBlocks = QueryUtils::fetchRecords($sql, []);
+
+        $cleared = 0;
+        foreach ($localBlocks as $row) {
+            $phone = (string) $row['phone_number'];
+            if (isset($sinchOptedOutPhones[$phone])) {
+                continue;
+            }
+
+            $patientId = (int) $row['patient_id'];
+            try {
+                $this->consentService->clearCarrierBlock($patientId, $phone);
+                $cleared++;
+                $this->logger->info('Cleared carrier block no longer in Sinch opt-out list', [
+                    'patientId' => $patientId,
+                    'phone' => $phone,
+                ]);
+            } catch (\Throwable $e) {
+                $errorId = ErrorId::generate();
+                $this->logger->error('Failed to clear lifted carrier block', [
+                    'patientId' => $patientId,
+                    'phone' => $phone,
+                    'errorId' => $errorId,
+                    'exception' => $e,
+                ]);
+            }
+        }
+
+        return $cleared;
+    }
+
+    /**
+     * Find all patient IDs associated with a phone number
+     *
+     * @return list<int>
+     */
+    private function findPatientsByPhone(string $phoneNumber): array
+    {
+        $sql = "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?";
+        $results = QueryUtils::fetchRecords($sql, [$phoneNumber]);
+
+        return array_values(array_map(
+            static fn(array $row): int => (int) $row['patient_id'],
+            $results
+        ));
+    }
+}

--- a/table.sql
+++ b/table.sql
@@ -81,12 +81,16 @@ CREATE TABLE IF NOT EXISTS `oce_sinch_patient_consent` (
   `opt_out_date` DATETIME DEFAULT NULL COMMENT 'When they opted out',
   `opt_out_method` VARCHAR(50) DEFAULT NULL COMMENT 'How they opted out (sms_stop, web_form, etc)',
   `consent_text` TEXT DEFAULT NULL COMMENT 'Full text of consent agreement',
+  `carrier_blocked` BOOLEAN DEFAULT FALSE COMMENT 'Whether carrier has blocked delivery to this number',
+  `carrier_blocked_at` DATETIME DEFAULT NULL COMMENT 'When the carrier block was detected',
+  `carrier_block_reason` VARCHAR(255) DEFAULT NULL COMMENT 'SMPP error code or consent API source that triggered the block',
   `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'When this record was created',
   `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'When this record was last updated',
   INDEX `idx_patient_id` (`patient_id`),
   INDEX `idx_phone_number` (`phone_number`),
   INDEX `idx_opted_in` (`opted_in`),
   INDEX `idx_opted_out` (`opted_out`),
+  INDEX `idx_carrier_blocked` (`carrier_blocked`),
   UNIQUE KEY `unique_patient_phone` (`patient_id`, `phone_number`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -21,6 +21,7 @@ use OpenCoreEMR\Modules\SinchConversations\Controller\SettingsController;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConsentSyncService;
 use OpenCoreEMR\Modules\SinchConversations\Service\KeywordHandlerService;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessagePollingService;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
@@ -189,6 +190,13 @@ class BootstrapTest extends TestCase
         $service = $this->bootstrap->getTemplateSyncService();
 
         $this->assertInstanceOf(TemplateSyncService::class, $service);
+    }
+
+    public function testGetConsentSyncServiceReturnsService(): void
+    {
+        $service = $this->bootstrap->getConsentSyncService();
+
+        $this->assertInstanceOf(ConsentSyncService::class, $service);
     }
 
     public function testSubscribeToEventsCallsAddGlobalSettings(): void

--- a/tests/Unit/Controller/WebhookControllerTest.php
+++ b/tests/Unit/Controller/WebhookControllerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Controller;
 
+use OpenCoreEMR\Modules\SinchConversations\Channel;
 use OpenCoreEMR\Modules\SinchConversations\Controller\WebhookController;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
@@ -699,6 +700,362 @@ class WebhookControllerTest extends TestCase
                 && !str_contains($q['sql'], 'delivered_at')
         );
         $this->assertNotEmpty($updateQueries);
+    }
+
+    // --- Carrier block detection tests ---
+
+    public function testDeliveryFailureSmpp255TriggersCarrierBlock(): void
+    {
+        // Mock message lookup: outbound message to +15551234567
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-255'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('setCarrierBlock')
+            ->with(10, '+15551234567', 'SMPP error 255');
+
+        $this->mockConsentService->expects($this->once())
+            ->method('optOut')
+            ->with(10, '+15551234567', 'carrier_block', Channel::SMS);
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-255',
+                'status' => 'FAILED',
+                'reason_code' => '255',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testDeliveryFailureSmpp61TriggersCarrierBlock(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-61'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('setCarrierBlock')
+            ->with(10, '+15551234567', 'SMPP error 61');
+
+        $this->mockConsentService->expects($this->once())
+            ->method('optOut')
+            ->with(10, '+15551234567', 'carrier_block', Channel::SMS);
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-61',
+                'status' => 'FAILED',
+                'reason_code' => '61',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testDeliveryFailureSmpp151TriggersCarrierBlock(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-151'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('setCarrierBlock')
+            ->with(10, '+15551234567', 'SMPP error 151');
+
+        $this->mockConsentService->expects($this->once())
+            ->method('optOut')
+            ->with(10, '+15551234567', 'carrier_block', Channel::SMS);
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-151',
+                'status' => 'FAILED',
+                'reason_code' => '151',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testDeliveryFailureOtherCodeDoesNotTriggerCarrierBlock(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-400'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->never())->method('setCarrierBlock');
+        $this->mockConsentService->expects($this->never())->method('optOut');
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-400',
+                'status' => 'FAILED',
+                'reason_code' => '400',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testDeliveryFailureNoErrorCodeDoesNotTriggerCarrierBlock(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-nocode'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->never())->method('setCarrierBlock');
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-nocode',
+                'status' => 'FAILED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testSuccessfulDeliveryClearsCarrierBlock(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-delivered-clear'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('getCarrierBlock')
+            ->with(10, '+15551234567')
+            ->willReturn(['carrier_blocked_at' => '2026-04-01', 'carrier_block_reason' => 'SMPP error 255']);
+
+        $this->mockConsentService->expects($this->once())
+            ->method('clearCarrierBlock')
+            ->with(10, '+15551234567');
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-delivered-clear',
+                'status' => 'DELIVERED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testSuccessfulDeliverySkipsClearWhenNotBlocked(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-delivered-ok'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('getCarrierBlock')
+            ->with(10, '+15551234567')
+            ->willReturn(null);
+
+        $this->mockConsentService->expects($this->never())->method('clearCarrierBlock');
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-delivered-ok',
+                'status' => 'DELIVERED',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testDeliveryFailureNoMessageRecordSkipsCarrierBlock(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-unknown'],
+            []
+        );
+
+        $this->mockConsentService->expects($this->never())->method('setCarrierBlock');
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-unknown',
+                'status' => 'FAILED',
+                'reason_code' => '255',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testCarrierBlockUsesChannelErrorCodeFallback(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-nested'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->expects($this->once())
+            ->method('setCarrierBlock')
+            ->with(10, '+15551234567', 'SMPP error 255');
+
+        $this->mockConsentService->expects($this->once())
+            ->method('optOut')
+            ->with(10, '+15551234567', 'carrier_block', Channel::SMS);
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-nested',
+                'status' => 'FAILED',
+                'channel_identity' => [
+                    'channel_error_code' => '255',
+                ],
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testCarrierBlockAppliesToAllPatientsSharingPhone(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-multi'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 5], ['patient_id' => 6], ['patient_id' => 7]]
+        );
+
+        $this->mockConsentService->expects($this->exactly(3))
+            ->method('setCarrierBlock');
+
+        $this->mockConsentService->expects($this->exactly(3))
+            ->method('optOut');
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-multi',
+                'status' => 'FAILED',
+                'reason_code' => '255',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testCarrierBlockErrorDoesNotFailWebhook(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT to_identifier FROM oce_sinch_messages WHERE message_id = ? AND direction = 'outbound'",
+            ['msg-fail-err'],
+            [['to_identifier' => '+15551234567']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_contacts WHERE channel_identity = ?",
+            ['+15551234567'],
+            [['patient_id' => 10]]
+        );
+
+        $this->mockConsentService->method('setCarrierBlock')
+            ->willThrowException(new \RuntimeException('DB connection lost'));
+
+        $request = $this->makeRequest('POST', [
+            'message_delivery_report' => [
+                'message_id' => 'msg-fail-err',
+                'status' => 'FAILED',
+                'reason_code' => '255',
+            ],
+        ]);
+
+        $response = $this->controller->dispatch($request);
+
+        // Delivery status was already recorded — webhook succeeds despite carrier block error
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseContains($response, 'status', 'success');
+
+        $logs = SystemLogger::getLogs();
+        $errorLogs = array_filter($logs, fn($log) =>
+            $log['level'] === 'error'
+            && str_contains($log['message'], 'Carrier block detection failed')
+        );
+        $this->assertNotEmpty($errorLogs);
     }
 
     // --- OPT_OUT / OPT_IN tests ---

--- a/tests/Unit/Service/ConsentServiceTest.php
+++ b/tests/Unit/Service/ConsentServiceTest.php
@@ -158,6 +158,22 @@ class ConsentServiceTest extends TestCase
         $this->assertNotEmpty($errorLogs);
     }
 
+    public function testOptInSkipsUnparseablePhone(): void
+    {
+        $this->messageService->expects($this->never())->method('sendToPatient');
+
+        $result = $this->service->optIn(1, 'not-a-phone', 'web_form');
+
+        $this->assertFalse($result);
+
+        $queries = QueryUtils::getQueries();
+        $consentQueries = array_filter(
+            $queries,
+            fn($q) => str_contains($q['sql'], 'oce_sinch_patient_consent')
+        );
+        $this->assertEmpty($consentQueries);
+    }
+
     // --- optOut ---
 
     public function testOptOutSmsSyncsHipaaAllowSms(): void
@@ -178,6 +194,22 @@ class ConsentServiceTest extends TestCase
         $hipaaUpdate = array_values($hipaaQueries)[0];
         $this->assertEquals('NO', $hipaaUpdate['binds'][0]);
         $this->assertEquals(1, $hipaaUpdate['binds'][1]);
+    }
+
+    public function testOptOutSkipsUnparseablePhone(): void
+    {
+        $this->service->optOut(1, 'not-a-phone', 'sms_stop');
+
+        $queries = QueryUtils::getQueries();
+        $consentQueries = array_filter(
+            $queries,
+            fn($q) => str_contains($q['sql'], 'oce_sinch_patient_consent')
+        );
+        $this->assertEmpty($consentQueries);
+
+        $logs = SystemLogger::getLogs();
+        $warnings = array_filter($logs, fn($log) => $log['level'] === 'warning');
+        $this->assertNotEmpty($warnings);
     }
 
     public function testOptOutDefaultsToSmsChannel(): void
@@ -266,5 +298,137 @@ class ConsentServiceTest extends TestCase
         );
 
         $this->assertNull($this->service->getConsent(1, '+15551234567'));
+    }
+
+    // --- setCarrierBlock ---
+
+    public function testSetCarrierBlockInsertsOrUpdatesRecord(): void
+    {
+        $this->service->setCarrierBlock(1, '+15551234567', 'SMPP error 255');
+
+        $queries = QueryUtils::getQueries();
+        $upsertQueries = array_filter(
+            $queries,
+            fn($q) => str_contains($q['sql'], 'INSERT INTO oce_sinch_patient_consent')
+                && str_contains($q['sql'], 'ON DUPLICATE KEY UPDATE')
+                && str_contains($q['sql'], 'carrier_blocked = TRUE')
+        );
+        $this->assertNotEmpty($upsertQueries);
+
+        $upsert = array_values($upsertQueries)[0];
+        $this->assertEquals(1, $upsert['binds'][0]);
+        $this->assertEquals('+15551234567', $upsert['binds'][1]);
+        $this->assertEquals('SMPP error 255', $upsert['binds'][2]);
+    }
+
+    public function testSetCarrierBlockSkipsUnparseablePhone(): void
+    {
+        $this->service->setCarrierBlock(1, 'not-a-phone', 'SMPP error 255');
+
+        $queries = QueryUtils::getQueries();
+        $updateQueries = array_filter(
+            $queries,
+            fn($q) => str_contains($q['sql'], 'carrier_blocked')
+        );
+        $this->assertEmpty($updateQueries);
+
+        $logs = SystemLogger::getLogs();
+        $warnings = array_filter($logs, fn($log) => $log['level'] === 'warning');
+        $this->assertNotEmpty($warnings);
+    }
+
+    // --- clearCarrierBlock ---
+
+    public function testClearCarrierBlockUpdatesRecord(): void
+    {
+        $this->service->clearCarrierBlock(1, '+15551234567');
+
+        $queries = QueryUtils::getQueries();
+        $updateQueries = array_filter(
+            $queries,
+            fn($q) => str_contains($q['sql'], 'UPDATE oce_sinch_patient_consent')
+                && str_contains($q['sql'], 'carrier_blocked = FALSE')
+        );
+        $this->assertNotEmpty($updateQueries);
+
+        $update = array_values($updateQueries)[0];
+        $this->assertEquals(1, $update['binds'][0]);
+        $this->assertEquals('+15551234567', $update['binds'][1]);
+    }
+
+    public function testClearCarrierBlockSkipsUnparseablePhone(): void
+    {
+        $this->service->clearCarrierBlock(1, 'not-a-phone');
+
+        $queries = QueryUtils::getQueries();
+        $updateQueries = array_filter(
+            $queries,
+            fn($q) => str_contains($q['sql'], 'carrier_blocked')
+        );
+        $this->assertEmpty($updateQueries);
+    }
+
+    // --- getCarrierBlock ---
+
+    public function testGetCarrierBlockReturnsDataWhenBlocked(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT carrier_blocked_at, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ? AND carrier_blocked = TRUE",
+            [1, '+15551234567'],
+            [['carrier_blocked_at' => '2026-04-03 10:00:00', 'carrier_block_reason' => 'SMPP error 255']]
+        );
+
+        $result = $this->service->getCarrierBlock(1, '+15551234567');
+
+        $this->assertNotNull($result);
+        $this->assertEquals('2026-04-03 10:00:00', $result['carrier_blocked_at']);
+        $this->assertEquals('SMPP error 255', $result['carrier_block_reason']);
+    }
+
+    public function testGetCarrierBlockReturnsNullWhenNotBlocked(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT carrier_blocked_at, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ? AND carrier_blocked = TRUE",
+            [1, '+15551234567'],
+            []
+        );
+
+        $this->assertNull($this->service->getCarrierBlock(1, '+15551234567'));
+    }
+
+    // --- optIn does not clear carrier_blocked ---
+
+    public function testOptInDoesNotTouchCarrierBlockColumns(): void
+    {
+        $this->templateService->method('render')->willReturn('Welcome!');
+        $this->messageService->method('sendToPatient');
+
+        $this->service->optIn(1, '+15551234567', 'web_form');
+
+        // Verify none of the queries issued by optIn() reference carrier_blocked.
+        // The optIn SQL uses its own INSERT...ON DUPLICATE KEY UPDATE that must not
+        // clear the carrier_blocked flag — that is only cleared by successful delivery.
+        $queries = QueryUtils::getQueries();
+        foreach ($queries as $query) {
+            if (str_contains($query['sql'], 'hipaa_allowsms')) {
+                continue; // Skip the hipaa sync query
+            }
+            if (str_contains($query['sql'], 'oce_sinch_patient_consent')) {
+                $this->assertStringNotContainsString('carrier_blocked', $query['sql']);
+            }
+        }
+    }
+
+    public function testGetCarrierBlockSkipsUnparseablePhone(): void
+    {
+        $this->assertNull($this->service->getCarrierBlock(1, 'not-a-phone'));
+
+        $logs = SystemLogger::getLogs();
+        $warnings = array_filter($logs, fn($log) => $log['level'] === 'warning');
+        $this->assertNotEmpty($warnings);
     }
 }

--- a/tests/Unit/Service/ConsentSyncServiceTest.php
+++ b/tests/Unit/Service/ConsentSyncServiceTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * Unit tests for ConsentSyncService
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConsentSyncService;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
+use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ConsentSyncServiceTest extends TestCase
+{
+    private GlobalConfig $config;
+    private ConversationApiClient&MockObject $apiClient;
+    private ConsentService&MockObject $consentService;
+    private ConsentSyncService $service;
+
+    protected function setUp(): void
+    {
+        QueryUtils::clearQueries();
+        QueryUtils::clearMockResults();
+        SystemLogger::clearLogs();
+
+        $this->config = new GlobalConfig(new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_APP_ID => 'test-app-id',
+        ]), new MockConfigFactory());
+
+        $this->apiClient = $this->createMock(ConversationApiClient::class);
+        $this->consentService = $this->createMock(ConsentService::class);
+
+        $this->service = new ConsentSyncService(
+            $this->config,
+            $this->apiClient,
+            $this->consentService
+        );
+    }
+
+    public function testSyncOptOutsProcessesIdentities(): void
+    {
+        $this->apiClient->method('listOptOuts')
+            ->with('test-app-id')
+            ->willReturn([
+                ['identity' => '15551234567'],
+                ['identity' => '15559876543'],
+            ]);
+
+        // Patient lookup for first number
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?",
+            ['+15551234567'],
+            [['patient_id' => 1]]
+        );
+        // Patient lookup for second number
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?",
+            ['+15559876543'],
+            [['patient_id' => 2]]
+        );
+        // No local blocks to clear
+        $this->mockClearLiftedBlocksQuery([]);
+
+        $this->consentService->method('getCarrierBlock')->willReturn(null);
+
+        $this->consentService->expects($this->exactly(2))
+            ->method('setCarrierBlock');
+
+        $this->consentService->expects($this->exactly(2))
+            ->method('optOut');
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(2, $result['blocked']);
+        $this->assertEquals(0, $result['cleared']);
+        $this->assertEquals(0, $result['already_blocked']);
+        $this->assertEquals(0, $result['errors']);
+    }
+
+    public function testSyncOptOutsSkipsAlreadyBlocked(): void
+    {
+        $this->apiClient->method('listOptOuts')
+            ->willReturn([
+                ['identity' => '15551234567'],
+            ]);
+
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?",
+            ['+15551234567'],
+            [['patient_id' => 1]]
+        );
+        $this->mockClearLiftedBlocksQuery([]);
+
+        $this->consentService->method('getCarrierBlock')
+            ->willReturn(['carrier_blocked_at' => '2026-04-01', 'carrier_block_reason' => 'SMPP error 255']);
+
+        $this->consentService->expects($this->never())->method('setCarrierBlock');
+        $this->consentService->expects($this->never())->method('optOut');
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(0, $result['blocked']);
+        $this->assertEquals(1, $result['already_blocked']);
+        $this->assertEquals(0, $result['errors']);
+    }
+
+    public function testSyncOptOutsHandlesEmptyList(): void
+    {
+        $this->apiClient->method('listOptOuts')->willReturn([]);
+        $this->mockClearLiftedBlocksQuery([]);
+
+        $this->consentService->expects($this->never())->method('setCarrierBlock');
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(0, $result['blocked']);
+        $this->assertEquals(0, $result['already_blocked']);
+        $this->assertEquals(0, $result['errors']);
+    }
+
+    public function testSyncOptOutsCountsErrors(): void
+    {
+        $this->apiClient->method('listOptOuts')
+            ->willReturn([
+                ['identity' => '15551234567'],
+            ]);
+
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?",
+            ['+15551234567'],
+            [['patient_id' => 1]]
+        );
+        $this->mockClearLiftedBlocksQuery([]);
+
+        $this->consentService->method('getCarrierBlock')->willReturn(null);
+        $this->consentService->method('setCarrierBlock')
+            ->willThrowException(new \RuntimeException('DB error'));
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(0, $result['blocked']);
+        $this->assertEquals(1, $result['errors']);
+    }
+
+    public function testSyncOptOutsSkipsNoPatientsFound(): void
+    {
+        $this->apiClient->method('listOptOuts')
+            ->willReturn([
+                ['identity' => '15551234567'],
+            ]);
+
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?",
+            ['+15551234567'],
+            []
+        );
+        $this->mockClearLiftedBlocksQuery([]);
+
+        $this->consentService->expects($this->never())->method('setCarrierBlock');
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(0, $result['blocked']);
+    }
+
+    public function testCheckIdentityReturnsConsentData(): void
+    {
+        $this->apiClient->method('getConsentStatus')
+            ->with('test-app-id', '+15551234567')
+            ->willReturn(['identity' => '15551234567', 'status' => 'OPT_OUT']);
+
+        $result = $this->service->checkIdentity('+15551234567');
+
+        $this->assertNotEmpty($result);
+        $this->assertEquals('OPT_OUT', $result['status']);
+    }
+
+    public function testCheckIdentityReturnsEmptyWhenNotFound(): void
+    {
+        $this->apiClient->method('getConsentStatus')
+            ->with('test-app-id', '+15551234567')
+            ->willReturn([]);
+
+        $result = $this->service->checkIdentity('+15551234567');
+
+        $this->assertEmpty($result);
+    }
+
+    public function testCheckIdentityReturnsEmptyForUnparseablePhone(): void
+    {
+        $this->apiClient->expects($this->never())->method('getConsentStatus');
+
+        $result = $this->service->checkIdentity('not-a-phone');
+
+        $this->assertEmpty($result);
+    }
+
+    public function testSyncOptOutsClearsLiftedBlocks(): void
+    {
+        // No opt-outs in Sinch
+        $this->apiClient->method('listOptOuts')->willReturn([]);
+
+        // But we have a local consent_api_sync block that should be cleared
+        $this->mockClearLiftedBlocksQuery([
+            ['patient_id' => 1, 'phone_number' => '+15551234567'],
+        ]);
+
+        $this->consentService->expects($this->once())
+            ->method('clearCarrierBlock')
+            ->with(1, '+15551234567');
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(0, $result['blocked']);
+        $this->assertEquals(1, $result['cleared']);
+    }
+
+    public function testSyncOptOutsDoesNotClearBlockStillInSinch(): void
+    {
+        $this->apiClient->method('listOptOuts')
+            ->willReturn([
+                ['identity' => '15551234567'],
+            ]);
+
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?",
+            ['+15551234567'],
+            [['patient_id' => 1]]
+        );
+
+        // Patient is already blocked — won't be re-blocked
+        $this->consentService->method('getCarrierBlock')
+            ->willReturn(['carrier_blocked_at' => '2026-04-01', 'carrier_block_reason' => 'consent_api_sync']);
+
+        // The local block still appears in Sinch, so it should NOT be cleared
+        $this->mockClearLiftedBlocksQuery([
+            ['patient_id' => 1, 'phone_number' => '+15551234567'],
+        ]);
+
+        $this->consentService->expects($this->never())->method('clearCarrierBlock');
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(0, $result['cleared']);
+        $this->assertEquals(1, $result['already_blocked']);
+    }
+
+    public function testSyncOptOutsThrowsWhenListOptOutsFails(): void
+    {
+        $this->apiClient->method('listOptOuts')
+            ->willThrowException(new \RuntimeException('API error'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('API error');
+
+        $this->service->syncOptOuts();
+    }
+
+    public function testSyncOptOutsHandlesMultiplePatientsPerPhone(): void
+    {
+        $this->apiClient->method('listOptOuts')
+            ->willReturn([
+                ['identity' => '15551234567'],
+            ]);
+
+        QueryUtils::setMockResult(
+            "SELECT DISTINCT patient_id FROM oce_sinch_patient_consent WHERE phone_number = ?",
+            ['+15551234567'],
+            [['patient_id' => 1], ['patient_id' => 2], ['patient_id' => 3]]
+        );
+        $this->mockClearLiftedBlocksQuery([]);
+
+        $this->consentService->method('getCarrierBlock')->willReturn(null);
+
+        $this->consentService->expects($this->exactly(3))
+            ->method('setCarrierBlock');
+
+        $this->consentService->expects($this->exactly(3))
+            ->method('optOut');
+
+        $result = $this->service->syncOptOuts();
+
+        $this->assertEquals(3, $result['blocked']);
+    }
+
+    // --- Helpers ---
+
+    /**
+     * Mock the query used by clearLiftedBlocks to find local consent_api_sync blocks
+     *
+     * @param list<array{patient_id: int, phone_number: string}> $rows
+     */
+    private function mockClearLiftedBlocksQuery(array $rows): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT patient_id, phone_number
+                FROM oce_sinch_patient_consent
+                WHERE carrier_blocked = TRUE AND carrier_block_reason = 'consent_api_sync'",
+            [],
+            $rows
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Detect carrier-level opt-outs from SMPP error codes 255/61/151 in delivery failure webhooks, recording a `carrier_blocked` flag and opting all patients sharing the phone number out automatically
- Clear carrier blocks when a subsequent delivery succeeds, confirming the block has been lifted (staff must manually re-opt-in)
- Add `ConsentSyncService` for periodic two-way reconciliation with the Sinch consent API — blocks patients who appear in Sinch's opt-out list, and clears local `consent_api_sync` blocks that no longer appear
- Add `carrier_blocked`, `carrier_blocked_at`, `carrier_block_reason` columns to `oce_sinch_patient_consent` schema

## Design decisions

- **Carrier block is separate from opt-out.** The `carrier_blocked` flag persists even when staff re-opts-in a patient, because the carrier may still be blocking regardless of intent. Only a successful delivery clears it.
- **Clearing a block does not re-opt-in.** The carrier block flow opts out for safety; re-opt-in requires explicit staff action per the issue spec.
- **Multi-patient handling.** Carrier blocks apply to all patients sharing a phone number (consistent with opt-out webhook handler pattern).
- **Channel-aware opt-out.** Webhook handler passes `Channel::SMS` explicitly (SMPP codes are SMS-specific). Consent sync passes `channel: null` to skip `hipaa_allowsms` sync since the API opt-out list is cross-channel.
- **Carrier block detection is fault-tolerant.** Errors during carrier block recording don't fail the delivery status webhook — the status is already persisted.
- **`setCarrierBlock` uses upsert.** `INSERT...ON DUPLICATE KEY UPDATE` ensures blocks are recorded even when no prior consent record exists.

## Test plan

- [x] 384 tests pass, 967 assertions
- [x] PHPStan, PHPCS, Rector, Composer Require Checker all pass
- [ ] Manual: send to a known-blocked number, verify carrier block is recorded for all patients sharing the number
- [ ] Manual: re-opt-in a carrier-blocked patient, verify `carrier_blocked` persists
- [ ] Manual: run `ConsentSyncService::syncOptOuts()` against a Sinch app with known opt-outs
- [ ] Manual: verify lifted blocks are cleared by sync when no longer in Sinch opt-out list

Closes #31
Related: #98 (ALTER TABLE migration for existing installs)