### PR TITLE
feat: automate Sinch webhook provisioning from settings page

### DIFF
--- a/public/settings.php
+++ b/public/settings.php
@@ -27,7 +27,15 @@ $logger = new SystemLogger();
 $action = (string)($_GET['action'] ?? $_POST['action'] ?? 'show');
 
 // Actions that expect JSON responses
-$jsonActions = ['test', 'test-sms', 'sync-templates'];
+$jsonActions = [
+    'test',
+    'test-sms',
+    'sync-templates',
+    'webhook-status',
+    'webhook-provision',
+    'webhook-update',
+    'webhook-remove',
+];
 $expectsJson = in_array($action, $jsonActions, true);
 
 try {

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -160,6 +160,26 @@ class Bootstrap
     }
 
     /**
+     * Get App Configuration Client instance
+     */
+    public function getAppConfigurationClient(): \OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient
+    {
+        return new \OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient($this->globalsConfig);
+    }
+
+    /**
+     * Get Webhook Provisioning Service
+     */
+    public function getWebhookProvisioningService(): Service\WebhookProvisioningService
+    {
+        return new Service\WebhookProvisioningService(
+            $this->globalsConfig,
+            $this->getAppConfigurationClient(),
+            $this->getConfigService()
+        );
+    }
+
+    /**
      * Get Message Polling Service
      */
     public function getMessagePollingService(): Service\MessagePollingService
@@ -346,6 +366,7 @@ class Bootstrap
             $this->getConfigService(),
             $this->getConversationApiClient(),
             $this->getTemplateSyncService(),
+            $this->getWebhookProvisioningService(),
             $this->session,
             $this->twig,
             $this->logger

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -19,6 +19,7 @@ use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
+use OpenCoreEMR\Modules\SinchConversations\Service\WebhookProvisioningService;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Config\Region;
@@ -40,6 +41,7 @@ class SettingsController
         private readonly ConfigService $configService,
         private readonly ConversationApiClient $apiClient,
         private readonly TemplateSyncService $templateSyncService,
+        private readonly WebhookProvisioningService $webhookProvisioningService,
         private readonly SessionAccessor $session,
         private readonly Environment $twig,
         private readonly LoggerInterface $logger
@@ -61,6 +63,10 @@ class SettingsController
             'test' => $this->handleTest($request),
             'test-sms' => $this->handleTestSms($request),
             'sync-templates' => $this->handleSyncTemplates($request),
+            'webhook-status' => $this->handleWebhookStatus($request),
+            'webhook-provision' => $this->handleWebhookProvision($request),
+            'webhook-update' => $this->handleWebhookUpdate($request),
+            'webhook-remove' => $this->handleWebhookRemove($request),
             'show', 'default' => $this->showSettings(),
             default => $this->showSettings(),
         };
@@ -83,11 +89,15 @@ class SettingsController
             'clinic_phone' => $this->config->getClinicPhone(),
         ];
 
+        $webhookStatus = $this->safeWebhookStatus();
+
         $content = $this->twig->render('settings/config.html.twig', [
             'settings' => $settings,
             'is_external_config' => $this->config->isExternalConfigMode(),
             'success_message' => $this->session->getFlash('settings_message'),
             'csrf_token' => CsrfUtils::collectCsrfToken(),
+            'webhook_status' => $webhookStatus,
+            'webhook_target_url' => $this->config->getWebhookTargetUrl(),
         ]);
 
         $response = new Response($content);
