### PR TITLE
fix: emit structured warnings for appointment reminder skip decisions

### DIFF
--- a/src/Module/ConsentState.php
+++ b/src/Module/ConsentState.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Patient consent state for a single phone number
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations;
+
+/**
+ * Stable consent classification used for gating sends and tagging logs.
+ *
+ * Values are written into log context (`consent_state` field) and are part
+ * of the observability contract — keep them stable across releases.
+ */
+enum ConsentState: string
+{
+    case Active = 'active';
+    case None = 'none';
+    case OptedOut = 'opted_out';
+    case NotOptedIn = 'not_opted_in';
+
+    /**
+     * Classify a row from oce_sinch_patient_consent.
+     *
+     * Treats null and empty array the same so call sites that use
+     * `QueryUtils::querySingleRow()` (returns null on no row) and call sites
+     * that pass `[]` for "row not found" both map to None.
+     *
+     * @param array<string, mixed>|null $row
+     */
+    public static function fromRow(?array $row): self
+    {
+        if ($row === null || $row === []) {
+            return self::None;
+        }
+        if ((bool) ($row['opted_out'] ?? false)) {
+            return self::OptedOut;
+        }
+        if (!(bool) ($row['opted_in'] ?? false)) {
+            return self::NotOptedIn;
+        }
+        return self::Active;
+    }
+}

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -24,6 +24,24 @@ use OpenEMR\Common\Logging\SystemLogger;
 
 class AppointmentReminderService
 {
+    /**
+     * Stable reason codes emitted when a reminder is skipped or fails.
+     * Kept stable across releases so log consumers (alerts, dashboards)
+     * can pivot on them.
+     */
+    public const REASON_MISSING_PHONE = 'missing_phone';
+    public const REASON_UNPARSEABLE_PHONE = 'unparseable_phone';
+    public const REASON_HIPAA_DISALLOWS_SMS = 'hipaa_disallows_sms';
+    public const REASON_NO_ACTIVE_CONSENT = 'no_active_consent';
+
+    /**
+     * Sub-states for REASON_NO_ACTIVE_CONSENT to aid triage.
+     */
+    private const CONSENT_STATE_ACTIVE = 'active';
+    private const CONSENT_STATE_NONE = 'none';
+    private const CONSENT_STATE_OPTED_OUT = 'opted_out';
+    private const CONSENT_STATE_NOT_OPTED_IN = 'not_opted_in';
+
     private readonly SystemLogger $logger;
 
     public function __construct(
@@ -73,28 +91,34 @@ class AppointmentReminderService
 
             $rawPhone = $appointment['phone_cell'] ?? '';
             if ($rawPhone === '') {
+                $this->logSkip($pcEid, $patientId, self::REASON_MISSING_PHONE);
                 $results['skipped']++;
                 continue;
             }
 
             $phoneNumber = PhoneNormalizer::toE164($rawPhone);
             if ($phoneNumber === null) {
-                $this->logger->warning('Skipping appointment reminder: unparseable phone number', [
-                    'pc_eid' => $pcEid,
-                    'patientId' => $patientId,
-                    'phone' => $rawPhone,
+                $this->logSkip($pcEid, $patientId, self::REASON_UNPARSEABLE_PHONE, [
+                    'phone_last4' => PhoneNormalizer::last4($rawPhone),
                 ]);
                 $results['skipped']++;
                 continue;
             }
 
-            $hipaaAllowSms = $appointment['hipaa_allowsms'] ?? '';
+            $hipaaAllowSms = (string) ($appointment['hipaa_allowsms'] ?? '');
             if ($hipaaAllowSms !== 'YES') {
+                $this->logSkip($pcEid, $patientId, self::REASON_HIPAA_DISALLOWS_SMS, [
+                    'hipaa_allowsms' => $hipaaAllowSms === '' ? 'unset' : $hipaaAllowSms,
+                ]);
                 $results['skipped']++;
                 continue;
             }
 
-            if (!$this->hasActiveConsent($patientId, $phoneNumber)) {
+            $consentState = $this->getConsentState($patientId, $phoneNumber);
+            if ($consentState !== self::CONSENT_STATE_ACTIVE) {
+                $this->logSkip($pcEid, $patientId, self::REASON_NO_ACTIVE_CONSENT, [
+                    'consent_state' => $consentState,
+                ]);
                 $results['skipped']++;
                 continue;
             }
@@ -200,14 +224,19 @@ class AppointmentReminderService
     }
 
     /**
-     * Check if patient has active SMS consent
+     * Classify module-level consent into a stable state for logging and gating.
      *
      * The hipaa_allowsms check is handled in run() from the main query result.
-     * This method checks only module-level consent in oce_sinch_patient_consent.
+     * This method checks only module-level consent in oce_sinch_patient_consent
+     * and returns one of:
+     * - CONSENT_STATE_ACTIVE: opted in and not opted out
+     * - CONSENT_STATE_NONE: no consent row exists for this patient/phone
+     * - CONSENT_STATE_OPTED_OUT: row exists with opted_out=true
+     * - CONSENT_STATE_NOT_OPTED_IN: row exists with opted_in=false
      *
      * @param string $phoneNumber E.164 normalized phone number
      */
-    private function hasActiveConsent(int $patientId, string $phoneNumber): bool
+    private function getConsentState(int $patientId, string $phoneNumber): string
     {
         $sql = "SELECT opted_in, opted_out
                 FROM oce_sinch_patient_consent
@@ -215,11 +244,36 @@ class AppointmentReminderService
         $consent = QueryUtils::querySingleRow($sql, [$patientId, $phoneNumber]);
 
         if ($consent === null) {
-            return false;
+            return self::CONSENT_STATE_NONE;
         }
 
-        return (bool) ($consent['opted_in'] ?? false)
-            && !((bool) ($consent['opted_out'] ?? false));
+        if ((bool) ($consent['opted_out'] ?? false)) {
+            return self::CONSENT_STATE_OPTED_OUT;
+        }
+
+        if (!(bool) ($consent['opted_in'] ?? false)) {
+            return self::CONSENT_STATE_NOT_OPTED_IN;
+        }
+
+        return self::CONSENT_STATE_ACTIVE;
+    }
+
+    /**
+     * Emit a structured warning that a per-appointment skip decision was made.
+     *
+     * Every skip path increments the `skipped` counter; this helper makes the
+     * decision visible at WARNING level so a clinic seeing zero reminders can
+     * tell whether the cron is firing and why each appointment was dropped.
+     *
+     * @param array<string, scalar|null> $extra additional cheap context to aid triage
+     */
+    private function logSkip(int $pcEid, int $patientId, string $reason, array $extra = []): void
+    {
+        $this->logger->warning('Appointment reminder skipped', [
+            'pc_eid' => $pcEid,
+            'patient_id' => $patientId,
+            'reason' => $reason,
+        ] + $extra);
     }
 
     /**

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -18,30 +18,14 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
+use OpenCoreEMR\Modules\SinchConversations\ConsentState;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 
 class AppointmentReminderService
 {
-    /**
-     * Stable reason codes emitted when a reminder is skipped or fails.
-     * Kept stable across releases so log consumers (alerts, dashboards)
-     * can pivot on them.
-     */
-    public const REASON_MISSING_PHONE = 'missing_phone';
-    public const REASON_UNPARSEABLE_PHONE = 'unparseable_phone';
-    public const REASON_HIPAA_DISALLOWS_SMS = 'hipaa_disallows_sms';
-    public const REASON_NO_ACTIVE_CONSENT = 'no_active_consent';
-
-    /**
-     * Sub-states for REASON_NO_ACTIVE_CONSENT to aid triage.
-     */
-    private const CONSENT_STATE_ACTIVE = 'active';
-    private const CONSENT_STATE_NONE = 'none';
-    private const CONSENT_STATE_OPTED_OUT = 'opted_out';
-    private const CONSENT_STATE_NOT_OPTED_IN = 'not_opted_in';
-
     private readonly SystemLogger $logger;
 
     public function __construct(
@@ -91,14 +75,14 @@ class AppointmentReminderService
 
             $rawPhone = $appointment['phone_cell'] ?? '';
             if ($rawPhone === '') {
-                $this->logSkip($pcEid, $patientId, self::REASON_MISSING_PHONE);
+                $this->logSkip($pcEid, $patientId, SkipReason::MissingPhone);
                 $results['skipped']++;
                 continue;
             }
 
             $phoneNumber = PhoneNormalizer::toE164($rawPhone);
             if ($phoneNumber === null) {
-                $this->logSkip($pcEid, $patientId, self::REASON_UNPARSEABLE_PHONE, [
+                $this->logSkip($pcEid, $patientId, SkipReason::UnparseablePhone, [
                     'phone_last4' => PhoneNormalizer::last4($rawPhone),
                 ]);
                 $results['skipped']++;
@@ -107,7 +91,7 @@ class AppointmentReminderService
 
             $hipaaAllowSms = (string) ($appointment['hipaa_allowsms'] ?? '');
             if ($hipaaAllowSms !== 'YES') {
-                $this->logSkip($pcEid, $patientId, self::REASON_HIPAA_DISALLOWS_SMS, [
+                $this->logSkip($pcEid, $patientId, SkipReason::HipaaDisallowsSms, [
                     'hipaa_allowsms' => $hipaaAllowSms === '' ? 'unset' : $hipaaAllowSms,
                 ]);
                 $results['skipped']++;
@@ -115,9 +99,9 @@ class AppointmentReminderService
             }
 
             $consentState = $this->getConsentState($patientId, $phoneNumber);
-            if ($consentState !== self::CONSENT_STATE_ACTIVE) {
-                $this->logSkip($pcEid, $patientId, self::REASON_NO_ACTIVE_CONSENT, [
-                    'consent_state' => $consentState,
+            if ($consentState !== ConsentState::Active) {
+                $this->logSkip($pcEid, $patientId, SkipReason::NoActiveConsent, [
+                    'consent_state' => $consentState->value,
                 ]);
                 $results['skipped']++;
                 continue;
@@ -224,38 +208,19 @@ class AppointmentReminderService
     }
 
     /**
-     * Classify module-level consent into a stable state for logging and gating.
+     * Classify module-level consent for a patient/phone.
      *
      * The hipaa_allowsms check is handled in run() from the main query result.
-     * This method checks only module-level consent in oce_sinch_patient_consent
-     * and returns one of:
-     * - CONSENT_STATE_ACTIVE: opted in and not opted out
-     * - CONSENT_STATE_NONE: no consent row exists for this patient/phone
-     * - CONSENT_STATE_OPTED_OUT: row exists with opted_out=true
-     * - CONSENT_STATE_NOT_OPTED_IN: row exists with opted_in=false
+     * This method checks only module-level consent in oce_sinch_patient_consent.
      *
      * @param string $phoneNumber E.164 normalized phone number
      */
-    private function getConsentState(int $patientId, string $phoneNumber): string
+    private function getConsentState(int $patientId, string $phoneNumber): ConsentState
     {
         $sql = "SELECT opted_in, opted_out
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?";
-        $consent = QueryUtils::querySingleRow($sql, [$patientId, $phoneNumber]);
-
-        if ($consent === null) {
-            return self::CONSENT_STATE_NONE;
-        }
-
-        if ((bool) ($consent['opted_out'] ?? false)) {
-            return self::CONSENT_STATE_OPTED_OUT;
-        }
-
-        if (!(bool) ($consent['opted_in'] ?? false)) {
-            return self::CONSENT_STATE_NOT_OPTED_IN;
-        }
-
-        return self::CONSENT_STATE_ACTIVE;
+        return ConsentState::fromRow(QueryUtils::querySingleRow($sql, [$patientId, $phoneNumber]));
     }
 
     /**
@@ -267,12 +232,12 @@ class AppointmentReminderService
      *
      * @param array<string, scalar|null> $extra additional cheap context to aid triage
      */
-    private function logSkip(int $pcEid, int $patientId, string $reason, array $extra = []): void
+    private function logSkip(int $pcEid, int $patientId, SkipReason $reason, array $extra = []): void
     {
         $this->logger->warning('Appointment reminder skipped', [
             'pc_eid' => $pcEid,
             'patient_id' => $patientId,
-            'reason' => $reason,
+            'reason' => $reason->value,
         ] + $extra);
     }
 

--- a/src/Module/Service/MessageService.php
+++ b/src/Module/Service/MessageService.php
@@ -219,6 +219,9 @@ class MessageService
      * Normalize the phone number to E.164 before checking consent so that
      * user-entered formats match the E.164 stored by Sinch callbacks.
      *
+     * Emit a structured warning before throwing so the block decision is
+     * visible at WARNING level, not just inferable from caught exceptions.
+     *
      * @throws ValidationException
      */
     private function assertPatientEligible(int $patientId, string $phoneNumber): void
@@ -228,6 +231,9 @@ class MessageService
         $hipaaAllowSms = $result['hipaa_allowsms'] ?? '';
 
         if ($hipaaAllowSms !== 'YES') {
+            $this->logBlock($patientId, 'hipaa_disallows_sms', [
+                'hipaa_allowsms' => $hipaaAllowSms === '' ? 'unset' : $hipaaAllowSms,
+            ]);
             throw new ValidationException(
                 "Patient {$patientId} has not allowed SMS (hipaa_allowsms is not YES)"
             );
@@ -235,6 +241,9 @@ class MessageService
 
         $normalized = PhoneNormalizer::toE164($phoneNumber);
         if ($normalized === null) {
+            $this->logBlock($patientId, 'unparseable_phone', [
+                'phone_last4' => PhoneNormalizer::last4($phoneNumber),
+            ]);
             throw new ValidationException(
                 "Cannot check eligibility: unparseable phone number for patient {$patientId}"
             );
@@ -246,10 +255,48 @@ class MessageService
         $consent = QueryUtils::querySingleRow($sql, [$patientId, $normalized]);
 
         if (!$consent || !($consent['opted_in'] ?? false) || ($consent['opted_out'] ?? false)) {
+            $this->logBlock($patientId, 'no_active_consent', [
+                'consent_state' => $this->classifyConsent($consent),
+            ]);
             throw new ValidationException(
                 "Patient {$patientId} has not consented to messages at {$phoneNumber}"
             );
         }
+    }
+
+    /**
+     * Emit a structured warning that a send was blocked at the eligibility gate.
+     *
+     * @param array<string, scalar|null> $extra additional cheap context to aid triage
+     */
+    private function logBlock(int $patientId, string $reason, array $extra = []): void
+    {
+        $this->logger->warning('Message send blocked', [
+            'patient_id' => $patientId,
+            'reason' => $reason,
+        ] + $extra);
+    }
+
+    /**
+     * Reduce a consent row to a stable state code for logging.
+     *
+     * Treat an empty array (no row found) as 'none' so the log code matches
+     * the gate above which uses `!$consent` to cover both null and empty.
+     *
+     * @param array<string, mixed>|null $consent
+     */
+    private function classifyConsent(?array $consent): string
+    {
+        if ($consent === null || $consent === []) {
+            return 'none';
+        }
+        if ((bool) ($consent['opted_out'] ?? false)) {
+            return 'opted_out';
+        }
+        if (!(bool) ($consent['opted_in'] ?? false)) {
+            return 'not_opted_in';
+        }
+        return 'active';
     }
 
     /**

--- a/src/Module/Service/MessageService.php
+++ b/src/Module/Service/MessageService.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;
+use OpenCoreEMR\Modules\SinchConversations\ConsentState;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Database\QueryUtils;
@@ -231,7 +233,7 @@ class MessageService
         $hipaaAllowSms = $result['hipaa_allowsms'] ?? '';
 
         if ($hipaaAllowSms !== 'YES') {
-            $this->logBlock($patientId, 'hipaa_disallows_sms', [
+            $this->logBlock($patientId, SkipReason::HipaaDisallowsSms, [
                 'hipaa_allowsms' => $hipaaAllowSms === '' ? 'unset' : $hipaaAllowSms,
             ]);
             throw new ValidationException(
@@ -241,7 +243,7 @@ class MessageService
 
         $normalized = PhoneNormalizer::toE164($phoneNumber);
         if ($normalized === null) {
-            $this->logBlock($patientId, 'unparseable_phone', [
+            $this->logBlock($patientId, SkipReason::UnparseablePhone, [
                 'phone_last4' => PhoneNormalizer::last4($phoneNumber),
             ]);
             throw new ValidationException(
@@ -252,11 +254,11 @@ class MessageService
         $sql = "SELECT opted_in, opted_out
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?";
-        $consent = QueryUtils::querySingleRow($sql, [$patientId, $normalized]);
+        $consentState = ConsentState::fromRow(QueryUtils::querySingleRow($sql, [$patientId, $normalized]));
 
-        if (!$consent || !($consent['opted_in'] ?? false) || ($consent['opted_out'] ?? false)) {
-            $this->logBlock($patientId, 'no_active_consent', [
-                'consent_state' => $this->classifyConsent($consent),
+        if ($consentState !== ConsentState::Active) {
+            $this->logBlock($patientId, SkipReason::NoActiveConsent, [
+                'consent_state' => $consentState->value,
             ]);
             throw new ValidationException(
                 "Patient {$patientId} has not consented to messages at {$phoneNumber}"
@@ -269,34 +271,12 @@ class MessageService
      *
      * @param array<string, scalar|null> $extra additional cheap context to aid triage
      */
-    private function logBlock(int $patientId, string $reason, array $extra = []): void
+    private function logBlock(int $patientId, SkipReason $reason, array $extra = []): void
     {
         $this->logger->warning('Message send blocked', [
             'patient_id' => $patientId,
-            'reason' => $reason,
+            'reason' => $reason->value,
         ] + $extra);
-    }
-
-    /**
-     * Reduce a consent row to a stable state code for logging.
-     *
-     * Treat an empty array (no row found) as 'none' so the log code matches
-     * the gate above which uses `!$consent` to cover both null and empty.
-     *
-     * @param array<string, mixed>|null $consent
-     */
-    private function classifyConsent(?array $consent): string
-    {
-        if ($consent === null || $consent === []) {
-            return 'none';
-        }
-        if ((bool) ($consent['opted_out'] ?? false)) {
-            return 'opted_out';
-        }
-        if (!(bool) ($consent['opted_in'] ?? false)) {
-            return 'not_opted_in';
-        }
-        return 'active';
     }
 
     /**

--- a/src/Module/Service/PhoneNormalizer.php
+++ b/src/Module/Service/PhoneNormalizer.php
@@ -69,4 +69,20 @@ class PhoneNormalizer
 
         return $normalized;
     }
+
+    /**
+     * Return the last four digits of a phone number for safe identification in logs.
+     *
+     * Strips non-digit characters first so '(555) 123-4567' and '+15551234567'
+     * both yield '4567'. Returns an empty string if no digits are present.
+     */
+    public static function last4(string $phone): string
+    {
+        $digits = preg_replace('/[^0-9]/', '', $phone);
+        if ($digits === null || $digits === '') {
+            return '';
+        }
+
+        return substr($digits, -4);
+    }
 }

--- a/src/Module/SkipReason.php
+++ b/src/Module/SkipReason.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Stable reason codes for why a message or reminder was not delivered
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations;
+
+/**
+ * Why a patient was not (or could not be) sent a message.
+ *
+ * Values are written into log context (`reason` field) and are part of the
+ * observability contract — keep them stable across releases. Used by both
+ * the appointment-reminder cron (skip decisions) and the send-path
+ * eligibility gate (block decisions).
+ */
+enum SkipReason: string
+{
+    case MissingPhone = 'missing_phone';
+    case UnparseablePhone = 'unparseable_phone';
+    case HipaaDisallowsSms = 'hipaa_disallows_sms';
+    case NoActiveConsent = 'no_active_consent';
+}

--- a/tests/Unit/ConsentStateTest.php
+++ b/tests/Unit/ConsentStateTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Unit tests for ConsentState
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchConversations\ConsentState;
+use PHPUnit\Framework\TestCase;
+
+class ConsentStateTest extends TestCase
+{
+    public function testFromRowMapsNullToNone(): void
+    {
+        $this->assertSame(ConsentState::None, ConsentState::fromRow(null));
+    }
+
+    public function testFromRowMapsEmptyArrayToNone(): void
+    {
+        $this->assertSame(ConsentState::None, ConsentState::fromRow([]));
+    }
+
+    public function testFromRowMapsOptedOutEvenWhenAlsoOptedIn(): void
+    {
+        // opted_out wins over opted_in: a patient who opted in and later
+        // opted out is OptedOut, not Active.
+        $this->assertSame(
+            ConsentState::OptedOut,
+            ConsentState::fromRow(['opted_in' => true, 'opted_out' => true])
+        );
+    }
+
+    public function testFromRowMapsRowWithoutOptInFlagToNotOptedIn(): void
+    {
+        $this->assertSame(
+            ConsentState::NotOptedIn,
+            ConsentState::fromRow(['opted_in' => false, 'opted_out' => false])
+        );
+    }
+
+    public function testFromRowMapsActiveConsent(): void
+    {
+        $this->assertSame(
+            ConsentState::Active,
+            ConsentState::fromRow(['opted_in' => true, 'opted_out' => false])
+        );
+    }
+
+    public function testValuesAreStableObservabilityContract(): void
+    {
+        // These string values are written to log context. Changing them
+        // breaks dashboards and alerting; the test guards against that.
+        $this->assertSame('active', ConsentState::Active->value);
+        $this->assertSame('none', ConsentState::None->value);
+        $this->assertSame('opted_out', ConsentState::OptedOut->value);
+        $this->assertSame('not_opted_in', ConsentState::NotOptedIn->value);
+    }
+}

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -160,6 +160,34 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
+
+        $this->assertSkipLogged(101, 43, 'no_active_consent', ['consent_state' => 'opted_out']);
+    }
+
+    public function testRunSkipsPatientWithNoConsentRow(): void
+    {
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(110, 49, '2026-04-01', '10:00:00', '+15554443322', 'YES'),
+        ]);
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [49, '+15554443322'],
+            []
+        );
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+
+        $this->messageService->expects($this->never())->method('sendToPatient');
+
+        $results = $this->service->run();
+
+        $this->assertSame(0, $results['sent']);
+        $this->assertSame(1, $results['skipped']);
+
+        $this->assertSkipLogged(110, 49, 'no_active_consent', ['consent_state' => 'none']);
     }
 
     // --- hipaa_allowsms = NO -> no reminder ---
@@ -180,6 +208,25 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
+
+        $this->assertSkipLogged(102, 44, 'hipaa_disallows_sms', ['hipaa_allowsms' => 'NO']);
+    }
+
+    public function testRunSkipsPatientWithUnsetHipaaAllowSms(): void
+    {
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(103, 45, '2026-04-01', '12:00:00', '+15556665555', ''),
+        ]);
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+
+        $this->messageService->expects($this->never())->method('sendToPatient');
+
+        $results = $this->service->run();
+
+        $this->assertSame(1, $results['skipped']);
+        $this->assertSkipLogged(103, 45, 'hipaa_disallows_sms', ['hipaa_allowsms' => 'unset']);
     }
 
     // --- reminder already sent -> excluded by LEFT JOIN (not in results) ---
@@ -220,6 +267,43 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
+
+        $this->assertSkipLogged(104, 46, 'missing_phone');
+    }
+
+    public function testRunSkipsPatientWithUnparseablePhone(): void
+    {
+        // 'abc' has no digits, so PhoneNormalizer::toE164() returns null
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(120, 55, '2026-04-01', '13:00:00', 'abc', 'YES'),
+        ]);
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+
+        $this->messageService->expects($this->never())->method('sendToPatient');
+
+        $results = $this->service->run();
+
+        $this->assertSame(1, $results['skipped']);
+        $this->assertSkipLogged(120, 55, 'unparseable_phone', ['phone_last4' => '']);
+    }
+
+    public function testRunUnparseablePhoneLogsLast4WhenDigitsPresent(): void
+    {
+        // '5551234' is 7 digits — too short to disambiguate without '+', so
+        // toE164() returns null. last4() should still extract '1234'.
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(121, 56, '2026-04-01', '13:00:00', '5551234', 'YES'),
+        ]);
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+
+        $results = $this->service->run();
+
+        $this->assertSame(1, $results['skipped']);
+        $this->assertSkipLogged(121, 56, 'unparseable_phone', ['phone_last4' => '1234']);
     }
 
     // --- send failure -> counted as failed ---
@@ -484,5 +568,42 @@ class AppointmentReminderServiceTest extends TestCase
             [$patientId, $phoneNumber],
             [['opted_in' => true, 'opted_out' => false]]
         );
