### PR TITLE
fix: require module vendor/autoload.php in bootstrap and background entry

### DIFF
--- a/background_service_entry.php
+++ b/background_service_entry.php
@@ -30,6 +30,11 @@ function oce_sinch_run_appointment_reminders(): void
         return;
     }
 
+    // Background services bypass openemr.bootstrap.php, so the module's composer
+    // autoloader isn't loaded yet. Without it, vendor classes like
+    // ModuleConfigDescriptor and ConfigFactory are not autoloadable.
+    require_once $moduleDir . '/vendor/autoload.php';
+
     // The module's openemr.bootstrap.php registers namespaces via the
     // ModulesClassLoader, but background services bypass that path.
     // Register namespaces directly so autoloading works.

--- a/openemr.bootstrap.php
+++ b/openemr.bootstrap.php
@@ -14,6 +14,11 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations;
 
+// OpenEMR's $classLoader only handles PSR-4 namespace registration for module
+// source code. Third-party packages in the module's vendor/ (oce-lib-module-config,
+// Guzzle, etc.) are invisible without the module's own composer autoloader.
+require_once __DIR__ . '/vendor/autoload.php';
+
 /**
  * @var \OpenEMR\Core\ModulesClassLoader $classLoader Injected by the OpenEMR module loader
  */


### PR DESCRIPTION
## Summary

- Add `require_once __DIR__ . '/vendor/autoload.php'` to `openemr.bootstrap.php` and `background_service_entry.php`
- Without this, the module crashes OpenEMR entirely when enabled because `ModuleConfigDescriptor` (from `oce-lib-module-config`) and other vendor dependencies aren't autoloadable
- The crash happens during `globals.php` initialization, making the entire application unreachable — not just the module

## Test plan

- [x] All pre-commit checks pass
- [ ] Start fresh Docker environment, register and enable module — OpenEMR should not crash
- [ ] Trigger background service — should not crash with class-not-found