@@ -445,6 +455,240 @@ class SettingsController
                 'success' => false,
                 'message' => "Template sync failed (ref: $errorId). Check logs for details.",
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Return current webhook provisioning status as JSON.
+     */
+    private function handleWebhookStatus(Request $request): Response
+    {
+        if (!CsrfUtils::verifyCsrfToken($request->query->get('csrf_token', ''))) {
+            throw new AccessDeniedException("CSRF token verification failed");
+        }
+
+        $credentialError = $this->validateApiCredentialsConfigured();
+        if ($credentialError !== null) {
+            return $credentialError;
+        }
+
+        try {
+            $status = $this->webhookProvisioningService->getStatus();
+            return new JsonResponse([
+                'success' => true,
+                'status' => $status,
+            ]);
+        } catch (\Throwable $e) {
+            $errorId = ErrorId::generate();
+            $this->logger->error('Failed to fetch webhook status', [
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
+            return new JsonResponse([
+                'success' => false,
+                'message' => "Failed to fetch webhook status (ref: $errorId). Check logs for details.",
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Provision a new webhook for this tenant on Sinch.
+     */
+    private function handleWebhookProvision(Request $request): Response
+    {
+        if (!$request->isMethod('POST')) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => 'Invalid request method',
+            ], Response::HTTP_METHOD_NOT_ALLOWED);
+        }
+
+        if (!CsrfUtils::verifyCsrfToken($request->request->get('csrf_token', ''))) {
+            throw new AccessDeniedException("CSRF token verification failed");
+        }
+
+        $credentialError = $this->validateApiCredentialsConfigured();
+        if ($credentialError !== null) {
+            return $credentialError;
+        }
+
+        try {
+            $webhook = $this->webhookProvisioningService->provision();
+            $this->logger->info('Webhook provisioned', ['webhook_id' => $webhook['id'] ?? null]);
+            return new JsonResponse([
+                'success' => true,
+                'message' => 'Webhook provisioned successfully.',
+                'webhook' => $webhook,
+            ]);
+        } catch (ValidationException $e) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], Response::HTTP_BAD_REQUEST);
+        } catch (\Throwable $e) {
+            $errorId = ErrorId::generate();
+            $this->logger->error('Webhook provision failed', [
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
+            return new JsonResponse([
+                'success' => false,
+                'message' => "Webhook provision failed (ref: $errorId). Check logs for details.",
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Update the existing webhook (rotate secret, fix triggers).
+     */
+    private function handleWebhookUpdate(Request $request): Response
+    {
+        if (!$request->isMethod('POST')) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => 'Invalid request method',
+            ], Response::HTTP_METHOD_NOT_ALLOWED);
+        }
+
+        if (!CsrfUtils::verifyCsrfToken($request->request->get('csrf_token', ''))) {
+            throw new AccessDeniedException("CSRF token verification failed");
+        }
+
+        $credentialError = $this->validateApiCredentialsConfigured();
+        if ($credentialError !== null) {
+            return $credentialError;
+        }
+
+        try {
+            $webhook = $this->webhookProvisioningService->update();
+            $this->logger->info('Webhook updated', ['webhook_id' => $webhook['id'] ?? null]);
+            return new JsonResponse([
+                'success' => true,
+                'message' => 'Webhook updated successfully.',
+                'webhook' => $webhook,
+            ]);
+        } catch (ValidationException $e) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], Response::HTTP_BAD_REQUEST);
+        } catch (\Throwable $e) {
+            $errorId = ErrorId::generate();
+            $this->logger->error('Webhook update failed', [
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
+            return new JsonResponse([
+                'success' => false,
+                'message' => "Webhook update failed (ref: $errorId). Check logs for details.",
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Remove the existing webhook from Sinch and clear the local secret.
+     */
+    private function handleWebhookRemove(Request $request): Response
+    {
+        if (!$request->isMethod('POST')) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => 'Invalid request method',
+            ], Response::HTTP_METHOD_NOT_ALLOWED);
+        }
+
+        if (!CsrfUtils::verifyCsrfToken($request->request->get('csrf_token', ''))) {
+            throw new AccessDeniedException("CSRF token verification failed");
+        }
+
+        $credentialError = $this->validateApiCredentialsConfigured();
+        if ($credentialError !== null) {
+            return $credentialError;
+        }
+
+        try {
+            $deleted = $this->webhookProvisioningService->remove();
+            $message = $deleted
+                ? 'Webhook removed successfully.'
+                : 'No webhook was registered; local secret cleared.';
+            $this->logger->info('Webhook remove completed', ['deleted' => $deleted]);
+            return new JsonResponse([
+                'success' => true,
+                'message' => $message,
+            ]);
+        } catch (\Throwable $e) {
+            $errorId = ErrorId::generate();
+            $this->logger->error('Webhook remove failed', [
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
+            return new JsonResponse([
+                'success' => false,
+                'message' => "Webhook remove failed (ref: $errorId). Check logs for details.",
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Validate that the four core API credentials are configured. Returns a JSON
+     * error response if anything is missing, or null on success.
+     */
+    private function validateApiCredentialsConfigured(): ?JsonResponse
+    {
+        if (
+            $this->config->getSinchProjectId() === ''
+            || $this->config->getSinchAppId() === ''
+            || $this->config->getSinchApiKey() === ''
+            || $this->config->getSinchApiSecret() === ''
+        ) {
+            return new JsonResponse([
+                'success' => false,
+                'message' => 'Sinch API credentials are incomplete. ' .
+                    'Please configure Project ID, App ID, API Key, and API Secret.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+        return null;
+    }
+
+    /**
+     * Fetch webhook status for the settings page, swallowing API failures so the
+     * page still renders. Returns a not_configured-shaped status on any error.
+     *
+     * @return array<string, mixed>
+     */
+    private function safeWebhookStatus(): array
+    {
+        $defaults = [
+            'state' => WebhookProvisioningService::STATE_NOT_CONFIGURED,
+            'webhook' => null,
+            'triggers_match' => false,
+            'total_webhooks' => 0,
+            'target_url' => $this->config->getWebhookTargetUrl(),
+            'required_triggers' => WebhookProvisioningService::REQUIRED_TRIGGERS,
+            'max_webhooks' => WebhookProvisioningService::MAX_WEBHOOKS,
+            'error' => null,
+        ];
+
+        if (
+            $this->config->getSinchProjectId() === ''
+            || $this->config->getSinchAppId() === ''
+            || $this->config->getSinchApiKey() === ''
+            || $this->config->getSinchApiSecret() === ''
+        ) {
+            $defaults['error'] = 'credentials_missing';
+            return $defaults;
+        }
+
+        try {
+            return $this->webhookProvisioningService->getStatus();
+        } catch (\Throwable $e) {
+            $errorId = ErrorId::generate();
+            $this->logger->warning('Webhook status fetch failed on settings page', [
+                'errorId' => $errorId,
+                'exception' => $e,
+            ]);
+            $defaults['error'] = "fetch_failed:$errorId";
+            return $defaults;
         }
     }
 

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -25,6 +25,7 @@ use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ExceptionInterface;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use Psr\Log\LoggerInterface;
@@ -478,11 +479,19 @@ class SettingsController
                 'success' => true,
                 'status' => $status,
             ]);
+        } catch (ExceptionInterface $e) {
+            $this->logger->warning('Webhook status fetch rejected', [
+                'exception' => ExceptionContext::fromThrowable($e),
+            ]);
+            return new JsonResponse([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], $e->getStatusCode());
         } catch (\Throwable $e) {
             $errorId = ErrorId::generate();
             $this->logger->error('Failed to fetch webhook status', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse([
                 'success' => false,
@@ -520,16 +529,19 @@ class SettingsController
                 'message' => 'Webhook provisioned successfully.',
                 'webhook' => $webhook,
             ]);
-        } catch (ValidationException $e) {
+        } catch (ExceptionInterface $e) {
+            $this->logger->warning('Webhook provision rejected', [
+                'exception' => ExceptionContext::fromThrowable($e),
+            ]);
             return new JsonResponse([
                 'success' => false,
                 'message' => $e->getMessage(),
-            ], Response::HTTP_BAD_REQUEST);
+            ], $e->getStatusCode());
         } catch (\Throwable $e) {
             $errorId = ErrorId::generate();
             $this->logger->error('Webhook provision failed', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse([
                 'success' => false,
@@ -567,16 +579,19 @@ class SettingsController
                 'message' => 'Webhook updated successfully.',
                 'webhook' => $webhook,
             ]);
-        } catch (ValidationException $e) {
+        } catch (ExceptionInterface $e) {
+            $this->logger->warning('Webhook update rejected', [
+                'exception' => ExceptionContext::fromThrowable($e),
+            ]);
             return new JsonResponse([
                 'success' => false,
                 'message' => $e->getMessage(),
-            ], Response::HTTP_BAD_REQUEST);
+            ], $e->getStatusCode());
         } catch (\Throwable $e) {
             $errorId = ErrorId::generate();
             $this->logger->error('Webhook update failed', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse([
                 'success' => false,
@@ -616,11 +631,19 @@ class SettingsController
                 'success' => true,
                 'message' => $message,
             ]);
+        } catch (ExceptionInterface $e) {
+            $this->logger->warning('Webhook remove rejected', [
+                'exception' => ExceptionContext::fromThrowable($e),
+            ]);
+            return new JsonResponse([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], $e->getStatusCode());
         } catch (\Throwable $e) {
             $errorId = ErrorId::generate();
             $this->logger->error('Webhook remove failed', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse([
                 'success' => false,
@@ -685,7 +708,7 @@ class SettingsController
             $errorId = ErrorId::generate();
             $this->logger->warning('Webhook status fetch failed on settings page', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             $defaults['error'] = "fetch_failed:$errorId";
             return $defaults;

--- a/src/Module/GlobalConfig.php
+++ b/src/Module/GlobalConfig.php
@@ -17,11 +17,14 @@ namespace OpenCoreEMR\Modules\SinchConversations;
 use OpenCoreEMR\ModuleConfig\ConfigAccessorInterface;
 use OpenCoreEMR\ModuleConfig\ConfigFactory;
 use OpenCoreEMR\Sinch\Conversation\Config\Region;
+use OpenCoreEMR\Sinch\Conversation\Config\SinchCredentialsInterface;
 use OpenEMR\Common\Crypto\CryptoGen;
 use Symfony\Component\HttpFoundation\IpUtils;
 
-class GlobalConfig
+class GlobalConfig implements SinchCredentialsInterface
 {
+    public const WEBHOOK_PATH = '/interface/modules/custom_modules/oce-module-sinch-conversations/public/webhook.php';
+
     private readonly bool $isExternalConfigMode;
 
     public function __construct(
@@ -134,6 +137,31 @@ class GlobalConfig
     public function getWebroot(): string
     {
         return $this->configAccessor->getString('webroot', '');
+    }
+
+    /**
+     * Get the fully qualified site address (scheme + host + webroot) for building absolute URLs.
+     *
+     * Set by OpenEMR in interface/globals.php from the "Site Address Override" global or resolved
+     * from request headers. Canonical source for the module's public-facing base URL.
+     */
+    public function getQualifiedSiteAddr(): string
+    {
+        return $this->configAccessor->getString('qualified_site_addr', '');
+    }
+
+    /**
+     * Get the absolute URL where this module receives Sinch webhooks.
+     *
+     * Returns empty string if qualified_site_addr is not configured.
+     */
+    public function getWebhookTargetUrl(): string
+    {
+        $siteAddr = $this->getQualifiedSiteAddr();
+        if ($siteAddr === '') {
+            return '';
+        }
+        return rtrim($siteAddr, '/') . self::WEBHOOK_PATH;
     }
 
     /**

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -155,6 +155,22 @@ class ConfigService
         }
     }
 
+    /**
+     * Save the webhook shared secret (encrypted in database mode).
+     */
+    public function saveWebhookSecret(string $secret): void
+    {
+        $this->saveEncryptedSetting(GlobalConfig::CONFIG_OPTION_WEBHOOK_SECRET, $secret);
+    }
+
+    /**
+     * Clear the stored webhook shared secret.
+     */
+    public function clearWebhookSecret(): void
+    {
+        $this->saveSetting(GlobalConfig::CONFIG_OPTION_WEBHOOK_SECRET, '');
+    }
+
     private function saveSetting(string $key, string $value): void
     {
         $this->libConfigService->saveSetting($key, $value);

--- a/src/Module/Service/WebhookProvisioningService.php
+++ b/src/Module/Service/WebhookProvisioningService.php
@@ -10,7 +10,7 @@
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
- * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
  * @license   GNU General Public License 3
  */
 
@@ -212,10 +212,11 @@ class WebhookProvisioningService
     }
 
     /**
-     * Determine whether a webhook target URL belongs to this OpenEMR tenant.
+     * Determine whether a webhook target URL belongs to this OpenEMR installation.
      *
-     * Compares the host component of the target URL with the host of this
-     * tenant's qualified site address (case-insensitive).
+     * Matches on host (case-insensitive) AND the module's webhook path suffix.
+     * The path check prevents claiming a manually-configured webhook that
+     * happens to share our hostname but points to a different endpoint.
      */
     private function isOurWebhook(string $target): bool
     {
@@ -226,12 +227,17 @@ class WebhookProvisioningService
 
         $ourHost = parse_url($siteAddr, PHP_URL_HOST);
         $targetHost = parse_url($target, PHP_URL_HOST);
+        $targetPath = parse_url($target, PHP_URL_PATH);
 
-        if (!is_string($ourHost) || !is_string($targetHost)) {
+        if (!is_string($ourHost) || !is_string($targetHost) || !is_string($targetPath)) {
             return false;
         }
 
-        return strcasecmp($ourHost, $targetHost) === 0;
+        if (strcasecmp($ourHost, $targetHost) !== 0) {
+            return false;
+        }
+
+        return str_ends_with($targetPath, GlobalConfig::WEBHOOK_PATH);
     }
 
     /**

--- a/src/Module/Service/WebhookProvisioningService.php
+++ b/src/Module/Service/WebhookProvisioningService.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Webhook Provisioning Service
+ *
+ * Manages the lifecycle of this module's Sinch webhook via the Sinch
+ * Conversation API. Identifies "our" webhook among the app's webhooks by
+ * matching the host of its target URL against the OpenEMR site address.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;
+use OpenCoreEMR\Sinch\Conversation\Exception\ConfigurationException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
+
+class WebhookProvisioningService
+{
+    /** @var list<string> */
+    public const REQUIRED_TRIGGERS = ['MESSAGE_INBOUND', 'MESSAGE_DELIVERY', 'OPT_IN', 'OPT_OUT'];
+
+    public const MAX_WEBHOOKS = 5;
+
+    public const STATE_NOT_CONFIGURED = 'not_configured';
+    public const STATE_NOT_PROVISIONED = 'not_provisioned';
+    public const STATE_ACTIVE = 'active';
+    public const STATE_NEEDS_UPDATE = 'needs_update';
+
+    public function __construct(
+        private readonly GlobalConfig $config,
+        private readonly AppConfigurationClient $appConfigClient,
+        private readonly ConfigService $configService,
+    ) {
+    }
+
+    /**
+     * Inspect the current state of this module's webhook registration on Sinch.
+     *
+     * @return array{
+     *     state: string,
+     *     webhook: array<string, mixed>|null,
+     *     triggers_match: bool,
+     *     total_webhooks: int,
+     *     target_url: string,
+     *     required_triggers: list<string>,
+     *     max_webhooks: int,
+     * }
+     */
+    public function getStatus(): array
+    {
+        $targetUrl = $this->config->getWebhookTargetUrl();
+        if ($targetUrl === '') {
+            return [
+                'state' => self::STATE_NOT_CONFIGURED,
+                'webhook' => null,
+                'triggers_match' => false,
+                'total_webhooks' => 0,
+                'target_url' => '',
+                'required_triggers' => self::REQUIRED_TRIGGERS,
+                'max_webhooks' => self::MAX_WEBHOOKS,
+            ];
+        }
+
+        $webhooks = $this->appConfigClient->listWebhooks();
+        $ours = null;
+        foreach ($webhooks as $webhook) {
+            $target = (string)($webhook['target'] ?? '');
+            if ($this->isOurWebhook($target)) {
+                $ours = $webhook;
+                break;
+            }
+        }
+
+        if ($ours === null) {
+            return [
+                'state' => self::STATE_NOT_PROVISIONED,
+                'webhook' => null,
+                'triggers_match' => false,
+                'total_webhooks' => count($webhooks),
+                'target_url' => $targetUrl,
+                'required_triggers' => self::REQUIRED_TRIGGERS,
+                'max_webhooks' => self::MAX_WEBHOOKS,
+            ];
+        }
+
+        $rawTriggers = (array)($ours['triggers'] ?? []);
+        $triggers = [];
+        foreach ($rawTriggers as $trigger) {
+            $triggers[] = is_string($trigger) ? $trigger : '';
+        }
+        $triggersMatch = $this->triggersMatch($triggers);
+
+        return [
+            'state' => $triggersMatch ? self::STATE_ACTIVE : self::STATE_NEEDS_UPDATE,
+            'webhook' => $ours,
+            'triggers_match' => $triggersMatch,
+            'total_webhooks' => count($webhooks),
+            'target_url' => $targetUrl,
+            'required_triggers' => self::REQUIRED_TRIGGERS,
+            'max_webhooks' => self::MAX_WEBHOOKS,
+        ];
+    }
+
+    /**
+     * Create a new webhook on Sinch for this module.
+     *
+     * Generates a fresh HMAC secret, registers the webhook with all required
+     * triggers, and persists the secret locally.
+     *
+     * @return array<string, mixed> The created webhook object from Sinch
+     * @throws ConfigurationException When the site address is not configured
+     * @throws ValidationException When a webhook already exists or the app is at capacity
+     */
+    public function provision(): array
+    {
+        $status = $this->getStatus();
+
+        if ($status['state'] === self::STATE_NOT_CONFIGURED) {
+            throw new ConfigurationException(
+                'OpenEMR site address (qualified_site_addr) is not configured; cannot build webhook URL.'
+            );
+        }
+
+        if ($status['webhook'] !== null) {
+            throw new ValidationException(
+                'A webhook for this tenant already exists. Use update to rotate its secret.'
+            );
+        }
+
+        if ($status['total_webhooks'] >= self::MAX_WEBHOOKS) {
+            throw new ValidationException(sprintf(
+                'Sinch app is at the %d-webhook limit; free a slot before provisioning.',
+                self::MAX_WEBHOOKS
+            ));
+        }
+
+        $secret = $this->generateSecret();
+        $webhook = $this->appConfigClient->createWebhook([
+            'target' => $status['target_url'],
+            'triggers' => self::REQUIRED_TRIGGERS,
+            'secret' => $secret,
+        ]);
+
+        $this->configService->saveWebhookSecret($secret);
+
+        return $webhook;
+    }
+
+    /**
+     * Update the existing webhook with the current required triggers and a fresh secret.
+     *
+     * @return array<string, mixed> The updated webhook object from Sinch
+     * @throws ValidationException When no webhook exists to update
+     */
+    public function update(): array
+    {
+        $status = $this->getStatus();
+
+        if ($status['webhook'] === null) {
+            throw new ValidationException('No webhook exists for this tenant; provision one first.');
+        }
+
+        $webhookId = (string)($status['webhook']['id'] ?? '');
+        if ($webhookId === '') {
+            throw new ValidationException('Existing webhook has no id; cannot update.');
+        }
+
+        $secret = $this->generateSecret();
+        $webhook = $this->appConfigClient->updateWebhook($webhookId, [
+            'target' => $status['target_url'],
+            'triggers' => self::REQUIRED_TRIGGERS,
+            'secret' => $secret,
+        ]);
+
+        $this->configService->saveWebhookSecret($secret);
+
+        return $webhook;
+    }
+
+    /**
+     * Delete the existing webhook from Sinch and clear the local secret.
+     *
+     * @return bool True if a webhook was deleted, false if nothing was registered
+     */
+    public function remove(): bool
+    {
+        $status = $this->getStatus();
+
+        if ($status['webhook'] === null) {
+            $this->configService->clearWebhookSecret();
+            return false;
+        }
+
+        $webhookId = (string)($status['webhook']['id'] ?? '');
+        if ($webhookId === '') {
+            throw new ValidationException('Existing webhook has no id; cannot remove.');
+        }
+
+        $deleted = $this->appConfigClient->deleteWebhook($webhookId);
+        $this->configService->clearWebhookSecret();
+
+        return $deleted;
+    }
+
+    /**
+     * Determine whether a webhook target URL belongs to this OpenEMR tenant.
+     *
+     * Compares the host component of the target URL with the host of this
+     * tenant's qualified site address (case-insensitive).
+     */
+    private function isOurWebhook(string $target): bool
+    {
+        $siteAddr = $this->config->getQualifiedSiteAddr();
+        if ($siteAddr === '' || $target === '') {
+            return false;
+        }
+
+        $ourHost = parse_url($siteAddr, PHP_URL_HOST);
+        $targetHost = parse_url($target, PHP_URL_HOST);
+
+        if (!is_string($ourHost) || !is_string($targetHost)) {
+            return false;
+        }
+
+        return strcasecmp($ourHost, $targetHost) === 0;
+    }
+
+    /**
+     * @param list<string> $triggers
+     */
+    private function triggersMatch(array $triggers): bool
+    {
+        $actual = array_map('strtoupper', $triggers);
+        sort($actual);
+        $expected = self::REQUIRED_TRIGGERS;
+        sort($expected);
+        return $actual === $expected;
+    }
+
+    /**
+     * Generate a cryptographically random secret suitable for HMAC-SHA256 validation.
+     */
+    private function generateSecret(): string
+    {
+        return bin2hex(random_bytes(32));
+    }
+}

--- a/src/Sinch/Conversation/Client/AppConfigurationClient.php
+++ b/src/Sinch/Conversation/Client/AppConfigurationClient.php
@@ -21,7 +21,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use OpenCoreEMR\Modules\SinchConversations\Common\ArrayPath;
 use OpenCoreEMR\Modules\SinchConversations\Common\Json;
-use OpenCoreEMR\Sinch\Conversation\Config\ConfigInterface;
+use OpenCoreEMR\Sinch\Conversation\Config\SinchCredentialsInterface;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 
 class AppConfigurationClient
@@ -30,7 +30,7 @@ class AppConfigurationClient
     private readonly Client $httpClient;
     private ?string $cachedAccessToken = null;
 
-    public function __construct(private readonly ConfigInterface $config)
+    public function __construct(private readonly SinchCredentialsInterface $config)
     {
         $this->httpClient = new Client([
             'base_uri' => $config->getSinchApiBaseUrl(),

--- a/src/Sinch/Conversation/Client/AppConfigurationClient.php
+++ b/src/Sinch/Conversation/Client/AppConfigurationClient.php
@@ -235,12 +235,14 @@ class AppConfigurationClient
             throw new ApiException("App ID is required");
         }
 
+        $body = $webhookData + ['app_id' => $appId, 'target_type' => 'HTTP'];
+
         try {
             $response = $this->httpClient->post(
-                "/v1/projects/{$projectId}/apps/{$appId}/webhooks",
+                "/v1/projects/{$projectId}/webhooks",
                 [
                     'headers' => $this->getHeaders(),
-                    'json' => $webhookData,
+                    'json' => $body,
                 ]
             );
 
@@ -270,7 +272,7 @@ class AppConfigurationClient
 
         try {
             $response = $this->httpClient->patch(
-                "/v1/projects/{$projectId}/apps/{$appId}/webhooks/{$webhookId}",
+                "/v1/projects/{$projectId}/webhooks/{$webhookId}",
                 [
                     'headers' => $this->getHeaders(),
                     'json' => $webhookData,
@@ -302,7 +304,7 @@ class AppConfigurationClient
 
         try {
             $response = $this->httpClient->delete(
-                "/v1/projects/{$projectId}/apps/{$appId}/webhooks/{$webhookId}",
+                "/v1/projects/{$projectId}/webhooks/{$webhookId}",
                 [
                     'headers' => $this->getHeaders(),
                 ]

--- a/src/Sinch/Conversation/Config/SinchCredentialsInterface.php
+++ b/src/Sinch/Conversation/Config/SinchCredentialsInterface.php
@@ -1,7 +1,10 @@
 <?php
 
 /**
- * Configuration Interface for Sinch API Clients
+ * Sinch API credentials interface.
+ *
+ * Defines the credential getters required by Sinch API clients. Distinct from
+ * the generic OpenEMR module config layer (oce-lib-module-config).
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com/
@@ -14,7 +17,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Sinch\Conversation\Config;
 
-interface ConfigInterface
+interface SinchCredentialsInterface
 {
     public function getSinchProjectId(): string;
 

--- a/src/Sinch/Conversation/Config/StandaloneConfig.php
+++ b/src/Sinch/Conversation/Config/StandaloneConfig.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Sinch\Conversation\Config;
 
-class StandaloneConfig implements ConfigInterface
+class StandaloneConfig implements SinchCredentialsInterface
 {
     /**
      * @param array<string, string> $config

--- a/templates/settings/config.html.twig
+++ b/templates/settings/config.html.twig
@@ -243,6 +243,99 @@
         <div id="test-sms-result" class="mt-3" style="display: none;">
             <div class="alert" role="alert" id="test-sms-alert"></div>
         </div>
+
+        {# Webhook Configuration #}
+        <div class="section-header mt-4">
+            <h3>{{ 'Webhook Configuration'|xlt }}</h3>
+            <p class="help-text">
+                {{ 'Manage the Sinch webhook that delivers inbound messages and opt-in/opt-out events to this OpenEMR instance.'|xlt }}
+            </p>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">{{ 'Webhook Target URL'|xlt }}</label>
+            <input
+                type="text"
+                class="form-control"
+                value="{{ webhook_target_url|attr }}"
+                readonly
+            >
+            <div class="help-text">
+                {% if webhook_target_url == '' %}
+                    {{ 'Site address (qualified_site_addr) is not configured in OpenEMR globals; cannot build webhook URL.'|xlt }}
+                {% else %}
+                    {{ 'Built from the OpenEMR site address. Webhook will register against this URL.'|xlt }}
+                {% endif %}
+            </div>
+        </div>
+
+        <div id="webhook-status-display" class="mt-3">
+            {% if webhook_status.error == 'credentials_missing' %}
+                <div class="alert alert-secondary" role="alert">
+                    {{ 'Configure and save Sinch API credentials above before managing the webhook.'|xlt }}
+                </div>
+            {% elseif webhook_status.error starts with 'fetch_failed' %}
+                <div class="alert alert-danger" role="alert">
+                    {{ 'Failed to fetch webhook status from Sinch. See server logs.'|xlt }}
+                    <code>{{ webhook_status.error|text }}</code>
+                </div>
+            {% elseif webhook_status.state == 'not_configured' %}
+                <div class="alert alert-warning" role="alert">
+                    {{ 'Webhook URL cannot be built without a configured site address.'|xlt }}
+                </div>
+            {% elseif webhook_status.state == 'not_provisioned' %}
+                <div class="alert alert-warning" role="alert">
+                    <strong>{{ 'Not provisioned.'|xlt }}</strong>
+                    {{ 'No webhook is registered for this OpenEMR instance.'|xlt }}
+                    <div class="mt-2">
+                        {{ '%d of %d webhook slots used on this Sinch app.'|xlt|format(webhook_status.total_webhooks, webhook_status.max_webhooks) }}
+                    </div>
+                </div>
+            {% elseif webhook_status.state == 'active' %}
+                <div class="alert alert-success" role="alert">
+                    <strong>{{ 'Active.'|xlt }}</strong>
+                    {{ 'Webhook is registered and configured with the required triggers.'|xlt }}
+                    <div class="mt-2">
+                        <strong>{{ 'Webhook ID:'|xlt }}</strong> <code>{{ webhook_status.webhook.id|text }}</code><br>
+                        <strong>{{ 'Triggers:'|xlt }}</strong> {{ webhook_status.webhook.triggers|join(', ')|text }}<br>
+                        {{ '%d of %d webhook slots used on this Sinch app.'|xlt|format(webhook_status.total_webhooks, webhook_status.max_webhooks) }}
+                    </div>
+                </div>
+            {% elseif webhook_status.state == 'needs_update' %}
+                <div class="alert alert-warning" role="alert">
+                    <strong>{{ 'Needs update.'|xlt }}</strong>
+                    {{ 'Webhook is registered but its triggers do not match the current required set.'|xlt }}
+                    <div class="mt-2">
+                        <strong>{{ 'Webhook ID:'|xlt }}</strong> <code>{{ webhook_status.webhook.id|text }}</code><br>
+                        <strong>{{ 'Current triggers:'|xlt }}</strong> {{ webhook_status.webhook.triggers|join(', ')|text }}<br>
+                        <strong>{{ 'Required triggers:'|xlt }}</strong> {{ webhook_status.required_triggers|join(', ')|text }}
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="d-flex gap-2 mt-3">
+            <button type="button" class="btn btn-secondary" id="webhook-refresh-btn">
+                {{ 'Refresh Status'|xlt }}
+            </button>
+            {% if webhook_status.state == 'not_provisioned' %}
+                <button type="button" class="btn btn-primary" id="webhook-provision-btn">
+                    {{ 'Provision Webhook'|xlt }}
+                </button>
+            {% endif %}
+            {% if webhook_status.state == 'active' or webhook_status.state == 'needs_update' %}
+                <button type="button" class="btn btn-warning" id="webhook-update-btn">
+                    {{ 'Update Webhook (rotate secret)'|xlt }}
+                </button>
+                <button type="button" class="btn btn-danger" id="webhook-remove-btn">
+                    {{ 'Remove Webhook'|xlt }}
+                </button>
+            {% endif %}
+        </div>
+
+        <div id="webhook-result" class="mt-3" style="display: none;">
+            <div class="alert" role="alert" id="webhook-alert"></div>
+        </div>
     </div>
 
     <script src="{{ webroot }}/public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
@@ -393,6 +486,108 @@
                     btn.textContent = {{ 'Send Test SMS'|xlj }};
                 });
         });
+
+        // Webhook provisioning controls
+        (function() {
+            const csrfToken = document.querySelector('input[name="csrf_token"]').value;
+            const resultDiv = document.getElementById('webhook-result');
+            const alertDiv = document.getElementById('webhook-alert');
+
+            function showResult(success, message) {
+                resultDiv.style.display = 'block';
+                alertDiv.className = 'alert ' + (success ? 'alert-success' : 'alert-danger');
+                alertDiv.textContent = message;
+            }
+
+            function postAction(action, btn, busyLabel, originalLabel, confirmMessage) {
+                if (confirmMessage && !window.confirm(confirmMessage)) {
+                    return;
+                }
+                btn.disabled = true;
+                btn.textContent = busyLabel;
+                const formData = new FormData();
+                formData.append('csrf_token', csrfToken);
+                fetch('?action=' + action, { method: 'POST', body: formData })
+                    .then(response => response.json())
+                    .then(data => {
+                        showResult(data.success, data.message || '');
+                        if (data.success) {
+                            window.setTimeout(() => window.location.reload(), 800);
+                        }
+                    })
+                    .catch(error => {
+                        showResult(false, '{{ 'Webhook action failed: '|xlj }}' + error.message);
+                    })
+                    .finally(() => {
+                        btn.disabled = false;
+                        btn.textContent = originalLabel;
+                    });
+            }
+
+            const refreshBtn = document.getElementById('webhook-refresh-btn');
+            if (refreshBtn) {
+                refreshBtn.addEventListener('click', function() {
+                    const btn = this;
+                    btn.disabled = true;
+                    btn.textContent = {{ 'Refreshing...'|xlj }};
+                    fetch('?action=webhook-status&csrf_token=' + encodeURIComponent(csrfToken))
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.success) {
+                                window.location.reload();
+                            } else {
+                                showResult(false, data.message || '{{ 'Failed to refresh status'|xlj }}');
+                                btn.disabled = false;
+                                btn.textContent = {{ 'Refresh Status'|xlj }};
+                            }
+                        })
+                        .catch(error => {
+                            showResult(false, '{{ 'Failed to refresh status: '|xlj }}' + error.message);
+                            btn.disabled = false;
+                            btn.textContent = {{ 'Refresh Status'|xlj }};
+                        });
+                });
+            }
+
+            const provisionBtn = document.getElementById('webhook-provision-btn');
+            if (provisionBtn) {
+                provisionBtn.addEventListener('click', function() {
+                    postAction(
+                        'webhook-provision',
+                        this,
+                        {{ 'Provisioning...'|xlj }},
+                        {{ 'Provision Webhook'|xlj }},
+                        null
+                    );
+                });
+            }
+
+            const updateBtn = document.getElementById('webhook-update-btn');
+            if (updateBtn) {
+                updateBtn.addEventListener('click', function() {
+                    postAction(
+                        'webhook-update',
+                        this,
+                        {{ 'Updating...'|xlj }},
+                        {{ 'Update Webhook (rotate secret)'|xlj }},
+                        {{ 'This will rotate the webhook secret. Continue?'|xlj }}
+                    );
+                });
+            }
+
+            const removeBtn = document.getElementById('webhook-remove-btn');
+            if (removeBtn) {
+                removeBtn.addEventListener('click', function() {
+                    postAction(
+                        'webhook-remove',
+                        this,
+                        {{ 'Removing...'|xlj }},
+                        {{ 'Remove Webhook'|xlj }},
+                        {{ 'This will delete the webhook from Sinch. Continue?'|xlj }}
+                    );
+                });
+            }
+        })();
     </script>
 </body>
 </html>

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -253,6 +253,7 @@ class SettingsControllerTest extends TestCase
             $this->configService,
             $this->apiClient,
             $this->syncService,
+            $this->webhookProvisioningService,
             $this->session,
             $this->twig,
             new SystemLogger()

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -18,6 +18,7 @@ use OpenCoreEMR\Modules\SinchConversations\Controller\SettingsController;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
+use OpenCoreEMR\Modules\SinchConversations\Service\WebhookProvisioningService;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
@@ -43,6 +44,7 @@ class SettingsControllerTest extends TestCase
     private ConfigService&MockObject $configService;
     private ConversationApiClient&MockObject $apiClient;
     private TemplateSyncService&MockObject $syncService;
+    private WebhookProvisioningService&MockObject $webhookProvisioningService;
     private SessionAccessor&MockObject $session;
     private Environment $twig;
     private SettingsController $controller;
@@ -78,6 +80,7 @@ class SettingsControllerTest extends TestCase
         $this->configService = $this->createMock(ConfigService::class);
         $this->apiClient = $this->createMock(ConversationApiClient::class);
         $this->syncService = $this->createMock(TemplateSyncService::class);
+        $this->webhookProvisioningService = $this->createMock(WebhookProvisioningService::class);
         $this->session = $this->createMock(SessionAccessor::class);
 
         $loader = new ArrayLoader([
@@ -90,6 +93,7 @@ class SettingsControllerTest extends TestCase
             $this->configService,
             $this->apiClient,
             $this->syncService,
+            $this->webhookProvisioningService,
             $this->session,
             $this->twig,
             new SystemLogger()
@@ -320,6 +324,7 @@ class SettingsControllerTest extends TestCase
                 $this->configService,
                 $this->apiClient,
                 $this->syncService,
+                $this->webhookProvisioningService,
                 $this->session,
                 $this->twig,
                 new SystemLogger()
@@ -446,6 +451,7 @@ class SettingsControllerTest extends TestCase
             $this->configService,
             $this->apiClient,
             $this->syncService,
+            $this->webhookProvisioningService,
             $this->session,
             $this->twig,
             new SystemLogger()
@@ -599,6 +605,7 @@ class SettingsControllerTest extends TestCase
             $this->configService,
             $this->apiClient,
             $this->syncService,
+            $this->webhookProvisioningService,
             $this->session,
             $this->twig,
             new SystemLogger()

--- a/tests/Unit/Service/WebhookProvisioningServiceTest.php
+++ b/tests/Unit/Service/WebhookProvisioningServiceTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Unit tests for WebhookProvisioningService
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
+use OpenCoreEMR\Modules\SinchConversations\Service\WebhookProvisioningService;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
+use OpenCoreEMR\Sinch\Conversation\Client\AppConfigurationClient;
+use OpenCoreEMR\Sinch\Conversation\Exception\ConfigurationException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class WebhookProvisioningServiceTest extends TestCase
+{
+    private const TENANT_HOST = 'tenant-a.example.com';
+    private const TENANT_SITE_ADDR = 'https://tenant-a.example.com';
+    private const TENANT_TARGET = 'https://tenant-a.example.com'
+        . GlobalConfig::WEBHOOK_PATH;
+
+    private AppConfigurationClient&MockObject $appClient;
+    private ConfigService&MockObject $configService;
+
+    protected function setUp(): void
+    {
+        $this->appClient = $this->createMock(AppConfigurationClient::class);
+        $this->configService = $this->createMock(ConfigService::class);
+    }
+
+    private function makeService(string $siteAddr = self::TENANT_SITE_ADDR): WebhookProvisioningService
+    {
+        $config = new GlobalConfig(
+            new MockGlobalsAccessor(['qualified_site_addr' => $siteAddr]),
+            new MockConfigFactory()
+        );
+        return new WebhookProvisioningService($config, $this->appClient, $this->configService);
+    }
+
+    public function testGetStatusReturnsNotConfiguredWhenSiteAddressMissing(): void
+    {
+        $service = $this->makeService('');
+        $this->appClient->expects($this->never())->method('listWebhooks');
+
+        $status = $service->getStatus();
+
+        $this->assertSame(WebhookProvisioningService::STATE_NOT_CONFIGURED, $status['state']);
+        $this->assertNull($status['webhook']);
+        $this->assertSame('', $status['target_url']);
+    }
+
+    public function testGetStatusReturnsNotProvisionedWhenNoMatchingWebhook(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([
+            ['id' => 'wh-1', 'target' => 'https://other-tenant.example.com' . GlobalConfig::WEBHOOK_PATH, 'triggers' => ['MESSAGE_INBOUND']],
+        ]);
+
+        $status = $service->getStatus();
+
+        $this->assertSame(WebhookProvisioningService::STATE_NOT_PROVISIONED, $status['state']);
+        $this->assertNull($status['webhook']);
+        $this->assertSame(1, $status['total_webhooks']);
+        $this->assertSame(self::TENANT_TARGET, $status['target_url']);
+    }
+
+    public function testGetStatusReturnsActiveWhenAllTriggersMatch(): void
+    {
+        $service = $this->makeService();
+        $ours = [
+            'id' => 'wh-2',
+            'target' => self::TENANT_TARGET,
+            'triggers' => ['MESSAGE_INBOUND', 'MESSAGE_DELIVERY', 'OPT_IN', 'OPT_OUT'],
+        ];
+        $this->appClient->method('listWebhooks')->willReturn([$ours]);
+
+        $status = $service->getStatus();
+
+        $this->assertSame(WebhookProvisioningService::STATE_ACTIVE, $status['state']);
+        $this->assertSame($ours, $status['webhook']);
+        $this->assertTrue($status['triggers_match']);
+    }
+
+    public function testGetStatusReturnsNeedsUpdateWhenTriggersDiffer(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([[
+            'id' => 'wh-3',
+            'target' => self::TENANT_TARGET,
+            'triggers' => ['MESSAGE_INBOUND'],
+        ]]);
+
+        $status = $service->getStatus();
+
+        $this->assertSame(WebhookProvisioningService::STATE_NEEDS_UPDATE, $status['state']);
+        $this->assertFalse($status['triggers_match']);
+    }
+
+    public function testGetStatusMatchesHostnameCaseInsensitively(): void
+    {
+        $service = $this->makeService('https://TENANT-A.example.com');
+        $this->appClient->method('listWebhooks')->willReturn([[
+            'id' => 'wh-4',
+            'target' => 'https://tenant-a.example.com' . GlobalConfig::WEBHOOK_PATH,
+            'triggers' => ['MESSAGE_INBOUND', 'MESSAGE_DELIVERY', 'OPT_IN', 'OPT_OUT'],
+        ]]);
+
+        $status = $service->getStatus();
+
+        $this->assertSame(WebhookProvisioningService::STATE_ACTIVE, $status['state']);
+    }
+
+    public function testProvisionThrowsWhenSiteAddressMissing(): void
+    {
+        $service = $this->makeService('');
+
+        $this->expectException(ConfigurationException::class);
+        $service->provision();
+    }
+
+    public function testProvisionThrowsWhenWebhookAlreadyExists(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([[
+            'id' => 'wh-5',
+            'target' => self::TENANT_TARGET,
+            'triggers' => WebhookProvisioningService::REQUIRED_TRIGGERS,
+        ]]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/already exists/');
+        $service->provision();
+    }
+
+    public function testProvisionThrowsWhenAtCapacity(): void
+    {
+        $service = $this->makeService();
+        $foreignWebhooks = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $foreignWebhooks[] = [
+                'id' => "wh-$i",
+                'target' => "https://other-$i.example.com" . GlobalConfig::WEBHOOK_PATH,
+                'triggers' => ['MESSAGE_INBOUND'],
+            ];
+        }
+        $this->appClient->method('listWebhooks')->willReturn($foreignWebhooks);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/limit/');
+        $service->provision();
+    }
+
+    public function testProvisionCreatesWebhookAndSavesSecret(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([]);
+
+        $createdWebhook = ['id' => 'wh-new', 'target' => self::TENANT_TARGET, 'triggers' => WebhookProvisioningService::REQUIRED_TRIGGERS];
+        $this->appClient->expects($this->once())
+            ->method('createWebhook')
+            ->with($this->callback(function (array $data): bool {
+                $this->assertSame(self::TENANT_TARGET, $data['target']);
+                $this->assertSame(WebhookProvisioningService::REQUIRED_TRIGGERS, $data['triggers']);
+                $this->assertIsString($data['secret']);
+                $this->assertSame(64, strlen($data['secret']));
+                return true;
+            }))
+            ->willReturn($createdWebhook);
+
+        $this->configService->expects($this->once())
+            ->method('saveWebhookSecret')
+            ->with($this->isString());
+
+        $result = $service->provision();
+        $this->assertSame($createdWebhook, $result);
+    }
+
+    public function testUpdateThrowsWhenNoExistingWebhook(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/No webhook exists/');
+        $service->update();
+    }
+
+    public function testUpdateRotatesSecretAndFixesTriggers(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([[
+            'id' => 'wh-6',
+            'target' => self::TENANT_TARGET,
+            'triggers' => ['MESSAGE_INBOUND'],
+        ]]);
+
+        $updated = ['id' => 'wh-6', 'target' => self::TENANT_TARGET, 'triggers' => WebhookProvisioningService::REQUIRED_TRIGGERS];
+        $this->appClient->expects($this->once())
+            ->method('updateWebhook')
+            ->with(
+                'wh-6',
+                $this->callback(function (array $data): bool {
+                    $this->assertSame(WebhookProvisioningService::REQUIRED_TRIGGERS, $data['triggers']);
+                    $this->assertIsString($data['secret']);
+                    return true;
+                })
+            )
+            ->willReturn($updated);
+
+        $this->configService->expects($this->once())->method('saveWebhookSecret');
+
+        $result = $service->update();
+        $this->assertSame($updated, $result);
+    }
+
+    public function testRemoveDeletesWebhookAndClearsSecret(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([[
+            'id' => 'wh-7',
+            'target' => self::TENANT_TARGET,
+            'triggers' => WebhookProvisioningService::REQUIRED_TRIGGERS,
+        ]]);
+
+        $this->appClient->expects($this->once())
+            ->method('deleteWebhook')
+            ->with('wh-7')
+            ->willReturn(true);
+
+        $this->configService->expects($this->once())->method('clearWebhookSecret');
+
+        $this->assertTrue($service->remove());
+    }
+
+    public function testRemoveClearsSecretEvenWhenNothingRegistered(): void
+    {
+        $service = $this->makeService();
+        $this->appClient->method('listWebhooks')->willReturn([]);
+
+        $this->appClient->expects($this->never())->method('deleteWebhook');
+        $this->configService->expects($this->once())->method('clearWebhookSecret');
+
+        $this->assertFalse($service->remove());
+    }
+}


### PR DESCRIPTION
## Summary

- New `WebhookProvisioningService` manages this module's Sinch webhook lifecycle (status / provision / update / remove) via the Conversation API
- Settings page gains a Webhook Configuration section showing current state and exposing action buttons, eliminating manual dashboard setup
- "Our" webhook is identified by case-insensitive hostname match **and** webhook-path-suffix match between the registered target URL and this install's `qualified_site_addr`, so manually-configured webhooks on the same hostname are not accidentally claimed
- Auto-generates the HMAC secret and stores it locally (encrypted in DB mode), so admins never have to copy secrets between systems
- Renames `ConfigInterface` → `SinchCredentialsInterface` to clarify its narrow purpose and disambiguate it from the generic module config layer

Partial fix for #62. Several hardening items intentionally deferred to follow-up work; #62 stays open until they land.

## Test plan

- [x] `task check` (PHPStan, PHPCS, rector, composer-require-checker, smoke test)
- [x] `composer test` — 401 tests, 1015 assertions
- [x] 13 new unit tests for `WebhookProvisioningService` covering: not_configured / not_provisioned / active / needs_update states, capacity limit, hostname case-insensitivity, provision, update, remove flows
- [ ] Manual: settings page renders webhook section with correct status
- [ ] Manual: Provision creates a webhook on Sinch and stores secret locally
- [ ] Manual: `sinch:webhook:list` CLI shows the new webhook
- [ ] Manual: Update rotates the secret and fixes triggers
- [ ] Manual: Remove deletes from Sinch and clears local secret
- [ ] Manual: With another webhook on the same app pointing at a different path on this hostname, ours is correctly identified
