### PR TITLE
feat: opt patients in via hipaa_allowsms transitions on the chart

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -29,6 +29,8 @@
     "OpenEMR\\Services\\Utils\\SQLUpgradeService",
     "ModuleManagerListener",
     "OpenEMR\\Events\\Globals\\GlobalsInitializedEvent",
+    "OpenEMR\\Events\\Patient\\PatientCreatedEvent",
+    "OpenEMR\\Events\\Patient\\PatientUpdatedEvent",
     "OpenEMR\\Events\\PatientDocuments\\PatientDocumentEvent",
     "OpenEMR\\Menu\\MenuEvent",
     "OpenEMR\\Services\\Globals\\GlobalSetting",

--- a/docs/messaging/opt-out.md
+++ b/docs/messaging/opt-out.md
@@ -47,14 +47,29 @@ April 11, 2025.
 3. The module checks this field before sending — messages are blocked
    immediately
 
-## Opt-In (Re-subscribe)
+## Opt-In via Patient Chart
 
-A patient who previously opted out can opt back in:
+Staff capture verbal or written consent during registration or any
+subsequent visit. The chart-driven opt-in flow:
 
-1. The patient provides new consent (verbally or in writing)
-2. A staff member sets **Allow SMS** to Yes in the patient chart
-3. The `ConsentService` records a new opt-in
-4. The patient resumes receiving messages
+1. The patient provides consent (verbally or in writing) and a mobile number
+2. A staff member registers the patient (or edits the chart) with
+   **Allow SMS** (`hipaa_allowsms`) set to Yes and `phone_cell` populated
+3. `PatientConsentListener` observes the `patient.created` /
+   `patient.updated` event, detects the blank/NO → YES transition on
+   `hipaa_allowsms`, and calls `ConsentService::optIn()`
+4. `ConsentService` writes the row to `oce_sinch_patient_consent`
+   (`opted_in=TRUE`, `opted_out=FALSE`, `opt_in_method='chart_hipaa_allowsms'`)
+   and sends the opt-in confirmation SMS
+5. The patient resumes receiving automated messages
+
+The same listener handles the reverse: a YES → NO transition on
+`hipaa_allowsms` calls `ConsentService::optOut()` so the chart-side
+opt-out flow described above also produces a consent row update.
+
+The listener is a no-op when the chart save does not change
+`hipaa_allowsms`, when the new value matches the current value, or when
+`phone_cell` is blank on both the old and new patient record.
 
 > **Note:** If the carrier blocked messages at the network level after
 > a STOP, the patient may also need to text START to the same number

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -19,8 +19,11 @@ use OpenCoreEMR\ModuleConfig\ConfigFactory;
 use OpenCoreEMR\ModuleConfig\GlobalsRegistrar;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenCoreEMR\Modules\SinchConversations\Listener\PatientConsentListener;
 use OpenEMR\Core\Kernel;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\Patient\PatientCreatedEvent;
+use OpenEMR\Events\Patient\PatientUpdatedEvent;
 use OpenEMR\Menu\MenuEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -67,7 +70,22 @@ class Bootstrap
             return;
         }
 
+        $this->subscribeToPatientConsentEvents();
+
         $this->logger->debug('Sinch Conversations module is enabled');
+    }
+
+    private function subscribeToPatientConsentEvents(): void
+    {
+        $listener = $this->getPatientConsentListener();
+        $this->eventDispatcher->addListener(
+            PatientCreatedEvent::EVENT_HANDLE,
+            $listener->onPatientCreated(...)
+        );
+        $this->eventDispatcher->addListener(
+            PatientUpdatedEvent::EVENT_HANDLE,
+            $listener->onPatientUpdated(...)
+        );
     }
 
     private function addGlobalSettings(): void
@@ -162,6 +180,14 @@ class Bootstrap
             $this->getTemplateService(),
             $this->getMessageService()
         );