+    }
+
+    /**
+     * Assert that a structured skip warning was logged with the expected fields.
+     *
+     * @param array<string, scalar|null> $extraContext additional context fields to match
+     */
+    private function assertSkipLogged(int $pcEid, int $patientId, string $reason, array $extraContext = []): void
+    {
+        $matches = array_filter(
+            SystemLogger::getLogs(),
+            static fn(array $log): bool => $log['level'] === 'warning'
+                && $log['message'] === 'Appointment reminder skipped'
+                && ($log['context']['pc_eid'] ?? null) === $pcEid
+                && ($log['context']['patient_id'] ?? null) === $patientId
+                && ($log['context']['reason'] ?? null) === $reason
+        );
+
+        $this->assertCount(
+            1,
+            $matches,
+            sprintf(
+                'Expected exactly one "Appointment reminder skipped" warning for pc_eid=%d patient_id=%d reason=%s',
+                $pcEid,
+                $patientId,
+                $reason
+            )
+        );
+
+        $log = array_values($matches)[0];
+        foreach ($extraContext as $key => $expected) {
+            $this->assertSame(
+                $expected,
+                $log['context'][$key] ?? null,
+                sprintf('Skip log context "%s" did not match', $key)
+            );
+        }
     }
 }

--- a/tests/Unit/Service/MessageServiceTest.php
+++ b/tests/Unit/Service/MessageServiceTest.php
@@ -100,10 +100,14 @@ class MessageServiceTest extends TestCase
             [['hipaa_allowsms' => 'NO']]
         );
 
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('hipaa_allowsms is not YES');
+        try {
+            $this->service->sendToPatient(1, '+15559999999', 'Hello');
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('hipaa_allowsms is not YES', $e->getMessage());
+        }
 
