### PR TITLE
fix: normalize phone number in appointment reminder consent check

### DIFF
--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -71,8 +71,19 @@ class AppointmentReminderService
             $pcEid = (int) $appointment['pc_eid'];
             $patientId = (int) $appointment['pc_pid'];
 
-            $phoneNumber = $appointment['phone_cell'] ?? '';
-            if ($phoneNumber === '') {
+            $rawPhone = $appointment['phone_cell'] ?? '';
+            if ($rawPhone === '') {
+                $results['skipped']++;
+                continue;
+            }
+
+            $phoneNumber = PhoneNormalizer::toE164($rawPhone);
+            if ($phoneNumber === null) {
+                $this->logger->warning('Skipping appointment reminder: unparseable phone number', [
+                    'pc_eid' => $pcEid,
+                    'patientId' => $patientId,
+                    'phone' => $rawPhone,
+                ]);
                 $results['skipped']++;
                 continue;
             }
@@ -193,6 +204,8 @@ class AppointmentReminderService
      *
      * The hipaa_allowsms check is handled in run() from the main query result.
      * This method checks only module-level consent in oce_sinch_patient_consent.
+     *
+     * @param string $phoneNumber E.164 normalized phone number
      */
     private function hasActiveConsent(int $patientId, string $phoneNumber): bool
     {

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -386,6 +386,33 @@ class AppointmentReminderServiceTest extends TestCase
         $this->assertSame(1, $results['sent']);
     }
 
+    // --- raw phone_cell format is normalized before consent lookup ---
+
+    public function testRunNormalizesPhoneCellBeforeConsentLookup(): void
+    {
+        // phone_cell is a raw 10-digit number as stored in patient_data,
+        // but consent is recorded in E.164 format (+1 prefix)
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(500, 80, '2026-04-01', '09:00:00', '5102551233', 'YES'),
+        ]);
+        $this->mockActiveConsent(80, '+15102551233');
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+        $this->templateService->method('render')
+            ->willReturn('Reminder for raw phone.');
+
+        $this->messageService->expects($this->once())
+            ->method('sendToPatient')
+            ->with(80, '+15102551233', 'Reminder for raw phone.', $this->anything())
+            ->willReturn(['id' => 'msg-raw-phone']);
+
+        $results = $this->service->run();
+
+        $this->assertSame(1, $results['sent']);
+        $this->assertSame(0, $results['skipped']);
+    }
+
     // --- cleanup ---
 
     public function testRunPurgesExpiredReminders(): void


### PR DESCRIPTION
## Summary

- Appointment reminders were silently skipped for all patients because `hasActiveConsent()` compared the raw `phone_cell` value (e.g. `5102551233`) against consent records stored in E.164 format (`+15102551233`)
- Normalize via `PhoneNormalizer::toE164()` once at the top of the appointment loop so the E.164 value is used for both the consent lookup and `sendToPatient()`, preventing raw numbers from being stored in `oce_sinch_contacts` or sent to the Sinch API unnormalized

Closes #106