+    }
+
+    /**
+     * Get Patient Consent Listener
+     */
+    public function getPatientConsentListener(): PatientConsentListener
+    {
+        return new PatientConsentListener($this->getConsentService());
     }
 
     /**

--- a/src/Module/Listener/PatientConsentListener.php
+++ b/src/Module/Listener/PatientConsentListener.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Translates patient_data hipaa_allowsms transitions into ConsentService calls
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Listener;
+
+use OpenCoreEMR\Modules\SinchConversations\Channel;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Patient\PatientCreatedEvent;
+use OpenEMR\Events\Patient\PatientUpdatedEvent;
+
+class PatientConsentListener
+{
+    public const CONSENT_METHOD = 'chart_hipaa_allowsms';
+
+    private readonly SystemLogger $logger;
+
+    public function __construct(
+        private readonly ConsentService $consentService,
+    ) {
+        $this->logger = new SystemLogger();
+    }
+
+    public function onPatientCreated(PatientCreatedEvent $event): void
+    {
+        $data = $event->getPatientData();
+        if (!$this->isAllowSmsYes($data)) {
+            return;
+        }
+        $pid = $this->extractPid($data);
+        $phone = $this->extractPhone($data);
+        if ($pid === null || $phone === null) {
+            $this->logSkipped('created', $pid, $phone);
+            return;
+        }
+        $this->consentService->optIn($pid, $phone, self::CONSENT_METHOD, null, Channel::SMS);
+    }
+
+    public function onPatientUpdated(PatientUpdatedEvent $event): void
+    {
+        $newData = $event->getNewPatientData();
+        // The new-data payload only includes fields that were updated. If the
+        // chart save did not touch hipaa_allowsms, there is no transition to react to.
+        if (!is_array($newData) || !array_key_exists('hipaa_allowsms', $newData)) {
+            return;
+        }
+
+        $oldData = $event->getDataBeforeUpdate();
+        $oldYes = is_array($oldData) && $this->isAllowSmsYes($oldData);
+        $newYes = $this->isAllowSmsYes($newData);
+        if ($oldYes === $newYes) {
+            return;
+        }
+
+        $pid = $this->extractPid($newData);
+        if ($pid === null && is_array($oldData)) {
+            $pid = $this->extractPid($oldData);
+        }
+        // The phone may not be in the partial update payload; fall back to the
+        // pre-update row so a NO->YES toggle that doesn't re-post phone_cell still works.
+        $phone = $this->extractPhone($newData);
+        if ($phone === null && is_array($oldData)) {
+            $phone = $this->extractPhone($oldData);
+        }
+        if ($pid === null || $phone === null) {
+            $this->logSkipped('updated', $pid, $phone);
+            return;
+        }
+
+        if ($newYes) {
+            $this->consentService->optIn($pid, $phone, self::CONSENT_METHOD, null, Channel::SMS);
+        } else {
+            $this->consentService->optOut($pid, $phone, self::CONSENT_METHOD, Channel::SMS);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private function isAllowSmsYes(array $data): bool
+    {
+        $value = $data['hipaa_allowsms'] ?? null;
+        return is_string($value) && strcasecmp($value, 'YES') === 0;
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private function extractPid(array $data): ?int
+    {
+        $pid = $data['pid'] ?? null;
+        if (is_int($pid) && $pid > 0) {
+            return $pid;
+        }
+        if (is_string($pid) && preg_match('/^\d+$/', $pid) === 1 && (int) $pid > 0) {
+            return (int) $pid;
+        }
+        return null;
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private function extractPhone(array $data): ?string
+    {
+        $phone = $data['phone_cell'] ?? null;
+        if (is_string($phone) && trim($phone) !== '') {
+            return $phone;
+        }
+        return null;
+    }
+
+    private function logSkipped(string $action, ?int $pid, ?string $phone): void
+    {
+        $this->logger->info('Skipped chart-driven consent action: missing pid or phone_cell', [
+            'action' => $action,
+            'patientId' => $pid,
+            'phonePresent' => $phone !== null,
+        ]);
+    }
+}

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -19,6 +19,7 @@ use OpenCoreEMR\Modules\SinchConversations\Controller\ConversationController;
 use OpenCoreEMR\Modules\SinchConversations\Controller\InboxController;
 use OpenCoreEMR\Modules\SinchConversations\Controller\SettingsController;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Listener\PatientConsentListener;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentSyncService;
@@ -33,6 +34,8 @@ use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Events\Globals\GlobalsInitializedEvent;
+use OpenEMR\Events\Patient\PatientCreatedEvent;
+use OpenEMR\Events\Patient\PatientUpdatedEvent;
 use OpenEMR\Menu\MenuEvent;
 use OpenEMR\Services\Globals\GlobalSetting;
 use OpenEMR\Services\Globals\GlobalsService;
@@ -176,6 +179,39 @@ class BootstrapTest extends TestCase
         $service = $this->bootstrap->getKeywordHandlerService();
 
         $this->assertInstanceOf(KeywordHandlerService::class, $service);
+    }
+
+    public function testGetPatientConsentListenerReturnsListener(): void
+    {
+        $listener = $this->bootstrap->getPatientConsentListener();
+
+        $this->assertInstanceOf(PatientConsentListener::class, $listener);
+    }
+
+    public function testSubscribeToEventsRegistersPatientConsentListenersWhenEnabled(): void
+    {
+        $this->bootstrap->subscribeToEvents();
+
+        $this->assertNotEmpty($this->eventDispatcher->getListeners(PatientCreatedEvent::EVENT_HANDLE));
+        $this->assertNotEmpty($this->eventDispatcher->getListeners(PatientUpdatedEvent::EVENT_HANDLE));
+    }
+
+    public function testSubscribeToEventsDoesNotRegisterPatientConsentListenersWhenDisabled(): void
+    {
+        $disabledGlobals = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => '0',
+            GlobalConfig::CONFIG_OPTION_PROJECT_ID => 'test-project',
+            GlobalConfig::CONFIG_OPTION_APP_ID => 'test-app',
+            GlobalConfig::CONFIG_OPTION_API_KEY => 'test-key',
+            GlobalConfig::CONFIG_OPTION_API_SECRET => base64_encode('test-secret'),
+            GlobalConfig::CONFIG_OPTION_REGION => 'us',
+        ]);
+        $bootstrap = new Bootstrap($this->eventDispatcher, configAccessor: $disabledGlobals);
+
+        $bootstrap->subscribeToEvents();
+
+        $this->assertEmpty($this->eventDispatcher->getListeners(PatientCreatedEvent::EVENT_HANDLE));
+        $this->assertEmpty($this->eventDispatcher->getListeners(PatientUpdatedEvent::EVENT_HANDLE));
     }
 
     public function testGetConfigServiceReturnsService(): void

--- a/tests/Unit/Listener/PatientConsentListenerTest.php
+++ b/tests/Unit/Listener/PatientConsentListenerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * Unit tests for PatientConsentListener
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Listener;
+
+use OpenCoreEMR\Modules\SinchConversations\Channel;
+use OpenCoreEMR\Modules\SinchConversations\Listener\PatientConsentListener;
+use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Patient\PatientCreatedEvent;
+use OpenEMR\Events\Patient\PatientUpdatedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PatientConsentListenerTest extends TestCase
+{
+    private ConsentService&MockObject $consentService;
+    private PatientConsentListener $listener;
+
+    protected function setUp(): void
+    {
+        SystemLogger::clearLogs();
+        $this->consentService = $this->createMock(ConsentService::class);
+        $this->listener = new PatientConsentListener($this->consentService);
+    }
+
+    // --- onPatientCreated ---
+
+    public function testCreatedWithAllowSmsYesCallsOptIn(): void
+    {
+        $this->consentService->expects($this->once())
+            ->method('optIn')
+            ->with(
+                42,
+                '+15551234567',
+                PatientConsentListener::CONSENT_METHOD,
+                null,
+                Channel::SMS,
+            );
+
+        $this->listener->onPatientCreated(new PatientCreatedEvent([
+            'pid' => 42,
+            'hipaa_allowsms' => 'YES',
+            'phone_cell' => '+15551234567',
+        ]));
+    }
+
+    public function testCreatedWithAllowSmsNoIsNoop(): void
+    {
+        $this->consentService->expects($this->never())->method('optIn');
+        $this->consentService->expects($this->never())->method('optOut');
+
+        $this->listener->onPatientCreated(new PatientCreatedEvent([
+            'pid' => 42,
+            'hipaa_allowsms' => 'NO',
+            'phone_cell' => '+15551234567',
+        ]));
+    }
+
+    public function testCreatedWithBlankAllowSmsIsNoop(): void
+    {
+        $this->consentService->expects($this->never())->method('optIn');
+
+        $this->listener->onPatientCreated(new PatientCreatedEvent([
+            'pid' => 42,
+            'phone_cell' => '+15551234567',
+        ]));
+    }
+
+    public function testCreatedWithYesButNoPhoneLogsAndSkips(): void
+    {
+        $this->consentService->expects($this->never())->method('optIn');
+
+        $this->listener->onPatientCreated(new PatientCreatedEvent([
+            'pid' => 42,
+            'hipaa_allowsms' => 'YES',
+            'phone_cell' => '',
+        ]));
+
+        $logs = SystemLogger::getLogs();
+        $infoLogs = array_filter($logs, fn($log) => $log['level'] === 'info');
+        $this->assertNotEmpty($infoLogs);
+    }
+
+    public function testCreatedWithYesAndStringPidIsAccepted(): void
+    {
+        $this->consentService->expects($this->once())
+            ->method('optIn')
+            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, null, Channel::SMS);
+
+        $this->listener->onPatientCreated(new PatientCreatedEvent([
+            'pid' => '42',
+            'hipaa_allowsms' => 'YES',
+            'phone_cell' => '+15551234567',
+        ]));
+    }
+
+    // --- onPatientUpdated ---
+
+    public function testUpdatedNoToYesCallsOptIn(): void
+    {
+        $this->consentService->expects($this->once())
+            ->method('optIn')
+            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, null, Channel::SMS);
+        $this->consentService->expects($this->never())->method('optOut');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+        ));
+    }
+
+    public function testUpdatedBlankToYesCallsOptIn(): void
+    {
+        $this->consentService->expects($this->once())
+            ->method('optIn')
+            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, null, Channel::SMS);
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+        ));
+    }
+
+    public function testUpdatedYesToNoCallsOptOut(): void
+    {
+        $this->consentService->expects($this->once())
+            ->method('optOut')
+            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, Channel::SMS);
+        $this->consentService->expects($this->never())->method('optIn');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => '+15551234567'],
+        ));
+    }
+
+    public function testUpdatedYesToYesIsNoop(): void
+    {
+        $this->consentService->expects($this->never())->method('optIn');
+        $this->consentService->expects($this->never())->method('optOut');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+        ));
+    }
+
+    public function testUpdatedPayloadMissingFieldIsNoop(): void
+    {
+        // Partial REST PATCH that doesn't include hipaa_allowsms must not
+        // be interpreted as a transition.
+        $this->consentService->expects($this->never())->method('optIn');
+        $this->consentService->expects($this->never())->method('optOut');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'fname' => 'New First'],
+        ));
+    }
+
+    public function testUpdatedYesToNoWithMissingPhoneFallsBackToOldPhone(): void
+    {
+        $this->consentService->expects($this->once())
+            ->method('optOut')
+            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, Channel::SMS);
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'NO'],
+        ));
+    }
+
+    public function testUpdatedTransitionWithNoPhoneAtAllLogsAndSkips(): void
+    {
+        $this->consentService->expects($this->never())->method('optIn');
+        $this->consentService->expects($this->never())->method('optOut');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => ''],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => ''],
+        ));
+
+        $logs = SystemLogger::getLogs();
+        $infoLogs = array_filter($logs, fn($log) => $log['level'] === 'info');
+        $this->assertNotEmpty($infoLogs);
+    }
+
+    public function testUpdatedYesValueIsCaseInsensitive(): void
+    {
+        $this->consentService->expects($this->once())->method('optIn');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'no', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'yes', 'phone_cell' => '+15551234567'],
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Closes the chart-driven opt-in gap described in #111. Adds a `PatientConsentListener` that subscribes to OpenEMR's `PatientCreatedEvent` / `PatientUpdatedEvent` and translates `hipaa_allowsms` transitions on `patient_data` into `ConsentService::optIn()` / `optOut()` calls.

- Blank/NO → YES transition: calls `optIn()` (writes consent row, syncs `hipaa_allowsms`, sends opt-in confirmation SMS).
- YES → NO transition: calls `optOut()` (marks consent row opted out, syncs `hipaa_allowsms`).
- No-op when the update payload omits `hipaa_allowsms` (partial REST PATCH), when the value did not change, or when no `phone_cell` is available on either the new or pre-update record.
- Listener is wired only when the module is enabled.
- Updates `docs/messaging/opt-out.md` so the chart-driven opt-in flow now matches the implementation.

## Notes

- Whitelisted `OpenEMR\Events\Patient\PatientCreatedEvent` and `OpenEMR\Events\Patient\PatientUpdatedEvent` in `.composer-require-checker.json` — same pattern already used for `GlobalsInitializedEvent`, `PatientDocumentEvent`, and `MenuEvent` (host-platform symbols provided by `openemr/openemr`, which is `require-dev`).
- Backfill of pre-existing patients with `hipaa_allowsms='YES'` but no consent row is tracked separately as #113.

Closes #111

## Test plan

- [x] `task check` passes (PHPStan max, PHPCS, Rector, composer-require-checker)
- [x] `task test` — 405 tests, 1026 assertions, all pass; new listener at 95.74% line coverage
- [ ] Manual smoke in dev: register a new patient with Allow SMS = Yes and a mobile number, confirm `oce_sinch_patient_consent` row is written and an opt-in confirmation SMS is sent
- [ ] Manual smoke in dev: toggle Allow SMS Yes → No on an opted-in patient, confirm the row's `opted_out` flips and `hipaa_allowsms` syncs
- [ ] Manual smoke in dev: re-save an opted-in patient with no change to Allow SMS, confirm no duplicate confirmation SMS