-        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+        $this->assertBlockLogged(1, 'hipaa_disallows_sms', ['hipaa_allowsms' => 'NO']);
     }
 
     public function testSendToPatientThrowsWhenHipaaFieldMissing(): void
@@ -114,10 +118,14 @@ class MessageServiceTest extends TestCase
             []
         );
 
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('hipaa_allowsms is not YES');
+        try {
+            $this->service->sendToPatient(1, '+15559999999', 'Hello');
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('hipaa_allowsms is not YES', $e->getMessage());
+        }
 
-        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+        $this->assertBlockLogged(1, 'hipaa_disallows_sms', ['hipaa_allowsms' => 'unset']);
     }
 
     public function testSendToPatientThrowsWhenNoConsent(): void
@@ -135,10 +143,14 @@ class MessageServiceTest extends TestCase
             []
         );
 
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('has not consented');
+        try {
+            $this->service->sendToPatient(1, '+15559999999', 'Hello');
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('has not consented', $e->getMessage());
+        }
 
-        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+        $this->assertBlockLogged(1, 'no_active_consent', ['consent_state' => 'none']);
     }
 
     public function testSendToPatientThrowsWhenOptedOut(): void
@@ -156,10 +168,32 @@ class MessageServiceTest extends TestCase
             [['opted_in' => true, 'opted_out' => true]]
         );
 
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('has not consented');
+        try {
+            $this->service->sendToPatient(1, '+15559999999', 'Hello');
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('has not consented', $e->getMessage());
+        }
 
