### PR TITLE
fix: render Sinch channel state object in Test API Connection result

### DIFF
--- a/templates/settings/config.html.twig
+++ b/templates/settings/config.html.twig
@@ -287,8 +287,19 @@
                         if (data.app_config.channel_credentials && data.app_config.channel_credentials.length > 0) {
                             message += '\n{{ "Channels:"|xlt }}\n';
                             data.app_config.channel_credentials.forEach(channel => {
-                                message += '  - ' + (channel.channel || 'Unknown') + ': ' +
-                                          (channel.state || 'Unknown state') + '\n';
+                                // state can be a string or an object { status, description }
+                                let stateStatus = 'Unknown state';
+                                let stateDescription = '';
+                                if (channel.state && typeof channel.state === 'object') {
+                                    stateStatus = channel.state.status || 'Unknown state';
+                                    stateDescription = channel.state.description || '';
+                                } else if (channel.state) {
+                                    stateStatus = channel.state;
+                                }
+                                message += '  - ' + (channel.channel || 'Unknown') + ': ' + stateStatus + '\n';
+                                if (stateDescription) {
+                                    message += '    {{ "Description:"|xlt }} ' + stateDescription + '\n';
+                                }
                                 if (channel.static_bearer) {
                                     message += '    {{ "Bearer:"|xlt }} ' + channel.static_bearer.claimed_identity + '\n';
                                 }


### PR DESCRIPTION
## Summary

- The Test API Connection feature's result text displayed `[object Object]` for each channel (e.g., `- SMS: [object Object]`) because the inline JS in `templates/settings/config.html.twig` concatenated `channel.state` directly into a string. Sinch's Conversation API returns `channel_credentials[].state` as an object (`{ status, description }`) on current versions.
- The template now extracts `state.status` (and optionally `state.description` on a following line), while still falling back to treating `state` as a string for older API responses that used a plain enum. This mirrors the existing PHP handling in `InspectCommand.php`.

### Before
```
Channels:
  - SMS: [object Object]
    Bearer: OpenCoreEMR_RA
```

### After
```
Channels:
  - SMS: ACTIVE
    Bearer: OpenCoreEMR_RA
```

## Test plan

- [ ] Open Admin > Config > OpenCoreEMR Sinch Conversations, click **Test API Connection**, and confirm each channel line shows a human-readable status (e.g., `ACTIVE`) instead of `[object Object]`.
- [ ] If Sinch returns a `description` on the state, confirm it renders on an indented `Description:` line beneath the channel.
- [ ] Confirm no regression when `state` is absent (falls back to `Unknown state`).