-        $this->service->sendToPatient(1, '+15559999999', 'Hello');
+        $this->assertBlockLogged(1, 'no_active_consent', ['consent_state' => 'opted_out']);
+    }
+
+    public function testSendToPatientLogsBlockForUnparseablePhone(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            [1],
+            [['hipaa_allowsms' => 'YES']]
+        );
+
+        try {
+            $this->service->sendToPatient(1, 'abcdef', 'Hello');
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('unparseable phone number', $e->getMessage());
+        }
+
+        $this->assertBlockLogged(1, 'unparseable_phone', ['phone_last4' => '']);
     }
 
     public function testSendToPatientSkipsConsentCheckWhenOptionSet(): void
@@ -348,5 +382,40 @@ class MessageServiceTest extends TestCase
         $results = $this->service->sendBatch([1], 'Test');
 
         $this->assertEquals(1, $results['sent']);
+    }
+
+    /**
+     * Assert that a structured block warning was logged with the expected fields.
+     *
+     * @param array<string, scalar|null> $extraContext additional context fields to match
+     */
+    private function assertBlockLogged(int $patientId, string $reason, array $extraContext = []): void
+    {
+        $matches = array_filter(
+            SystemLogger::getLogs(),
+            static fn(array $log): bool => $log['level'] === 'warning'
+                && $log['message'] === 'Message send blocked'
+                && ($log['context']['patient_id'] ?? null) === $patientId
+                && ($log['context']['reason'] ?? null) === $reason
+        );
+
+        $this->assertCount(
+            1,
+            $matches,
+            sprintf(
+                'Expected exactly one "Message send blocked" warning for patient_id=%d reason=%s',
+                $patientId,
+                $reason
+            )
+        );
+
+        $log = array_values($matches)[0];
+        foreach ($extraContext as $key => $expected) {
+            $this->assertSame(
+                $expected,
+                $log['context'][$key] ?? null,
+                sprintf('Block log context "%s" did not match', $key)
+            );
+        }
     }
 }

--- a/tests/Unit/Service/PhoneNormalizerTest.php
+++ b/tests/Unit/Service/PhoneNormalizerTest.php
@@ -90,4 +90,26 @@ class PhoneNormalizerTest extends TestCase
         $this->assertCount(1, $unique, 'All formats should normalize to the same E.164 number');
         $this->assertSame('+15551234567', $unique[0]);
     }
+
+    #[DataProvider('last4Provider')]
+    public function testLast4(string $input, string $expected): void
+    {
+        $this->assertSame($expected, PhoneNormalizer::last4($input));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function last4Provider(): array
+    {
+        return [
+            'E.164' => ['+15551234567', '4567'],
+            '10-digit' => ['5551234567', '4567'],
+            'formatted' => ['(555) 123-4567', '4567'],
+            'fewer than four digits' => ['12', '12'],
+            'no digits' => ['abc', ''],
+            'empty' => ['', ''],
+            'mixed letters and digits' => ['ext-9876', '9876'],
+        ];
+    }
 }

--- a/tests/Unit/SkipReasonTest.php
+++ b/tests/Unit/SkipReasonTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Unit tests for SkipReason
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
+use PHPUnit\Framework\TestCase;
+
+class SkipReasonTest extends TestCase
+{
+    public function testValuesAreStableObservabilityContract(): void
+    {
+        // These string values are written to the `reason` field of WARNING
+        // logs and consumed by alerting/dashboards. Renaming them is a
+        // breaking change.
+        $this->assertSame('missing_phone', SkipReason::MissingPhone->value);
+        $this->assertSame('unparseable_phone', SkipReason::UnparseablePhone->value);
+        $this->assertSame('hipaa_disallows_sms', SkipReason::HipaaDisallowsSms->value);
+        $this->assertSame('no_active_consent', SkipReason::NoActiveConsent->value);
+    }
+}


### PR DESCRIPTION
## Summary

- Every skip path in `AppointmentReminderService::run()` now emits a `WARNING` with a stable `reason` code (`missing_phone`, `unparseable_phone`, `hipaa_disallows_sms`, `no_active_consent`) plus `pc_eid` and `patient_id`. Previously three of those four paths dropped silently and the aggregate-only `INFO` summary was suppressed by the default `WARNING` log threshold, so a clinic seeing zero reminders was indistinguishable from a clinic with nothing due.
- `no_active_consent` carries a `consent_state` sub-state (`none`, `opted_out`, `not_opted_in`) so triage can tell apart "never opted in" from "opted out".
- `MessageService::assertPatientEligible()` emits the same structured `WARNING` before throwing `ValidationException`, so blocks in the send path are visible at WARNING level rather than only inferable from caught exceptions.
- Phone numbers are reduced to a 4-digit suffix in WARNING+ logs (new `PhoneNormalizer::last4()`) to avoid logging PHI-adjacent identifiers. The pre-existing `unparseable_phone` log used to include the full raw phone — that's now `phone_last4`.

Closes #112.

## Test plan

- [x] `task test` — 417 tests, 1061 assertions pass (added new tests covering each skip path's log assertion plus `PhoneNormalizer::last4`)
- [x] `task check` — phpcs, phpstan, rector, composer-require-checker all pass
- [ ] Verify on canary (2026-04-29 build) that `oce_sinch_reminders` cron now logs one `WARNING` per skipped appointment with the expected `reason` code

## Out of scope

- `ConsentService::hasConsent()` DEBUG-level log when no row exists (the issue notes this was "up for discussion" — left for follow-up if useful)
- Diagnostics UI / consent-capture fix (#111)