### PR TITLE
refactor: treat hipaa_allowsms as consent source of truth

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -28,6 +28,7 @@
     "OpenEMR\\Core\\OEGlobalsBag",
     "OpenEMR\\Services\\Utils\\SQLUpgradeService",
     "ModuleManagerListener",
+    "OpenEMR\\Events\\Appointments\\AppointmentRenderEvent",
     "OpenEMR\\Events\\Globals\\GlobalsInitializedEvent",
     "OpenEMR\\Events\\Patient\\PatientCreatedEvent",
     "OpenEMR\\Events\\Patient\\PatientUpdatedEvent",

--- a/docs/messaging/opt-out.md
+++ b/docs/messaging/opt-out.md
@@ -36,56 +36,78 @@ April 11, 2025.
 2. The carrier may block future messages at the network level
 3. Sinch delivers the STOP as a `MESSAGE_INBOUND` webhook event
 4. The module's `KeywordHandlerService` detects the keyword
-5. `ConsentService::optOut()` records the opt-out
-6. The module sets the patient chart's **Allow SMS** field to No
-7. The patient no longer receives automated messages
+5. `ConsentService::optOut()` records the opt-out in
+   `oce_sinch_patient_consent` (the module's exception store) and sets the
+   chart's **Allow SMS** field to No
+6. The patient no longer receives automated messages
 
 ### Via Patient Chart
 
 1. A staff member navigates to the patient's chart
 2. Set **Allow SMS** (`hipaa_allowsms`) to No
-3. The module checks this field before sending — messages are blocked
-   immediately
+3. The chart `hipaa_allowsms='NO'` immediately gates all future sends —
+   no module-side mirroring is required
 
 ## Opt-In via Patient Chart
 
 Staff capture verbal or written consent during registration or any
-subsequent visit. The chart-driven opt-in flow:
+subsequent visit. The chart `hipaa_allowsms` field is the source of
+truth for SMS opt-in: setting it to YES is the consent record.
 
 1. The patient provides consent (verbally or in writing) and a mobile number
 2. A staff member registers the patient (or edits the chart) with
    **Allow SMS** (`hipaa_allowsms`) set to Yes and `phone_cell` populated
-3. `PatientConsentListener` observes the `patient.created` /
-   `patient.updated` event, detects the blank/NO → YES transition on
-   `hipaa_allowsms`, and calls `ConsentService::optIn()`
-4. `ConsentService` writes the row to `oce_sinch_patient_consent`
-   (`opted_in=TRUE`, `opted_out=FALSE`, `opt_in_method='chart_hipaa_allowsms'`)
-   and sends the opt-in confirmation SMS
-5. The patient resumes receiving automated messages
+3. `MessageService` will now treat the patient as eligible for SMS based
+   on the chart alone — no separate module opt-in row is required
+4. `PatientConsentListener` observes the `patient.created` /
+   `patient.updated` event and, on a NO → YES transition, sends the
+   opt-in confirmation SMS so the patient knows they will start receiving
+   messages from the clinic
+5. If a stale module-side opt-out exists (e.g., the patient previously
+   texted STOP), the listener skips the welcome SMS and logs the skip —
+   staff must clear the explicit opt-out deliberately before automated
+   messages resume
 
-The same listener handles the reverse: a YES → NO transition on
-`hipaa_allowsms` calls `ConsentService::optOut()` so the chart-side
-opt-out flow described above also produces a consent row update.
+The listener is a no-op for YES → NO transitions: chart NO already gates
+sends, so no module-side action is required. It is also a no-op when the
+chart save does not change `hipaa_allowsms`, when the new value matches
+the current value, or when `phone_cell` is blank on both the old and new
+patient record.
 
-The listener is a no-op when the chart save does not change
-`hipaa_allowsms`, when the new value matches the current value, or when
-`phone_cell` is blank on both the old and new patient record.
+> **Welcome-SMS coverage caveat:** the listener subscribes to OpenEMR's
+> `PatientUpdatedEvent` and `PatientCreatedEvent`. The legacy
+> `demographics_save.php` and `new_patient_save.php` chart save paths
+> dispatch `PatientUpdatedEventAux` (or no event at all), so a NO→YES
+> toggle through those paths will not trigger the welcome SMS. **Patient
+> eligibility is unaffected** — `MessageService::assertPatientEligible()`
+> reads `hipaa_allowsms` live, so the patient is still reachable by
+> appointment reminders the moment the chart shows YES. Reliable welcome
+> coverage across all save paths is tracked separately.
 
 > **Note:** If the carrier blocked messages at the network level after
 > a STOP, the patient may also need to text START to the same number
 > to unblock carrier-level filtering.
 
-## Dual Consent Check
+## Consent Check
 
-The module requires **both** consent signals to be affirmative before
-sending a message:
+To send a message the module requires:
 
 | Check | Source | What it represents |
 |-------|--------|-------------------|
-| `hipaa_allowsms` | `patient_data` table | Patient-level consent (TCPA prior express consent) |
-| Consent record | `ConsentService` | Module-level opt-in/opt-out tracking |
+| `hipaa_allowsms = 'YES'` | `patient_data` (chart) | Patient-level opt-in (TCPA prior express consent) — the source of truth |
+| No `opted_out=TRUE` row in `oce_sinch_patient_consent` for `(patient_id, phone_number)` | Module exception store | Patient-side opt-out the chart cannot represent (STOP keyword, channel-native opt-out) |
+| No `carrier_blocked=TRUE` row in `oce_sinch_patient_consent` for `(patient_id, phone_number)` | Module exception store | Carrier- or Sinch-side block discovered via SMPP delivery error or consent-API reconciliation — closes the partial-write window between `setCarrierBlock()` and the paired `optOut()` |
 
-If either is negative, the `MessageService` blocks the message.
+The module table is consulted **only for exceptions** that override the
+chart's YES. The absence of any module row means we have no exception on
+file — the chart YES alone is sufficient.
+
+The `carrier_blocked` check above closes the gate-level part of the
+broader Sinch-side desync work in
+[issue #42](https://github.com/openCoreEMR/oce-module-sinch-conversations/issues/42),
+which still tracks the proactive consent-API reconciliation job, the
+staff workflow for re-enabling a Sinch-blacklisted number, and the
+chart-side indicator.
 
 ## Compliance Notes
 

--- a/public/eligibility.php
+++ b/public/eligibility.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * SMS-eligibility verdict endpoint for the calendar appointment form
+ *
+ * Returns the rendered alert markup for a single patient (Content-Type:
+ * text/html). The calendar JS layer fetches this on page load and after
+ * every patient swap so the badge below the patient field stays in sync
+ * with what the user sees.
+ *
+ * Returns 404 when the module is not installed/enabled (so the endpoint's
+ * existence is not leaked to unauthenticated callers) and 403 when the
+ * caller lacks the same ACL the appointment form itself requires.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../../../globals.php';
+
+use OpenCoreEMR\ModuleConfig\ConfigFactory;
+use OpenCoreEMR\Modules\SinchConversations\Bootstrap;
+use OpenCoreEMR\Modules\SinchConversations\ModuleAccessGuard;
+use OpenCoreEMR\Modules\SinchConversations\SinchModuleConfig;
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Core\OEGlobalsBag;
+use Symfony\Component\HttpFoundation\Response;
+
+// Check if module is installed and enabled - return 404 if not
+$guardResponse = ModuleAccessGuard::check(Bootstrap::MODULE_NAME);
+if ($guardResponse instanceof Response) {
+    $guardResponse->send();
+    return;
+}
+
+// Same ACL the appointment form itself requires
+// (interface/main/calendar/add_edit_event.php:63)
+if (!AclMain::aclCheckCore('patients', 'appt', '', ['write', 'wsome'])) {
+    (new Response('', Response::HTTP_FORBIDDEN))->send();
+    return;
+}
+
+$logger = new SystemLogger();
+
+try {
+    $globalsBag = OEGlobalsBag::getInstance();
+    $kernel = $globalsBag->get('kernel');
+    if (!$kernel instanceof \OpenEMR\Core\Kernel) {
+        throw new \RuntimeException('OpenEMR Kernel not available');
+    }
+    $configFactory = new ConfigFactory(SinchModuleConfig::createConfigDescriptor(), $globalsBag);
+    $configAccessor = $configFactory->createConfigAccessor();
+    $bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $configAccessor, $configFactory);
+
+    $action = is_string($_GET['action'] ?? null) ? $_GET['action'] : 'html';
+    $controller = $bootstrap->getEligibilityController();
+    $response = $controller->dispatch($action);
+    $response->send();
+} catch (\Throwable $e) {
+    $logger->error('Eligibility endpoint unexpected error', ['exception' => $e]);
+
+    $response = new Response(
+        '',
+        Response::HTTP_INTERNAL_SERVER_ERROR,
+        ['Content-Type' => 'text/html; charset=utf-8']
+    );
+    $response->send();
+}

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -19,9 +19,13 @@ use OpenCoreEMR\ModuleConfig\ConfigFactory;
 use OpenCoreEMR\ModuleConfig\GlobalsRegistrar;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenCoreEMR\Modules\SinchConversations\Listener\AppointmentSmsStatusJsListener;
+use OpenCoreEMR\Modules\SinchConversations\Listener\AppointmentSmsStatusListener;
 use OpenCoreEMR\Modules\SinchConversations\Listener\PatientConsentListener;
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
 use OpenEMR\Core\Kernel;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\Appointments\AppointmentRenderEvent;
 use OpenEMR\Events\Patient\PatientCreatedEvent;
 use OpenEMR\Events\Patient\PatientUpdatedEvent;
 use OpenEMR\Menu\MenuEvent;
@@ -36,6 +40,7 @@ class Bootstrap
     private readonly SessionAccessor $session;
     private readonly \Twig\Environment $twig;
     private readonly SystemLogger $logger;
+    private ?EligibilityAlertRenderer $eligibilityAlertRenderer = null;
 
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
@@ -71,6 +76,7 @@ class Bootstrap
         }
 
         $this->subscribeToPatientConsentEvents();
+        $this->subscribeToAppointmentRenderEvents();
 
         $this->logger->debug('Sinch Conversations module is enabled');
     }
@@ -85,6 +91,21 @@ class Bootstrap
         $this->eventDispatcher->addListener(
             PatientUpdatedEvent::EVENT_HANDLE,
             $listener->onPatientUpdated(...)
+        );
+    }
+
+    private function subscribeToAppointmentRenderEvents(): void
+    {
+        $listener = $this->getAppointmentSmsStatusListener();
+        $this->eventDispatcher->addListener(
+            AppointmentRenderEvent::RENDER_BELOW_PATIENT,
+            $listener->onRenderBelowPatient(...)
+        );
+
+        $jsListener = $this->getAppointmentSmsStatusJsListener();
+        $this->eventDispatcher->addListener(
+            AppointmentRenderEvent::RENDER_JAVASCRIPT,
+            $jsListener->onRenderJavascript(...)
         );
     }
 
@@ -188,6 +209,46 @@ class Bootstrap
     public function getPatientConsentListener(): PatientConsentListener
     {
         return new PatientConsentListener($this->getConsentService());
+    }
+
+    /**
+     * Get Appointment SMS Status Listener
+     */
+    public function getAppointmentSmsStatusListener(): AppointmentSmsStatusListener
+    {
+        return new AppointmentSmsStatusListener(
+            $this->getMessageService(),
+            $this->getEligibilityAlertRenderer()
+        );
+    }
+
+    /**
+     * Get Appointment SMS Status JS Listener
+     */
+    public function getAppointmentSmsStatusJsListener(): AppointmentSmsStatusJsListener
+    {
+        return new AppointmentSmsStatusJsListener();
+    }
+
+    /**
+     * Get Eligibility Alert Renderer (memoized — stateless and shared
+     * between the listener and the controller).
+     */
+    public function getEligibilityAlertRenderer(): EligibilityAlertRenderer
+    {
+        return $this->eligibilityAlertRenderer ??= new EligibilityAlertRenderer();
+    }
+
+    /**
+     * Get Eligibility Controller
+     */
+    public function getEligibilityController(): Controller\EligibilityController
+    {
+        return new Controller\EligibilityController(
+            $this->getMessageService(),
+            $this->getEligibilityAlertRenderer(),
+            $this->logger
+        );
     }
 
     /**

--- a/src/Module/ConsentBlock.php
+++ b/src/Module/ConsentBlock.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Module-side block on a chart YES opt-in
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations;
+
+/**
+ * A module-side block that overrides the chart's hipaa_allowsms='YES' opt-in.
+ *
+ * Not a PHP exception — does not extend \Throwable. Represents a domain-level
+ * "exception to the chart YES rule": a row from oce_sinch_patient_consent
+ * that the chart's positive consent cannot override (an explicit STOP keyword
+ * opt-out, a channel-native opt-out webhook, or a carrier block discovered
+ * via SMPP error codes or Sinch consent-API reconciliation).
+ *
+ * Centralizing the row → block mapping here keeps the carrier-blocked
+ * vs. opted-out check ordering in one place. The send gate, the diagnostic
+ * verdict surface, the appointment-reminder cron, and the welcome-SMS
+ * listener all share this evaluation; drifting any one of them silently
+ * would mask a carrier_block_reason or change the gating semantics in only
+ * some paths.
+ */
+final readonly class ConsentBlock
+{
+    /**
+     * @param array<string, scalar|null> $context
+     */
+    private function __construct(
+        public SkipReason $reason,
+        public array $context,
+    ) {
+    }
+
+    /**
+     * Evaluate a row from oce_sinch_patient_consent.
+     *
+     * Returns null when no module-side block applies — either no row exists,
+     * or the row has no blocking flag set. Callers that see null should
+     * treat the chart's hipaa_allowsms='YES' as authoritative and proceed.
+     *
+     * Check ordering: carrier_blocked before opted_out. The normal carrier-
+     * block flow (setCarrierBlock then optOut) leaves both flags TRUE; the
+     * carrier block is the more specific cause, and reporting opt-out first
+     * would mask the carrier_block_reason context for every steady-state
+     * carrier-block row.
+     *
+     * @param array<string, mixed>|null $row
+     */
+    public static function evaluate(?array $row): ?self
+    {
+        if ($row === null) {
+            return null;
+        }
+
+        if ((bool) ($row['carrier_blocked'] ?? false)) {
+            $blockReason = is_string($row['carrier_block_reason'] ?? null)
+                ? $row['carrier_block_reason']
+                : null;
+            return new self(
+                reason: SkipReason::CarrierBlocked,
+                context: ['carrier_block_reason' => $blockReason],
+            );
+        }
+
+        if (ConsentState::fromRow($row) === ConsentState::OptedOut) {
+            return new self(
+                reason: SkipReason::ModuleOptOut,
+                context: ['consent_state' => ConsentState::OptedOut->value],
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/Module/Controller/EligibilityController.php
+++ b/src/Module/Controller/EligibilityController.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Returns the SMS-eligibility alert markup for a single patient
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Controller;
+
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Backs the public/eligibility.php endpoint that the calendar JS layer
+ * fetches whenever the appointment form's patient changes (popup picker
+ * swap, or initial load when the server-rendered listener could not
+ * resolve a pid).
+ *
+ * Returns the same alert markup the server-side listener emits — the
+ * EligibilityAlertRenderer is the single source of truth for both paths.
+ * On any failure (missing pid, non-numeric pid, diagnose() throws), the
+ * controller returns the empty placeholder div with HTTP 200 instead of
+ * a status code that would surface as a console error and leave the
+ * staff-facing badge in an indeterminate state.
+ */
+class EligibilityController
+{
+    public function __construct(
+        private readonly MessageService $messageService,
+        private readonly EligibilityAlertRenderer $renderer,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function dispatch(string $action = 'html'): Response
+    {
+        return match ($action) {
+            'html' => $this->renderHtml(),
+            default => $this->renderHtml(),
+        };
+    }
+
+    private function renderHtml(): Response
+    {
+        $request = Request::createFromGlobals();
+        $rawPid = $request->query->get('pid');
+        $pid = $this->coercePid($rawPid);
+
+        if ($pid === null) {
+            return $this->htmlResponse($this->renderer->renderEmpty());
+        }
+
+        try {
+            $verdict = $this->messageService->diagnose($pid);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to diagnose SMS eligibility for endpoint request', [
+                'patientId' => $pid,
+                'exception' => $e,
+            ]);
+            return $this->htmlResponse($this->renderer->renderEmpty());
+        }
+
+        return $this->htmlResponse($this->renderer->render($verdict));
+    }
+
+    private function coercePid(mixed $value): ?int
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+        if (preg_match('/^\d+$/', $value) !== 1) {
+            return null;
+        }
+        $pid = (int) $value;
+        return $pid > 0 ? $pid : null;
+    }
+
+    private function htmlResponse(string $body): Response
+    {
+        return new Response($body, Response::HTTP_OK, ['Content-Type' => 'text/html; charset=utf-8']);
+    }
+}

--- a/src/Module/Listener/AppointmentSmsStatusJsListener.php
+++ b/src/Module/Listener/AppointmentSmsStatusJsListener.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Echoes inline JS that keeps the SMS-eligibility badge in sync with the
+ * patient field on the calendar add/edit appointment form
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Listener;
+
+use OpenCoreEMR\Modules\SinchConversations\Bootstrap;
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\Appointments\AppointmentRenderEvent;
+
+/**
+ * Subscribes to AppointmentRenderEvent::RENDER_JAVASCRIPT. The companion
+ * server-side listener (AppointmentSmsStatusListener) emits an initial
+ * placeholder div on first render. This listener echoes inline JS that:
+ *
+ *   1. On DOMContentLoaded, fetches the alert markup for the current
+ *      form_pid value (covers the new-with-preselect path even when the
+ *      pid arrived via a route the server-side listener did not see).
+ *   2. Subscribes to the openemr:appointment:patient:set custom event the
+ *      core calendar already dispatches when staff swap patients via the
+ *      popup picker, and re-fetches on each swap.
+ *
+ * AbortController guards against rapid swaps racing each other to write
+ * stale results into the placeholder.
+ *
+ * Inline JS is acceptable on this page — the calendar already inlines
+ * scripts via $eventDispatcher->dispatch(..., RENDER_JAVASCRIPT) and the
+ * core file itself is full of inline <script> blocks.
+ */
+class AppointmentSmsStatusJsListener
+{
+    public const PATIENT_SET_EVENT = 'openemr:appointment:patient:set';
+
+    public function onRenderJavascript(AppointmentRenderEvent $event): void
+    {
+        unset($event); // signature is fixed by the dispatcher; nothing in $event is needed here
+        $webrootValue = OEGlobalsBag::getInstance()->get('webroot');
+        $webroot = is_string($webrootValue) ? $webrootValue : '';
+        $url = $webroot . '/interface/modules/custom_modules/' . Bootstrap::MODULE_NAME . '/public/eligibility.php';
+
+        // Embed every dynamic value as JSON so any future webroot change
+        // (or test that injects a quote) cannot break out of the JS string.
+        $jsUrl = json_encode($url);
+        $jsPlaceholderId = json_encode(EligibilityAlertRenderer::PLACEHOLDER_ID);
+        $jsEventName = json_encode(self::PATIENT_SET_EVENT);
+        $jsInputName = json_encode('form_pid');
+
+        echo <<<JS
+(function () {
+    var URL = {$jsUrl};
+    var PLACEHOLDER_ID = {$jsPlaceholderId};
+    var EVENT_NAME = {$jsEventName};
+    var INPUT_NAME = {$jsInputName};
+    var abort = null;
+    function refresh(pid) {
+        var placeholder = document.getElementById(PLACEHOLDER_ID);
+        if (!placeholder) { return; }
+        if (!pid || !/^\d+\$/.test(String(pid))) { placeholder.innerHTML = ''; return; }
+        if (abort) { abort.abort(); }
+        abort = new AbortController();
+        fetch(URL + '?pid=' + encodeURIComponent(pid), { signal: abort.signal, credentials: 'same-origin' })
+            .then(function (r) { return r.text(); })
+            .then(function (html) { placeholder.innerHTML = html; })
+            .catch(function (e) { if (e && e.name !== 'AbortError') { console.error(e); } });
+    }
+    document.addEventListener('DOMContentLoaded', function () {
+        var input = document.querySelector('input[name="' + INPUT_NAME + '"]');
+        if (input) { refresh(input.value); }
+        document.addEventListener(EVENT_NAME, function (e) {
+            var pid = (e && e.detail && e.detail.pid) || (input ? input.value : null);
+            refresh(pid);
+        });
+    });
+})();
+JS;
+        echo "\n";
+    }
+}

--- a/src/Module/Listener/AppointmentSmsStatusListener.php
+++ b/src/Module/Listener/AppointmentSmsStatusListener.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Renders an SMS-eligibility status line below the patient field on the
+ * calendar add/edit appointment form
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Listener;
+
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Appointments\AppointmentRenderEvent;
+
+/**
+ * Subscribes to AppointmentRenderEvent::RENDER_BELOW_PATIENT so staff can see
+ * at-a-glance whether the selected patient is eligible to receive SMS
+ * appointment reminders — without having to dig through logs after the fact.
+ *
+ * Scope: this is a patient-level eligibility check (chart hipaa_allowsms,
+ * phone parsability, module-side opt-out / carrier block). It does NOT
+ * predict whether the reminder cron will actually fire for this specific
+ * appointment — that depends on the notification-hours window, whether a
+ * reminder was already sent for pc_eid, and whether reminders are enabled
+ * in the module config. The label wording reflects that distinction.
+ *
+ * The pid cascade mirrors interface/main/calendar/add_edit_event.php:
+ * the edit-existing flow populates $row['pc_pid'], the new-with-preselect
+ * flow puts the pid in $_REQUEST['patientid'], and a stale session pid
+ * is the last-resort fallback. When no pid is available (truly blank new
+ * appointment), an empty placeholder is emitted so the companion
+ * AppointmentSmsStatusJsListener can populate it after the user picks a
+ * patient via the popup.
+ */
+class AppointmentSmsStatusListener
+{
+    private readonly SystemLogger $logger;
+
+    public function __construct(
+        private readonly MessageService $messageService,
+        private readonly EligibilityAlertRenderer $renderer,
+    ) {
+        $this->logger = new SystemLogger();
+    }
+
+    public function onRenderBelowPatient(AppointmentRenderEvent $event): void
+    {
+        $appt = $event->getAppt();
+        $pid = $this->extractPid($appt);
+        if ($pid === null) {
+            // Empty placeholder is still emitted so the JS layer has a
+            // target div to populate when the user picks a patient.
+            echo $this->renderer->renderEmpty();
+            return;
+        }
+
+        // Render is best-effort. A transient diagnose() failure (DB blip, a
+        // misconfigured module) must not take down the whole appointment
+        // form — emit an empty placeholder (the JS layer can retry on a
+        // patient swap) and leave a trace in the log.
+        try {
+            $verdict = $this->messageService->diagnose($pid);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to diagnose SMS eligibility for calendar render', [
+                'patientId' => $pid,
+                'exception' => $e,
+            ]);
+            echo $this->renderer->renderEmpty();
+            return;
+        }
+        echo $this->renderer->render($verdict);
+    }
+
+    /**
+     * Resolve the patient id for the appointment about to be rendered.
+     *
+     * Cascade matches interface/main/calendar/add_edit_event.php lines
+     * 793–798 and 830 — the edit-existing flow populates $row['pc_pid']
+     * from the database; the new-appointment-with-preselected-patient flow
+     * leaves $row empty and puts the pid in $_REQUEST['patientid'], with
+     * $_SESSION['pid'] as the last-resort fallback for staff who navigated
+     * here straight from a chart.
+     *
+     * @param array<array-key, mixed> $appt
+     */
+    private function extractPid(array $appt): ?int
+    {
+        $pid = $this->coercePid($appt['pc_pid'] ?? null);
+        if ($pid !== null) {
+            return $pid;
+        }
+
+        $pid = $this->coercePid($_REQUEST['patientid'] ?? null);
+        if ($pid !== null) {
+            return $pid;
+        }
+
+        return $this->coercePid($_SESSION['pid'] ?? null);
+    }
+
+    private function coercePid(mixed $value): ?int
+    {
+        if (is_int($value) && $value > 0) {
+            return $value;
+        }
+        if (is_string($value) && preg_match('/^\d+$/', $value) === 1 && (int) $value > 0) {
+            return (int) $value;
+        }
+        return null;
+    }
+}

--- a/src/Module/Listener/PatientConsentListener.php
+++ b/src/Module/Listener/PatientConsentListener.php
@@ -1,7 +1,23 @@
 <?php
 
 /**
- * Translates patient_data hipaa_allowsms transitions into ConsentService calls
+ * Sends an opt-in welcome SMS when the chart hipaa_allowsms field flips to YES
+ *
+ * Under the chart-as-source-of-truth model, hipaa_allowsms is itself the
+ * consent record — the module does not mirror it into oce_sinch_patient_consent.
+ * This listener exists only to send the patient a welcome message on the
+ * transition, so they know they will start receiving SMS from the clinic.
+ *
+ * Coverage note: this listener subscribes to PatientUpdatedEvent /
+ * PatientCreatedEvent. Several legacy chart save paths
+ * (interface/patient_file/summary/demographics_save.php and
+ * interface/new/new_patient_save.php) dispatch PatientUpdatedEventAux or
+ * no event at all, so a NO->YES toggle through those UI paths will not
+ * fire the welcome SMS. The patient is still eligible for reminders the
+ * moment the chart shows YES — MessageService::assertPatientEligible()
+ * reads hipaa_allowsms live at send time, independent of any event. The
+ * welcome SMS is therefore best-effort; reliable coverage is tracked
+ * separately. Eligibility coverage is not affected.
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
@@ -14,16 +30,15 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Listener;
 
-use OpenCoreEMR\Modules\SinchConversations\Channel;
+use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Events\Patient\PatientCreatedEvent;
 use OpenEMR\Events\Patient\PatientUpdatedEvent;
 
 class PatientConsentListener
 {
-    public const CONSENT_METHOD = 'chart_hipaa_allowsms';
-
     private readonly SystemLogger $logger;
 
     public function __construct(
@@ -44,7 +59,7 @@ class PatientConsentListener
             $this->logSkipped('created', $pid, $phone);
             return;
         }
-        $this->consentService->optIn($pid, $phone, self::CONSENT_METHOD, null, Channel::SMS);
+        $this->sendWelcomeIfNotBlocked($pid, $phone);
     }
 
     public function onPatientUpdated(PatientUpdatedEvent $event): void
@@ -59,7 +74,10 @@ class PatientConsentListener
         $oldData = $event->getDataBeforeUpdate();
         $oldYes = is_array($oldData) && $this->isAllowSmsYes($oldData);
         $newYes = $this->isAllowSmsYes($newData);
-        if ($oldYes === $newYes) {
+
+        // Only react to NO->YES. YES->NO needs no module-side action under
+        // chart-as-source-of-truth: the chart NO already gates future sends.
+        if (!$newYes || $oldYes) {
             return;
         }
 
@@ -78,10 +96,41 @@ class PatientConsentListener
             return;
         }
 
-        if ($newYes) {
-            $this->consentService->optIn($pid, $phone, self::CONSENT_METHOD, null, Channel::SMS);
-        } else {
-            $this->consentService->optOut($pid, $phone, self::CONSENT_METHOD, Channel::SMS);
+        $this->sendWelcomeIfNotBlocked($pid, $phone);
+    }
+
+    /**
+     * Send the welcome SMS unless a module-side block applies
+     *
+     * A staff chart toggle should not silently override either a patient's
+     * channel-native opt-out (e.g., a prior STOP) or a known carrier block.
+     * sendOptInConfirmation() bypasses the normal eligibility gate
+     * (skipConsentCheck=true), so this listener is the only thing standing
+     * between a chart toggle and a send to a number we already know is
+     * blocked. Reuses ConsentBlock::evaluate so the block ordering and
+     * context shape match the send gate, the appointment-reminder cron,
+     * and the diagnostic verdict surface.
+     */
+    private function sendWelcomeIfNotBlocked(int $pid, string $phone): void
+    {
+        $block = ConsentBlock::evaluate($this->consentService->getConsent($pid, $phone));
+        if ($block !== null) {
+            $message = match ($block->reason) {
+                SkipReason::CarrierBlocked => 'Skipped welcome SMS: carrier block present',
+                SkipReason::ModuleOptOut => 'Skipped welcome SMS: module opt-out present',
+                default => 'Skipped welcome SMS: ' . $block->reason->value,
+            };
+            $this->logger->info($message, ['patientId' => $pid] + $block->context);
+            return;
+        }
+
+        try {
+            $this->consentService->sendOptInConfirmation($pid, $phone);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to send opt-in confirmation', [
+                'patientId' => $pid,
+                'exception' => $e,
+            ]);
         }
     }
 

--- a/src/Module/Render/EligibilityAlertRenderer.php
+++ b/src/Module/Render/EligibilityAlertRenderer.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Renders the SMS-eligibility alert markup shared between the appointment
+ * form's server-rendered initial paint and the JS-fetched re-render
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Render;
+
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
+
+/**
+ * Single source of truth for the calendar SMS-eligibility badge markup.
+ *
+ * The same alert is produced two ways: once server-side at appointment-form
+ * render time (so the badge is present on first paint) and again by the JS
+ * layer when staff swap patients via the popup picker. Keeping the markup
+ * here means xlt() translation and HTML structure cannot drift between the
+ * two paths.
+ */
+class EligibilityAlertRenderer
+{
+    /**
+     * DOM id of the wrapper div the JS layer targets when replacing the
+     * alert after a patient swap. Server-rendered output and the
+     * empty-placeholder fallback both use this id so the JS lookup
+     * succeeds in either case.
+     */
+    public const PLACEHOLDER_ID = 'oce-sinch-eligibility-status';
+
+    /**
+     * Render the verdict as a Bootstrap alert wrapped in the placeholder div.
+     *
+     * Translated literals go through xlt() (translate + HTML-escape via
+     * OpenEMR's i18n helpers). The unknown-reason fallback is the only
+     * value that can carry untrusted input (a future SkipReason token), so
+     * it gets an explicit htmlspecialchars to make the escape obvious.
+     *
+     * @param array{
+     *     can_send: bool,
+     *     reason: ?string,
+     *     context: array<string, scalar|null>,
+     *     phone: ?string
+     * } $verdict
+     */
+    public function render(array $verdict): string
+    {
+        $canSend = $verdict['can_send'];
+        $cssClass = $canSend ? 'alert-success' : 'alert-warning';
+        // Phrased as patient-level eligibility, not as a per-appointment
+        // send prediction — the cron has additional checks (notification
+        // window, dedup) that this surface does not consult.
+        $headline = $canSend
+            ? xlt('Patient is eligible to receive SMS appointment reminders.')
+            : xlt('Patient is not eligible to receive SMS appointment reminders.');
+
+        $detail = $canSend ? '' : $this->reasonLabel($verdict['reason']);
+
+        $inner = '<div class="alert ' . $cssClass . ' mt-2 py-1 mb-0" role="status">'
+            . '<strong>' . $headline . '</strong>';
+        if ($detail !== '') {
+            $inner .= ' ' . $detail;
+        }
+        $inner .= '</div>';
+
+        return $this->wrap($inner);
+    }
+
+    /**
+     * Render just the empty placeholder div. Used when no pid is available
+     * (new-appointment flow without a preselected patient) so the JS layer
+     * always has a target element to populate after the user picks a
+     * patient.
+     */
+    public function renderEmpty(): string
+    {
+        return $this->wrap('');
+    }
+
+    private function wrap(string $inner): string
+    {
+        return '<div id="' . self::PLACEHOLDER_ID . '">' . $inner . '</div>';
+    }
+
+    /**
+     * Translate the structured SkipReason value into a staff-facing reason
+     * line. Unknown values fall back to the raw token (escaped) so a future
+     * reason surfaces as something rather than nothing.
+     */
+    private function reasonLabel(?string $reason): string
+    {
+        if ($reason === null) {
+            return '';
+        }
+
+        return match ($reason) {
+            SkipReason::HipaaDisallowsSms->value => xlt(
+                'Reason: the patient chart has Allow SMS set to No (or unset).'
+            ),
+            SkipReason::MissingPhone->value => xlt(
+                'Reason: no mobile phone number is on file for this patient.'
+            ),
+            SkipReason::UnparseablePhone->value => xlt(
+                "Reason: the patient's mobile phone number could not be parsed."
+            ),
+            SkipReason::ModuleOptOut->value => xlt(
+                'Reason: the patient has explicitly opted out of SMS messages.'
+            ),
+            SkipReason::CarrierBlocked->value => xlt(
+                "Reason: the patient's mobile carrier has blocked messages from us."
+            ),
+            default => xlt('Reason:') . ' ' . htmlspecialchars($reason, ENT_QUOTES, 'UTF-8'),
+        };
+    }
+}

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
-use OpenCoreEMR\Modules\SinchConversations\ConsentState;
+use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenEMR\Common\Database\QueryUtils;
@@ -98,11 +98,13 @@ class AppointmentReminderService
                 continue;
             }
 
-            $consentState = $this->getConsentState($patientId, $phoneNumber);
-            if ($consentState !== ConsentState::Active) {
-                $this->logSkip($pcEid, $patientId, SkipReason::NoActiveConsent, [
-                    'consent_state' => $consentState->value,
-                ]);
+            // Chart hipaa_allowsms='YES' (checked above) is the source of
+            // truth for opt-in. Module table is consulted only for explicit
+            // blocks (patient opt-out via STOP, carrier blocks, etc.).
+            // Absence of a row is fine — it just means no block on file.
+            $block = ConsentBlock::evaluate($this->getConsentRow($patientId, $phoneNumber));
+            if ($block !== null) {
+                $this->logSkip($pcEid, $patientId, $block->reason, $block->context);
                 $results['skipped']++;
                 continue;
             }
@@ -208,19 +210,24 @@ class AppointmentReminderService
     }
 
     /**
-     * Classify module-level consent for a patient/phone.
+     * Read the module-side exception row for a patient/phone, or null if none.
      *
-     * The hipaa_allowsms check is handled in run() from the main query result.
-     * This method checks only module-level consent in oce_sinch_patient_consent.
+     * The chart hipaa_allowsms check (the actual opt-in signal) is handled
+     * in run() from the main query result. This method only inspects the
+     * module's exception store so callers can detect explicit opt-outs and
+     * carrier blocks that should override the chart's YES.
      *
      * @param string $phoneNumber E.164 normalized phone number
+     * @return array<string, mixed>|null
      */
-    private function getConsentState(int $patientId, string $phoneNumber): ConsentState
+    private function getConsentRow(int $patientId, string $phoneNumber): ?array
     {
-        $sql = "SELECT opted_in, opted_out
+        $sql = "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?";
-        return ConsentState::fromRow(QueryUtils::querySingleRow($sql, [$patientId, $phoneNumber]));
+        // QueryUtils::querySingleRow returns false on no row; normalize so
+        // the declared ?array return holds.
+        return QueryUtils::querySingleRow($sql, [$patientId, $phoneNumber]) ?: null;
     }
 
     /**

--- a/src/Module/Service/ConsentService.php
+++ b/src/Module/Service/ConsentService.php
@@ -32,39 +32,6 @@ class ConsentService
     }
 
     /**
-     * Check if patient has active consent
-     *
-     * Normalizes the phone number to E.164 before lookup so that consent
-     * recorded as +15551234567 is found regardless of input format.
-     *
-     * @param int $patientId
-     * @param string $phoneNumber
-     * @return bool
-     */
-    public function hasConsent(int $patientId, string $phoneNumber): bool
-    {
-        $normalized = PhoneNormalizer::toE164($phoneNumber);
-        if ($normalized === null) {
-            $this->logger->warning('Cannot check consent with unparseable phone number', [
-                'patientId' => $patientId,
-                'phone' => $phoneNumber,
-            ]);
-            return false;
-        }
-
-        $sql = "SELECT opted_in, opted_out
-                FROM oce_sinch_patient_consent
-                WHERE patient_id = ? AND phone_number = ?";
-        $result = QueryUtils::querySingleRow($sql, [$patientId, $normalized]);
-
-        if (!$result) {
-            return false;
-        }
-
-        return ($result['opted_in'] ?? false) && !($result['opted_out'] ?? false);
-    }
-
-    /**
      * Record opt-in and send confirmation message
      *
      * Only syncs hipaa_allowsms when the channel is SMS, since that flag
@@ -95,17 +62,34 @@ class ConsentService
         }
         $phoneNumber = $normalized;
 
+        // An explicit opt-in clears every module-side exception, including a
+        // prior carrier_blocked. Provably correct for channel-confirmed
+        // signals (STOP→START, sinch_OPT_IN webhook): the carrier just
+        // delivered the message that triggered this opt-in, so the block
+        // is by definition gone. Optimistic for staff-driven signals
+        // (web_form, in_person, staff toggles): we don't know whether the
+        // carrier still blocks, but the next send attempt re-detects via
+        // setCarrierBlock() on delivery failure. That self-healing loop
+        // is strictly better than the alternative — leaving the row in
+        // (opted_out=FALSE, carrier_blocked=TRUE) deadlocks the patient
+        // because the eligibility gate refuses every send and no other
+        // code path clears the block from a re-subscribe signal.
+        $priorBlock = $this->getCarrierBlock($patientId, $phoneNumber);
+
         $sql = "INSERT INTO oce_sinch_patient_consent (
             patient_id, phone_number, opted_in, opt_in_method,
             opt_in_date, opt_in_ip_address, opted_out,
+            carrier_blocked, carrier_blocked_at,
             created_at, updated_at
-        ) VALUES (?, ?, TRUE, ?, NOW(), ?, FALSE, NOW(), NOW())
+        ) VALUES (?, ?, TRUE, ?, NOW(), ?, FALSE, FALSE, NULL, NOW(), NOW())
         ON DUPLICATE KEY UPDATE
             opted_in = TRUE,
             opt_in_method = VALUES(opt_in_method),
             opt_in_date = NOW(),
             opt_in_ip_address = VALUES(opt_in_ip_address),
             opted_out = FALSE,
+            carrier_blocked = FALSE,
+            carrier_blocked_at = NULL,
             updated_at = NOW()";
 
         QueryUtils::sqlStatementThrowException($sql, [
@@ -114,6 +98,21 @@ class ConsentService
             $method,
             $ipAddress,
         ]);
+
+        // Audit breadcrumb: a deliverability incident bisect months later
+        // should be able to see "this opt-in cleared a prior block" without
+        // having to reconstruct it from the row diff (carrier_blocked_at
+        // gets nulled by the upsert above, so this log line preserves the
+        // when/why for forensics).
+        if ($priorBlock !== null) {
+            $this->logger->info('Opt-in cleared prior carrier block', [
+                'patientId' => $patientId,
+                'method' => $method,
+                'channel' => $channel?->value,
+                'prior_carrier_blocked_at' => $priorBlock['carrier_blocked_at'],
+                'prior_carrier_block_reason' => $priorBlock['carrier_block_reason'],
+            ]);
+        }
 
         if ($channel === Channel::SMS) {
             $this->syncHipaaAllowSms($patientId, 'YES');
@@ -166,14 +165,25 @@ class ConsentService
         }
         $phoneNumber = $normalized;
 
-        $sql = "UPDATE oce_sinch_patient_consent
-                SET opted_out = TRUE,
-                    opt_out_method = ?,
+        // Use INSERT ... ON DUPLICATE KEY UPDATE so the opt-out is recorded
+        // even when no consent row exists yet. Under the chart-as-source-of
+        // -truth model, many patients legitimately have no module row until
+        // their first opt-out signal arrives (e.g., STOP keyword or a
+        // channel-native opt-out webhook). An UPDATE-only write would
+        // silently fail to persist these and leave the gating check seeing
+        // ConsentState::None on the next send.
+        $sql = "INSERT INTO oce_sinch_patient_consent (
+                    patient_id, phone_number, opted_in, opted_out,
+                    opt_out_method, opt_out_date,
+                    created_at, updated_at
+                ) VALUES (?, ?, FALSE, TRUE, ?, NOW(), NOW(), NOW())
+                ON DUPLICATE KEY UPDATE
+                    opted_out = TRUE,
+                    opt_out_method = VALUES(opt_out_method),
                     opt_out_date = NOW(),
-                    updated_at = NOW()
-                WHERE patient_id = ? AND phone_number = ?";
+                    updated_at = NOW()";
 
-        QueryUtils::sqlStatementThrowException($sql, [$method, $patientId, $phoneNumber]);
+        QueryUtils::sqlStatementThrowException($sql, [$patientId, $phoneNumber, $method]);
 
         if ($channel === Channel::SMS) {
             $this->syncHipaaAllowSms($patientId, 'NO');
@@ -329,13 +339,28 @@ class ConsentService
     }
 
     /**
-     * Send initial opt-in confirmation message
+     * Send the initial opt-in confirmation message
      *
-     * @param int $patientId
-     * @param string $phoneNumber
+     * Public so that PatientConsentListener can send a welcome SMS on a
+     * chart-driven NO->YES transition without going through optIn() (which
+     * would write a redundant module-level row — under the chart-as-source
+     * -of-truth model, the chart already records the consent intent).
+     *
+     * Normalizes the phone before delegating to MessageService so chart
+     * formats like "(555) 123-4567" reach the API as E.164. Callers that
+     * already hold a normalized number pay no penalty (PhoneNormalizer is
+     * idempotent for E.164 input).
      */
-    private function sendOptInConfirmation(int $patientId, string $phoneNumber): void
+    public function sendOptInConfirmation(int $patientId, string $phoneNumber): void
     {
+        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        if ($normalized === null) {
+            $this->logger->warning('Cannot send opt-in confirmation: unparseable phone', [
+                'patientId' => $patientId,
+            ]);
+            return;
+        }
+
         $variables = [
             'clinic_name' => $this->config->getClinicName(),
             'opt_out' => 'Reply STOP to opt-out',
@@ -343,7 +368,7 @@ class ConsentService
 
         $message = $this->templateService->render('opt_in_confirmation', $variables);
 
-        $this->messageService->sendToPatient($patientId, $phoneNumber, $message, new MessageOptions(
+        $this->messageService->sendToPatient($patientId, $normalized, $message, new MessageOptions(
             templateKey: 'opt_in_confirmation',
             skipConsentCheck: true,
         ));

--- a/src/Module/Service/MessageService.php
+++ b/src/Module/Service/MessageService.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;
-use OpenCoreEMR\Modules\SinchConversations\ConsentState;
+use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
@@ -216,54 +216,109 @@ class MessageService
     /**
      * Assert patient is eligible to receive messages
      *
-     * Check both OpenEMR's hipaa_allowsms field and module-level consent.
-     * Query consent directly to avoid circular dependency (ConsentService depends on MessageService).
-     * Normalize the phone number to E.164 before checking consent so that
-     * user-entered formats match the E.164 stored by Sinch callbacks.
-     *
-     * Emit a structured warning before throwing so the block decision is
-     * visible at WARNING level, not just inferable from caught exceptions.
+     * Delegates to diagnose() so the gate and the diagnostic verdict surface
+     * cannot drift apart — every check (chart hipaa_allowsms, phone parsability,
+     * module-side opt-out, carrier block) is evaluated in exactly one place.
+     * This method only adds the side effects: a structured WARNING log and a
+     * ValidationException.
      *
      * @throws ValidationException
      */
     private function assertPatientEligible(int $patientId, string $phoneNumber): void
     {
-        $sql = "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?";
+        $verdict = $this->diagnose($patientId, $phoneNumber);
+        if ($verdict['can_send']) {
+            return;
+        }
+
+        $reason = SkipReason::from((string) $verdict['reason']);
+        $this->logBlock($patientId, $reason, $verdict['context']);
+        throw new ValidationException(match ($reason) {
+            SkipReason::HipaaDisallowsSms => "Patient {$patientId} has not allowed SMS (hipaa_allowsms is not YES)",
+            SkipReason::MissingPhone => "Patient {$patientId} has no phone number on file",
+            SkipReason::UnparseablePhone => "Cannot check eligibility: unparseable phone number"
+                . " for patient {$patientId}",
+            SkipReason::CarrierBlocked => "Patient {$patientId}'s phone {$phoneNumber} is carrier-blocked",
+            SkipReason::ModuleOptOut => "Patient {$patientId} has explicitly opted out of messages at {$phoneNumber}",
+        });
+    }
+
+    /**
+     * Run the same checks as assertPatientEligible(), but return a structured
+     * verdict instead of throwing. Used by diagnostic surfaces (the calendar
+     * SMS-status renderer, support tools) that need to answer "would a send
+     * to this patient succeed right now?" without actually attempting one.
+     *
+     * Looks up phone_cell from patient_data when $phoneNumber is null, so
+     * UI callers can pass just the patient id.
+     *
+     * @return array{
+     *     can_send: bool,
+     *     reason: ?string,
+     *     context: array<string, scalar|null>,
+     *     phone: ?string
+     * }
+     */
+    public function diagnose(int $patientId, ?string $phoneNumber = null): array
+    {
+        $sql = "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?";
         $result = QueryUtils::querySingleRow($sql, [$patientId]);
-        $hipaaAllowSms = $result['hipaa_allowsms'] ?? '';
+        $hipaaAllowSms = is_string($result['hipaa_allowsms'] ?? null) ? $result['hipaa_allowsms'] : '';
 
         if ($hipaaAllowSms !== 'YES') {
-            $this->logBlock($patientId, SkipReason::HipaaDisallowsSms, [
-                'hipaa_allowsms' => $hipaaAllowSms === '' ? 'unset' : $hipaaAllowSms,
-            ]);
-            throw new ValidationException(
-                "Patient {$patientId} has not allowed SMS (hipaa_allowsms is not YES)"
-            );
+            return [
+                'can_send' => false,
+                'reason' => SkipReason::HipaaDisallowsSms->value,
+                'context' => ['hipaa_allowsms' => $hipaaAllowSms === '' ? 'unset' : $hipaaAllowSms],
+                'phone' => null,
+            ];
         }
 
-        $normalized = PhoneNormalizer::toE164($phoneNumber);
+        $rawPhone = $phoneNumber;
+        if ($rawPhone === null) {
+            $rawPhone = is_string($result['phone_cell'] ?? null) ? trim($result['phone_cell']) : '';
+        }
+        if ($rawPhone === '') {
+            return [
+                'can_send' => false,
+                'reason' => SkipReason::MissingPhone->value,
+                'context' => [],
+                'phone' => null,
+            ];
+        }
+
+        $normalized = PhoneNormalizer::toE164($rawPhone);
         if ($normalized === null) {
-            $this->logBlock($patientId, SkipReason::UnparseablePhone, [
-                'phone_last4' => PhoneNormalizer::last4($phoneNumber),
-            ]);
-            throw new ValidationException(
-                "Cannot check eligibility: unparseable phone number for patient {$patientId}"
-            );
+            return [
+                'can_send' => false,
+                'reason' => SkipReason::UnparseablePhone->value,
+                'context' => ['phone_last4' => PhoneNormalizer::last4($rawPhone)],
+                'phone' => null,
+            ];
         }
 
-        $sql = "SELECT opted_in, opted_out
+        $sql = "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?";
-        $consentState = ConsentState::fromRow(QueryUtils::querySingleRow($sql, [$patientId, $normalized]));
-
-        if ($consentState !== ConsentState::Active) {
-            $this->logBlock($patientId, SkipReason::NoActiveConsent, [
-                'consent_state' => $consentState->value,
-            ]);
-            throw new ValidationException(
-                "Patient {$patientId} has not consented to messages at {$phoneNumber}"
-            );
+        // QueryUtils::querySingleRow returns false on no row; normalize to
+        // null so ConsentBlock::evaluate's ?array contract holds.
+        $row = QueryUtils::querySingleRow($sql, [$patientId, $normalized]) ?: null;
+        $block = ConsentBlock::evaluate($row);
+        if ($block !== null) {
+            return [
+                'can_send' => false,
+                'reason' => $block->reason->value,
+                'context' => $block->context,
+                'phone' => $normalized,
+            ];
         }
+
+        return [
+            'can_send' => true,
+            'reason' => null,
+            'context' => [],
+            'phone' => $normalized,
+        ];
     }
 
     /**

--- a/src/Module/SkipReason.php
+++ b/src/Module/SkipReason.php
@@ -17,15 +17,18 @@ namespace OpenCoreEMR\Modules\SinchConversations;
 /**
  * Why a patient was not (or could not be) sent a message.
  *
- * Values are written into log context (`reason` field) and are part of the
- * observability contract — keep them stable across releases. Used by both
- * the appointment-reminder cron (skip decisions) and the send-path
- * eligibility gate (block decisions).
+ * Values are written into log context (`reason` field) and consumed by
+ * dashboards/alerts. Treat them as stable by default; only change a value
+ * when its meaning genuinely changes (in which case keeping the old name
+ * would mislead readers and downstream consumers more than the rename
+ * does). Used by both the appointment-reminder cron (skip decisions) and
+ * the send-path eligibility gate (block decisions).
  */
 enum SkipReason: string
 {
     case MissingPhone = 'missing_phone';
     case UnparseablePhone = 'unparseable_phone';
     case HipaaDisallowsSms = 'hipaa_disallows_sms';
-    case NoActiveConsent = 'no_active_consent';
+    case ModuleOptOut = 'module_opt_out';
+    case CarrierBlocked = 'carrier_blocked';
 }

--- a/tests/Mocks/MockAppointmentRenderEvent.php
+++ b/tests/Mocks/MockAppointmentRenderEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Mock AppointmentRenderEvent for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Appointments;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Minimal stand-in for OpenEMR's AppointmentRenderEvent. See issue #118 and
+ * tools/openemr/README.md.
+ */
+class AppointmentRenderEvent extends Event
+{
+    public const RENDER_JAVASCRIPT = 'appointment.render.javascript';
+    public const RENDER_BELOW_PATIENT = 'appointment.render.below.patient';
+    public const RENDER_BEFORE_ACTION_BAR = 'appointment.render.action-bar.before';
+
+    /**
+     * @param array<array-key, mixed> $appt
+     */
+    public function __construct(private array $appt)
+    {
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getAppt(): array
+    {
+        return $this->appt;
+    }
+}

--- a/tests/Mocks/MockQueryUtils.php
+++ b/tests/Mocks/MockQueryUtils.php
@@ -55,11 +55,16 @@ class QueryUtils
     }
 
     /**
+     * Faithful mock of the real OpenEMR helper, which has no declared return
+     * type and returns `false` (not `null`) on no row. Tests catch boundary
+     * bugs only if the mock matches that quirk — otherwise code that fails
+     * a `?array` type check at runtime passes the test suite.
+     *
      * @param string $sql
      * @param array<mixed> $binds
-     * @return array<string, mixed>|null
+     * @return array<string, mixed>|false
      */
-    public static function querySingleRow(string $sql, array $binds = []): ?array
+    public static function querySingleRow(string $sql, array $binds = []): array|false
     {
         self::$queries[] = ['sql' => $sql, 'binds' => $binds];
 
@@ -68,12 +73,12 @@ class QueryUtils
         // Check queue first for sequential results
         if (!empty(self::$mockResultQueue[$key])) {
             $results = array_shift(self::$mockResultQueue[$key]);
-            return !empty($results) ? $results[0] : null;
+            return !empty($results) ? $results[0] : false;
         }
 
         // Fall back to static mock results
         $results = self::$mockResults[$key] ?? [];
-        return !empty($results) ? $results[0] : null;
+        return !empty($results) ? $results[0] : false;
     }
 
     /**

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -18,8 +18,12 @@ use OpenCoreEMR\Modules\SinchConversations\Bootstrap;
 use OpenCoreEMR\Modules\SinchConversations\Controller\ConversationController;
 use OpenCoreEMR\Modules\SinchConversations\Controller\InboxController;
 use OpenCoreEMR\Modules\SinchConversations\Controller\SettingsController;
+use OpenCoreEMR\Modules\SinchConversations\Controller\EligibilityController;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Listener\AppointmentSmsStatusJsListener;
+use OpenCoreEMR\Modules\SinchConversations\Listener\AppointmentSmsStatusListener;
 use OpenCoreEMR\Modules\SinchConversations\Listener\PatientConsentListener;
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentSyncService;
@@ -33,6 +37,7 @@ use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Appointments\AppointmentRenderEvent;
 use OpenEMR\Events\Globals\GlobalsInitializedEvent;
 use OpenEMR\Events\Patient\PatientCreatedEvent;
 use OpenEMR\Events\Patient\PatientUpdatedEvent;
@@ -188,12 +193,65 @@ class BootstrapTest extends TestCase
         $this->assertInstanceOf(PatientConsentListener::class, $listener);
     }
 
+    public function testGetAppointmentSmsStatusListenerReturnsListener(): void
+    {
+        $listener = $this->bootstrap->getAppointmentSmsStatusListener();
+
+        $this->assertInstanceOf(AppointmentSmsStatusListener::class, $listener);
+    }
+
+    public function testGetAppointmentSmsStatusJsListenerReturnsListener(): void
+    {
+        $listener = $this->bootstrap->getAppointmentSmsStatusJsListener();
+
+        $this->assertInstanceOf(AppointmentSmsStatusJsListener::class, $listener);
+    }
+
+    public function testGetEligibilityAlertRendererReturnsMemoizedInstance(): void
+    {
+        $first = $this->bootstrap->getEligibilityAlertRenderer();
+        $second = $this->bootstrap->getEligibilityAlertRenderer();
+
+        $this->assertInstanceOf(EligibilityAlertRenderer::class, $first);
+        $this->assertSame($first, $second);
+    }
+
+    public function testGetEligibilityControllerReturnsController(): void
+    {
+        $controller = $this->bootstrap->getEligibilityController();
+
+        $this->assertInstanceOf(EligibilityController::class, $controller);
+    }
+
     public function testSubscribeToEventsRegistersPatientConsentListenersWhenEnabled(): void
     {
         $this->bootstrap->subscribeToEvents();
 
         $this->assertNotEmpty($this->eventDispatcher->getListeners(PatientCreatedEvent::EVENT_HANDLE));
         $this->assertNotEmpty($this->eventDispatcher->getListeners(PatientUpdatedEvent::EVENT_HANDLE));
+    }
+
+    public function testSubscribeToEventsRegistersAppointmentRenderListenerWhenEnabled(): void
+    {
+        // Pin the wiring so a typo'd event name or a future refactor that
+        // drops subscribeToAppointmentRenderEvents() fails the build instead
+        // of silently disabling the calendar SMS-eligibility badge.
+        $this->bootstrap->subscribeToEvents();
+
+        $this->assertNotEmpty(
+            $this->eventDispatcher->getListeners(AppointmentRenderEvent::RENDER_BELOW_PATIENT)
+        );
+    }
+
+    public function testSubscribeToEventsRegistersAppointmentRenderJsListenerWhenEnabled(): void
+    {
+        // The JS listener powers the live update on patient swap; without
+        // it the badge would only refresh on a full form re-render.
+        $this->bootstrap->subscribeToEvents();
+
+        $this->assertNotEmpty(
+            $this->eventDispatcher->getListeners(AppointmentRenderEvent::RENDER_JAVASCRIPT)
+        );
     }
 
     public function testSubscribeToEventsDoesNotRegisterPatientConsentListenersWhenDisabled(): void
@@ -212,6 +270,28 @@ class BootstrapTest extends TestCase
 
         $this->assertEmpty($this->eventDispatcher->getListeners(PatientCreatedEvent::EVENT_HANDLE));
         $this->assertEmpty($this->eventDispatcher->getListeners(PatientUpdatedEvent::EVENT_HANDLE));
+    }
+
+    public function testSubscribeToEventsDoesNotRegisterAppointmentRenderListenerWhenDisabled(): void
+    {
+        $disabledGlobals = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => '0',
+            GlobalConfig::CONFIG_OPTION_PROJECT_ID => 'test-project',
+            GlobalConfig::CONFIG_OPTION_APP_ID => 'test-app',
+            GlobalConfig::CONFIG_OPTION_API_KEY => 'test-key',
+            GlobalConfig::CONFIG_OPTION_API_SECRET => base64_encode('test-secret'),
+            GlobalConfig::CONFIG_OPTION_REGION => 'us',
+        ]);
+        $bootstrap = new Bootstrap($this->eventDispatcher, configAccessor: $disabledGlobals);
+
+        $bootstrap->subscribeToEvents();
+
+        $this->assertEmpty(
+            $this->eventDispatcher->getListeners(AppointmentRenderEvent::RENDER_BELOW_PATIENT)
+        );
+        $this->assertEmpty(
+            $this->eventDispatcher->getListeners(AppointmentRenderEvent::RENDER_JAVASCRIPT)
+        );
     }
 
     public function testGetConfigServiceReturnsService(): void

--- a/tests/Unit/ConsentBlockTest.php
+++ b/tests/Unit/ConsentBlockTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Unit tests for ConsentBlock
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
+use PHPUnit\Framework\TestCase;
+
+class ConsentBlockTest extends TestCase
+{
+    public function testEvaluateReturnsNullForMissingRow(): void
+    {
+        $this->assertNull(ConsentBlock::evaluate(null));
+    }
+
+    public function testEvaluateReturnsNullWhenNoBlockingFlagSet(): void
+    {
+        // Patient who opted in via module flow but has no block on file:
+        // chart YES is authoritative, so the helper should yield no block.
+        $this->assertNull(ConsentBlock::evaluate([
+            'opted_in' => true,
+            'opted_out' => false,
+            'carrier_blocked' => false,
+            'carrier_block_reason' => null,
+        ]));
+    }
+
+    public function testEvaluateReturnsNullForRowWithAllFlagsFalse(): void
+    {
+        // Sparse row left behind by a partial flow (e.g., a contact created
+        // for an inbound STOP that has since been overwritten). With every
+        // blocking flag FALSE, chart YES is authoritative.
+        $this->assertNull(ConsentBlock::evaluate([
+            'opted_in' => false,
+            'opted_out' => false,
+            'carrier_blocked' => false,
+        ]));
+    }
+
+    public function testEvaluateReturnsCarrierBlockedWithReasonContext(): void
+    {
+        $block = ConsentBlock::evaluate([
+            'opted_in' => false,
+            'opted_out' => false,
+            'carrier_blocked' => true,
+            'carrier_block_reason' => 'smpp_255',
+        ]);
+
+        $this->assertNotNull($block);
+        $this->assertSame(SkipReason::CarrierBlocked, $block->reason);
+        $this->assertSame(['carrier_block_reason' => 'smpp_255'], $block->context);
+    }
+
+    public function testEvaluateReturnsCarrierBlockedWithNullReasonWhenColumnMissing(): void
+    {
+        // The carrier_block_reason column is nullable; a block recorded
+        // without a reason should still produce a CarrierBlocked verdict
+        // with a null context value (not absent / not the string "null").
+        $block = ConsentBlock::evaluate([
+            'opted_in' => false,
+            'opted_out' => false,
+            'carrier_blocked' => true,
+        ]);
+
+        $this->assertNotNull($block);
+        $this->assertSame(SkipReason::CarrierBlocked, $block->reason);
+        $this->assertSame(['carrier_block_reason' => null], $block->context);
+    }
+
+    public function testEvaluateReturnsModuleOptOutForOptedOutRow(): void
+    {
+        $block = ConsentBlock::evaluate([
+            'opted_in' => true,
+            'opted_out' => true,
+            'carrier_blocked' => false,
+        ]);
+
+        $this->assertNotNull($block);
+        $this->assertSame(SkipReason::ModuleOptOut, $block->reason);
+        $this->assertSame(['consent_state' => 'opted_out'], $block->context);
+    }
+
+    public function testEvaluatePrefersCarrierBlockedWhenBothFlagsSet(): void
+    {
+        // Steady state of the carrier-block flow: setCarrierBlock() then
+        // optOut() leaves both flags TRUE. The helper must report the more
+        // specific carrier-block reason (with carrier_block_reason context),
+        // not collapse it to module_opt_out.
+        $block = ConsentBlock::evaluate([
+            'opted_in' => false,
+            'opted_out' => true,
+            'carrier_blocked' => true,
+            'carrier_block_reason' => 'smpp_255',
+        ]);
+
+        $this->assertNotNull($block);
+        $this->assertSame(SkipReason::CarrierBlocked, $block->reason);
+        $this->assertSame(['carrier_block_reason' => 'smpp_255'], $block->context);
+    }
+}

--- a/tests/Unit/Controller/EligibilityControllerTest.php
+++ b/tests/Unit/Controller/EligibilityControllerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Unit tests for EligibilityController
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Controller;
+
+use OpenCoreEMR\Modules\SinchConversations\Controller\EligibilityController;
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class EligibilityControllerTest extends TestCase
+{
+    private MessageService&MockObject $messageService;
+    private EligibilityController $controller;
+
+    protected function setUp(): void
+    {
+        QueryUtils::clearQueries();
+        QueryUtils::clearMockResults();
+        CsrfUtils::reset();
+        SystemLogger::clearLogs();
+
+        $_POST = [];
+        $_GET = [];
+        $_SERVER = [];
+        $_FILES = [];
+
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+
+        $this->messageService = $this->createMock(MessageService::class);
+        $this->controller = new EligibilityController(
+            $this->messageService,
+            new EligibilityAlertRenderer(),
+            new SystemLogger()
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        $_POST = [];
+        $_GET = [];
+        $_SERVER = [];
+        $_FILES = [];
+    }
+
+    public function testValidPidReturnsRenderedAlert(): void
+    {
+        $_GET['pid'] = '42';
+        $this->messageService->expects($this->once())
+            ->method('diagnose')
+            ->with(42)
+            ->willReturn([
+                'can_send' => true,
+                'reason' => null,
+                'context' => [],
+                'phone' => '+15551112222',
+            ]);
+
+        $response = $this->controller->dispatch('html');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/html; charset=utf-8', $response->headers->get('Content-Type'));
+        $body = (string) $response->getContent();
+        $this->assertStringContainsString('alert-success', $body);
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, $body);
+    }
+
+    public function testNotEligibleVerdictPassesThroughToRenderer(): void
+    {
+        $_GET['pid'] = '7';
+        $this->messageService->method('diagnose')->willReturn([
+            'can_send' => false,
+            'reason' => SkipReason::ModuleOptOut->value,
+            'context' => [],
+            'phone' => '+15551112222',
+        ]);
+
+        $response = $this->controller->dispatch('html');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getContent();
+        $this->assertStringContainsString('alert-warning', $body);
+        $this->assertStringContainsString('opted out', $body);
+    }
+
+    public function testMissingPidReturnsEmptyPlaceholder(): void
+    {
+        $this->messageService->expects($this->never())->method('diagnose');
+
+        $response = $this->controller->dispatch('html');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(
+            '<div id="' . EligibilityAlertRenderer::PLACEHOLDER_ID . '"></div>',
+            (string) $response->getContent()
+        );
+    }
+
+    public function testNonNumericPidReturnsEmptyPlaceholder(): void
+    {
+        $_GET['pid'] = 'not-a-number';
+        $this->messageService->expects($this->never())->method('diagnose');
+
+        $response = $this->controller->dispatch('html');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, (string) $response->getContent());
+        $this->assertStringNotContainsString('alert', (string) $response->getContent());
+    }
+
+    public function testZeroPidReturnsEmptyPlaceholder(): void
+    {
+        $_GET['pid'] = '0';
+        $this->messageService->expects($this->never())->method('diagnose');
+
+        $response = $this->controller->dispatch('html');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, (string) $response->getContent());
+    }
+
+    public function testNegativePidReturnsEmptyPlaceholder(): void
+    {
+        $_GET['pid'] = '-1';
+        $this->messageService->expects($this->never())->method('diagnose');
+
+        $response = $this->controller->dispatch('html');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, (string) $response->getContent());
+    }
+
+    public function testDiagnoseExceptionReturnsEmptyPlaceholderAndLogs(): void
+    {
+        // Same degraded-response policy as the listener: don't break the
+        // calendar UI on a transient failure, but leave a trace for ops.
+        $_GET['pid'] = '42';
+        $this->messageService->method('diagnose')
+            ->willThrowException(new \RuntimeException('DB unavailable'));
+
+        $response = $this->controller->dispatch('html');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, (string) $response->getContent());
+
+        $logs = SystemLogger::getLogs();
+        $errorLogs = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'error'
+                && str_contains($log['message'], 'Failed to diagnose SMS eligibility for endpoint request')
+        );
+        $this->assertNotEmpty($errorLogs);
+    }
+
+    public function testUnknownActionFallsBackToHtmlRender(): void
+    {
+        // Single-action controller — defensive default keeps a typo'd
+        // action from surfacing as a 500.
+        $_GET['pid'] = '42';
+        $this->messageService->method('diagnose')->willReturn([
+            'can_send' => true,
+            'reason' => null,
+            'context' => [],
+            'phone' => '+15551112222',
+        ]);
+
+        $response = $this->controller->dispatch('garbage');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/Unit/Listener/AppointmentSmsStatusJsListenerTest.php
+++ b/tests/Unit/Listener/AppointmentSmsStatusJsListenerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Unit tests for AppointmentSmsStatusJsListener
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Listener;
+
+use OpenCoreEMR\Modules\SinchConversations\Bootstrap;
+use OpenCoreEMR\Modules\SinchConversations\Listener\AppointmentSmsStatusJsListener;
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
+use OpenEMR\Events\Appointments\AppointmentRenderEvent;
+use PHPUnit\Framework\TestCase;
+
+class AppointmentSmsStatusJsListenerTest extends TestCase
+{
+    private string $savedWebroot;
+
+    protected function setUp(): void
+    {
+        $this->savedWebroot = is_string($GLOBALS['webroot'] ?? null) ? $GLOBALS['webroot'] : '';
+        $GLOBALS['webroot'] = '/openemr';
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['webroot'] = $this->savedWebroot;
+    }
+
+    public function testEchoesScriptReferencingPlaceholderIdAndEventName(): void
+    {
+        $js = $this->captureRender();
+
+        // Pinning constant references — a renamed placeholder id or event
+        // name in the corresponding renderer/listener will fail this test
+        // and force the JS to be updated alongside.
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, $js);
+        $this->assertStringContainsString(AppointmentSmsStatusJsListener::PATIENT_SET_EVENT, $js);
+    }
+
+    public function testEchoesScriptReferencingFormPidInputName(): void
+    {
+        $js = $this->captureRender();
+
+        // The form_pid hidden input name is set by core's add_edit_event.php
+        // (line 1423). If core ever renames it, this test fails loudly.
+        $this->assertStringContainsString('form_pid', $js);
+    }
+
+    public function testEchoesScriptReferencingEligibilityEndpointUrl(): void
+    {
+        $js = $this->captureRender();
+
+        // URL is embedded via json_encode, which escapes forward slashes;
+        // the JS source therefore contains the escaped form rather than
+        // the literal path.
+        $expectedPath = '/openemr/interface/modules/custom_modules/'
+            . Bootstrap::MODULE_NAME
+            . '/public/eligibility.php';
+        $this->assertStringContainsString(
+            (string) json_encode($expectedPath),
+            $js
+        );
+    }
+
+    public function testEchoesScriptUsingAbortControllerForRaceProtection(): void
+    {
+        $js = $this->captureRender();
+
+        $this->assertStringContainsString('AbortController', $js);
+    }
+
+    public function testEchoesScriptListeningForDomContentLoaded(): void
+    {
+        $js = $this->captureRender();
+
+        $this->assertStringContainsString('DOMContentLoaded', $js);
+    }
+
+    public function testEchoesScriptUsingFetchWithSameOriginCredentials(): void
+    {
+        // Without credentials: 'same-origin' the session cookie is not
+        // sent and the endpoint's ACL check would always reject the
+        // request as unauthenticated.
+        $js = $this->captureRender();
+
+        $this->assertStringContainsString("credentials: 'same-origin'", $js);
+    }
+
+    public function testEmbedsUrlAsJsonToProtectAgainstQuoteInjection(): void
+    {
+        // If a future webroot value contained a quote, embedding it
+        // unencoded would break out of the JS string. json_encode keeps
+        // the value safe regardless of contents.
+        $GLOBALS['webroot'] = '/foo"bar';
+
+        $js = $this->captureRender();
+
+        // json_encode escapes " as \" — the raw literal must not survive.
+        $this->assertStringNotContainsString('"/foo"bar/interface/', $js);
+        $this->assertStringContainsString('/foo\\"bar', $js);
+    }
+
+    private function captureRender(): string
+    {
+        $listener = new AppointmentSmsStatusJsListener();
+        ob_start();
+        $listener->onRenderJavascript(new AppointmentRenderEvent([]));
+        return (string) ob_get_clean();
+    }
+}

--- a/tests/Unit/Listener/AppointmentSmsStatusListenerTest.php
+++ b/tests/Unit/Listener/AppointmentSmsStatusListenerTest.php
@@ -1,0 +1,281 @@
+<?php
+
+/**
+ * Unit tests for AppointmentSmsStatusListener
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Listener;
+
+use OpenCoreEMR\Modules\SinchConversations\ConsentState;
+use OpenCoreEMR\Modules\SinchConversations\Listener\AppointmentSmsStatusListener;
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Appointments\AppointmentRenderEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AppointmentSmsStatusListenerTest extends TestCase
+{
+    private MessageService&MockObject $messageService;
+    private AppointmentSmsStatusListener $listener;
+
+    protected function setUp(): void
+    {
+        SystemLogger::clearLogs();
+        $_REQUEST = [];
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+
+        $this->messageService = $this->createMock(MessageService::class);
+        $this->listener = new AppointmentSmsStatusListener(
+            $this->messageService,
+            new EligibilityAlertRenderer()
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $_REQUEST = [];
+        $_SESSION = [];
+    }
+
+    public function testRendersEligibleAlertWhenDiagnoseReturnsCanSend(): void
+    {
+        $this->messageService->method('diagnose')->with(42)->willReturn([
+            'can_send' => true,
+            'reason' => null,
+            'context' => [],
+            'phone' => '+15551112222',
+        ]);
+
+        $html = $this->captureRender(['pc_pid' => 42]);
+
+        $this->assertStringContainsString('alert-success', $html);
+        $this->assertStringContainsString('eligible to receive SMS', $html);
+        $this->assertStringNotContainsString('Reason:', $html);
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, $html);
+    }
+
+    public function testRendersNotEligibleAlertWithReasonForOptedOut(): void
+    {
+        $this->messageService->method('diagnose')->willReturn([
+            'can_send' => false,
+            'reason' => SkipReason::ModuleOptOut->value,
+            'context' => ['consent_state' => ConsentState::OptedOut->value],
+            'phone' => '+15551112222',
+        ]);
+
+        $html = $this->captureRender(['pc_pid' => 42]);
+
+        $this->assertStringContainsString('alert-warning', $html);
+        $this->assertStringContainsString('not eligible', $html);
+        $this->assertStringContainsString('opted out', $html);
+    }
+
+    public function testRendersWillNotSendAlertForHipaaDisallows(): void
+    {
+        $this->messageService->method('diagnose')->willReturn([
+            'can_send' => false,
+            'reason' => SkipReason::HipaaDisallowsSms->value,
+            'context' => ['hipaa_allowsms' => 'NO'],
+            'phone' => null,
+        ]);
+
+        $html = $this->captureRender(['pc_pid' => 42]);
+
+        $this->assertStringContainsString('Allow SMS', $html);
+    }
+
+    public function testRendersWillNotSendAlertForCarrierBlock(): void
+    {
+        $this->messageService->method('diagnose')->willReturn([
+            'can_send' => false,
+            'reason' => SkipReason::CarrierBlocked->value,
+            'context' => ['carrier_block_reason' => 'smpp_255'],
+            'phone' => '+15551112222',
+        ]);
+
+        $html = $this->captureRender(['pc_pid' => 42]);
+
+        $this->assertStringContainsString('carrier', $html);
+    }
+
+    public function testRendersEmptyPlaceholderWhenAppointmentHasNoPatientId(): void
+    {
+        $this->messageService->expects($this->never())->method('diagnose');
+
+        $html = $this->captureRender(['pc_pid' => 0]);
+
+        // Empty placeholder is intentional — the JS layer needs a target
+        // div to populate when the user picks a patient via the popup.
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, $html);
+        $this->assertStringNotContainsString('alert', $html);
+    }
+
+    public function testFallsBackToRequestPatientIdWhenApptRowEmpty(): void
+    {
+        // Mirrors interface/main/calendar/add_edit_event.php new-appointment
+        // path: $row is empty, the preselected pid arrived via $_REQUEST.
+        $_REQUEST['patientid'] = '7';
+        $this->messageService->expects($this->once())
+            ->method('diagnose')
+            ->with(7)
+            ->willReturn([
+                'can_send' => true,
+                'reason' => null,
+                'context' => [],
+                'phone' => '+15551112222',
+            ]);
+
+        $html = $this->captureRender([]);
+
+        $this->assertStringContainsString('alert-success', $html);
+    }
+
+    public function testFallsBackToSessionPidWhenRequestEmpty(): void
+    {
+        // Last-resort fallback for staff who navigated here straight from
+        // a chart with $_SESSION['pid'] set but no $_REQUEST['patientid'].
+        $_SESSION['pid'] = '11';
+        $this->messageService->expects($this->once())
+            ->method('diagnose')
+            ->with(11)
+            ->willReturn([
+                'can_send' => true,
+                'reason' => null,
+                'context' => [],
+                'phone' => '+15551112222',
+            ]);
+
+        $html = $this->captureRender([]);
+
+        $this->assertStringContainsString('alert-success', $html);
+    }
+
+    public function testRequestTakesPrecedenceOverSession(): void
+    {
+        // $_REQUEST is the explicit "this appointment is for" signal from
+        // the calling page; $_SESSION is just whoever was last viewed.
+        $_REQUEST['patientid'] = '7';
+        $_SESSION['pid'] = '11';
+        $this->messageService->expects($this->once())
+            ->method('diagnose')
+            ->with(7)
+            ->willReturn([
+                'can_send' => true,
+                'reason' => null,
+                'context' => [],
+                'phone' => '+15551112222',
+            ]);
+
+        $this->captureRender([]);
+    }
+
+    public function testInvalidRequestPatientIdFallsThroughToSession(): void
+    {
+        $_REQUEST['patientid'] = 'not-a-number';
+        $_SESSION['pid'] = '11';
+        $this->messageService->expects($this->once())
+            ->method('diagnose')
+            ->with(11)
+            ->willReturn([
+                'can_send' => true,
+                'reason' => null,
+                'context' => [],
+                'phone' => '+15551112222',
+            ]);
+
+        $this->captureRender([]);
+    }
+
+    public function testNonPositiveRequestPatientIdIsIgnored(): void
+    {
+        $_REQUEST['patientid'] = '0';
+        $this->messageService->expects($this->never())->method('diagnose');
+
+        $html = $this->captureRender([]);
+
+        // Empty placeholder still rendered so JS has a target.
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, $html);
+    }
+
+    public function testAcceptsStringPidFromAppointmentRow(): void
+    {
+        // OpenEMR's calendar row arrays often carry pids as strings.
+        $this->messageService->expects($this->once())
+            ->method('diagnose')
+            ->with(42)
+            ->willReturn([
+                'can_send' => true,
+                'reason' => null,
+                'context' => [],
+                'phone' => '+15551112222',
+            ]);
+
+        $this->captureRender(['pc_pid' => '42']);
+    }
+
+    public function testEscapesUnknownReasonValueToPreventXss(): void
+    {
+        // Future SkipReason values pass through with the raw token. Make
+        // sure the renderer escapes that token instead of letting it land
+        // in the page as raw HTML.
+        $this->messageService->method('diagnose')->willReturn([
+            'can_send' => false,
+            'reason' => '<script>alert(1)</script>',
+            'context' => [],
+            'phone' => null,
+        ]);
+
+        $html = $this->captureRender(['pc_pid' => 42]);
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testDiagnoseExceptionIsLoggedAndSwallowed(): void
+    {
+        // A transient diagnose() failure (DB blip, misconfigured module)
+        // must not bubble out through the calendar render hook and break
+        // the appointment form. The empty placeholder is emitted so the JS
+        // layer can retry on a patient swap; the failure lands in the log
+        // for ops follow-up.
+        $this->messageService->method('diagnose')
+            ->willThrowException(new \RuntimeException('DB unavailable'));
+
+        $html = $this->captureRender(['pc_pid' => 42]);
+
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, $html);
+        $this->assertStringNotContainsString('alert-', $html);
+
+        $logs = SystemLogger::getLogs();
+        $errorLogs = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'error'
+                && str_contains($log['message'], 'Failed to diagnose SMS eligibility')
+        );
+        $this->assertNotEmpty($errorLogs);
+    }
+
+    /**
+     * @param array<array-key, mixed> $appt
+     */
+    private function captureRender(array $appt): string
+    {
+        ob_start();
+        $this->listener->onRenderBelowPatient(new AppointmentRenderEvent($appt));
+        return (string) ob_get_clean();
+    }
+}

--- a/tests/Unit/Listener/PatientConsentListenerTest.php
+++ b/tests/Unit/Listener/PatientConsentListenerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Listener;
 
-use OpenCoreEMR\Modules\SinchConversations\Channel;
 use OpenCoreEMR\Modules\SinchConversations\Listener\PatientConsentListener;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -35,19 +34,23 @@ class PatientConsentListenerTest extends TestCase
         $this->listener = new PatientConsentListener($this->consentService);
     }
 
+    /**
+     * Default mock: no module-side consent record exists. The listener calls
+     * getConsent() before sending the welcome SMS to detect a stale opt-out.
+     */
+    private function mockNoExistingConsent(): void
+    {
+        $this->consentService->method('getConsent')->willReturn(null);
+    }
+
     // --- onPatientCreated ---
 
-    public function testCreatedWithAllowSmsYesCallsOptIn(): void
+    public function testCreatedWithAllowSmsYesSendsWelcomeSms(): void
     {
+        $this->mockNoExistingConsent();
         $this->consentService->expects($this->once())
-            ->method('optIn')
-            ->with(
-                42,
-                '+15551234567',
-                PatientConsentListener::CONSENT_METHOD,
-                null,
-                Channel::SMS,
-            );
+            ->method('sendOptInConfirmation')
+            ->with(42, '+15551234567');
 
         $this->listener->onPatientCreated(new PatientCreatedEvent([
             'pid' => 42,
@@ -58,8 +61,7 @@ class PatientConsentListenerTest extends TestCase
 
     public function testCreatedWithAllowSmsNoIsNoop(): void
     {
-        $this->consentService->expects($this->never())->method('optIn');
-        $this->consentService->expects($this->never())->method('optOut');
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
 
         $this->listener->onPatientCreated(new PatientCreatedEvent([
             'pid' => 42,
@@ -70,7 +72,7 @@ class PatientConsentListenerTest extends TestCase
 
     public function testCreatedWithBlankAllowSmsIsNoop(): void
     {
-        $this->consentService->expects($this->never())->method('optIn');
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
 
         $this->listener->onPatientCreated(new PatientCreatedEvent([
             'pid' => 42,
@@ -80,7 +82,7 @@ class PatientConsentListenerTest extends TestCase
 
     public function testCreatedWithYesButNoPhoneLogsAndSkips(): void
     {
-        $this->consentService->expects($this->never())->method('optIn');
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
 
         $this->listener->onPatientCreated(new PatientCreatedEvent([
             'pid' => 42,
@@ -95,9 +97,10 @@ class PatientConsentListenerTest extends TestCase
 
     public function testCreatedWithYesAndStringPidIsAccepted(): void
     {
+        $this->mockNoExistingConsent();
         $this->consentService->expects($this->once())
-            ->method('optIn')
-            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, null, Channel::SMS);
+            ->method('sendOptInConfirmation')
+            ->with(42, '+15551234567');
 
         $this->listener->onPatientCreated(new PatientCreatedEvent([
             'pid' => '42',
@@ -106,14 +109,41 @@ class PatientConsentListenerTest extends TestCase
         ]));
     }
 
+    public function testCreatedSkipsWelcomeWhenStaleOptOutPresent(): void
+    {
+        // A patient created with chart YES who already has a module-side
+        // opt-out (e.g., they previously texted STOP and were re-created
+        // through some unusual path) should not get a welcome SMS — staff
+        // would have to clear the explicit opt-out deliberately first.
+        $this->consentService->method('getConsent')->willReturn([
+            'opted_in' => false,
+            'opted_out' => true,
+        ]);
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
+
+        $this->listener->onPatientCreated(new PatientCreatedEvent([
+            'pid' => 42,
+            'hipaa_allowsms' => 'YES',
+            'phone_cell' => '+15551234567',
+        ]));
+
+        $logs = SystemLogger::getLogs();
+        $infoLogs = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'info'
+                && str_contains($log['message'], 'Skipped welcome SMS')
+        );
+        $this->assertNotEmpty($infoLogs);
+    }
+
     // --- onPatientUpdated ---
 
-    public function testUpdatedNoToYesCallsOptIn(): void
+    public function testUpdatedNoToYesSendsWelcomeSms(): void
     {
+        $this->mockNoExistingConsent();
         $this->consentService->expects($this->once())
-            ->method('optIn')
-            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, null, Channel::SMS);
-        $this->consentService->expects($this->never())->method('optOut');
+            ->method('sendOptInConfirmation')
+            ->with(42, '+15551234567');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
             ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => '+15551234567'],
@@ -121,11 +151,12 @@ class PatientConsentListenerTest extends TestCase
         ));
     }
 
-    public function testUpdatedBlankToYesCallsOptIn(): void
+    public function testUpdatedBlankToYesSendsWelcomeSms(): void
     {
+        $this->mockNoExistingConsent();
         $this->consentService->expects($this->once())
-            ->method('optIn')
-            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, null, Channel::SMS);
+            ->method('sendOptInConfirmation')
+            ->with(42, '+15551234567');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
             ['pid' => 42, 'phone_cell' => '+15551234567'],
@@ -133,12 +164,13 @@ class PatientConsentListenerTest extends TestCase
         ));
     }
 
-    public function testUpdatedYesToNoCallsOptOut(): void
+    public function testUpdatedYesToNoIsNoop(): void
     {
-        $this->consentService->expects($this->once())
-            ->method('optOut')
-            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, Channel::SMS);
-        $this->consentService->expects($this->never())->method('optIn');
+        // Under chart-as-source-of-truth, chart NO already gates future
+        // sends — the listener does not need to mirror this into the module
+        // table. No welcome SMS, no opt-out write.
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
+        $this->consentService->expects($this->never())->method('getConsent');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
             ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
@@ -148,8 +180,7 @@ class PatientConsentListenerTest extends TestCase
 
     public function testUpdatedYesToYesIsNoop(): void
     {
-        $this->consentService->expects($this->never())->method('optIn');
-        $this->consentService->expects($this->never())->method('optOut');
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
             ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
@@ -161,8 +192,7 @@ class PatientConsentListenerTest extends TestCase
     {
         // Partial REST PATCH that doesn't include hipaa_allowsms must not
         // be interpreted as a transition.
-        $this->consentService->expects($this->never())->method('optIn');
-        $this->consentService->expects($this->never())->method('optOut');
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
             ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
@@ -170,22 +200,22 @@ class PatientConsentListenerTest extends TestCase
         ));
     }
 
-    public function testUpdatedYesToNoWithMissingPhoneFallsBackToOldPhone(): void
+    public function testUpdatedNoToYesWithMissingPhoneFallsBackToOldPhone(): void
     {
+        $this->mockNoExistingConsent();
         $this->consentService->expects($this->once())
-            ->method('optOut')
-            ->with(42, '+15551234567', PatientConsentListener::CONSENT_METHOD, Channel::SMS);
+            ->method('sendOptInConfirmation')
+            ->with(42, '+15551234567');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
-            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
-            ['pid' => 42, 'hipaa_allowsms' => 'NO'],
+            ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES'],
         ));
     }
 
     public function testUpdatedTransitionWithNoPhoneAtAllLogsAndSkips(): void
     {
-        $this->consentService->expects($this->never())->method('optIn');
-        $this->consentService->expects($this->never())->method('optOut');
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
             ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => ''],
@@ -199,11 +229,116 @@ class PatientConsentListenerTest extends TestCase
 
     public function testUpdatedYesValueIsCaseInsensitive(): void
     {
-        $this->consentService->expects($this->once())->method('optIn');
+        $this->mockNoExistingConsent();
+        $this->consentService->expects($this->once())->method('sendOptInConfirmation');
 
         $this->listener->onPatientUpdated(new PatientUpdatedEvent(
             ['pid' => 42, 'hipaa_allowsms' => 'no', 'phone_cell' => '+15551234567'],
             ['pid' => 42, 'hipaa_allowsms' => 'yes', 'phone_cell' => '+15551234567'],
         ));
+    }
+
+    public function testUpdatedNoToYesSkipsWelcomeWhenStaleOptOutPresent(): void
+    {
+        $this->consentService->method('getConsent')->willReturn([
+            'opted_in' => false,
+            'opted_out' => true,
+        ]);
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+        ));
+
+        $logs = SystemLogger::getLogs();
+        $infoLogs = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'info'
+                && str_contains($log['message'], 'Skipped welcome SMS')
+        );
+        $this->assertNotEmpty($infoLogs);
+    }
+
+    public function testUpdatedNoToYesSkipsWelcomeWhenCarrierBlockPresent(): void
+    {
+        // sendOptInConfirmation() bypasses assertPatientEligible() via
+        // skipConsentCheck=true, so the welcome path must independently
+        // honor the carrier_blocked flag — otherwise a chart toggle on a
+        // carrier-blocked number would push a send the rest of the module
+        // already refuses.
+        $this->consentService->method('getConsent')->willReturn([
+            'opted_in' => false,
+            'opted_out' => false,
+            'carrier_blocked' => true,
+            'carrier_block_reason' => 'smpp_255',
+        ]);
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+        ));
+
+        $logs = SystemLogger::getLogs();
+        $infoLogs = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'info'
+                && str_contains($log['message'], 'carrier block')
+        );
+        $this->assertNotEmpty($infoLogs);
+    }
+
+    public function testUpdatedNoToYesLogsCarrierBlockWhenBothFlagsSet(): void
+    {
+        // Steady state: setCarrierBlock() then optOut() leaves both flags
+        // TRUE. The listener must log the more specific carrier-block
+        // reason (with carrier_block_reason context), not the generic
+        // module-opt-out skip.
+        $this->consentService->method('getConsent')->willReturn([
+            'opted_in' => false,
+            'opted_out' => true,
+            'carrier_blocked' => true,
+            'carrier_block_reason' => 'smpp_255',
+        ]);
+        $this->consentService->expects($this->never())->method('sendOptInConfirmation');
+
+        $this->listener->onPatientUpdated(new PatientUpdatedEvent(
+            ['pid' => 42, 'hipaa_allowsms' => 'NO', 'phone_cell' => '+15551234567'],
+            ['pid' => 42, 'hipaa_allowsms' => 'YES', 'phone_cell' => '+15551234567'],
+        ));
+
+        $logs = SystemLogger::getLogs();
+        $carrierLogs = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'info'
+                && str_contains($log['message'], 'carrier block')
+        );
+        $optOutLogs = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'info'
+                && str_contains($log['message'], 'opt-out')
+        );
+        $this->assertNotEmpty($carrierLogs);
+        $this->assertEmpty($optOutLogs);
+    }
+
+    public function testWelcomeSmsFailureIsLoggedNotPropagated(): void
+    {
+        $this->mockNoExistingConsent();
+        $this->consentService->method('sendOptInConfirmation')
+            ->willThrowException(new \RuntimeException('API timeout'));
+
+        // Should not throw — listener swallows so a downstream messaging
+        // failure does not roll back the chart save.
+        $this->listener->onPatientCreated(new PatientCreatedEvent([
+            'pid' => 42,
+            'hipaa_allowsms' => 'YES',
+            'phone_cell' => '+15551234567',
+        ]));
+
+        $logs = SystemLogger::getLogs();
+        $errorLogs = array_filter($logs, fn(array $log): bool => $log['level'] === 'error');
+        $this->assertNotEmpty($errorLogs);
     }
 }

--- a/tests/Unit/Render/EligibilityAlertRendererTest.php
+++ b/tests/Unit/Render/EligibilityAlertRendererTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Unit tests for EligibilityAlertRenderer
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Render;
+
+use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
+use OpenCoreEMR\Modules\SinchConversations\SkipReason;
+use PHPUnit\Framework\TestCase;
+
+class EligibilityAlertRendererTest extends TestCase
+{
+    private EligibilityAlertRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new EligibilityAlertRenderer();
+    }
+
+    public function testEligibleVerdictRendersSuccessAlert(): void
+    {
+        $html = $this->renderer->render([
+            'can_send' => true,
+            'reason' => null,
+            'context' => [],
+            'phone' => '+15551112222',
+        ]);
+
+        $this->assertStringContainsString('alert-success', $html);
+        $this->assertStringContainsString('eligible to receive SMS', $html);
+        $this->assertStringNotContainsString('Reason:', $html);
+        $this->assertStringContainsString('id="' . EligibilityAlertRenderer::PLACEHOLDER_ID . '"', $html);
+    }
+
+    public function testHipaaDisallowsRendersWarningWithChartReason(): void
+    {
+        $html = $this->renderer->render([
+            'can_send' => false,
+            'reason' => SkipReason::HipaaDisallowsSms->value,
+            'context' => ['hipaa_allowsms' => 'NO'],
+            'phone' => null,
+        ]);
+
+        $this->assertStringContainsString('alert-warning', $html);
+        $this->assertStringContainsString('Allow SMS', $html);
+    }
+
+    public function testMissingPhoneRendersWarningWithPhoneReason(): void
+    {
+        $html = $this->renderer->render([
+            'can_send' => false,
+            'reason' => SkipReason::MissingPhone->value,
+            'context' => [],
+            'phone' => null,
+        ]);
+
+        $this->assertStringContainsString('alert-warning', $html);
+        $this->assertStringContainsString('mobile phone number is on file', $html);
+    }
+
+    public function testUnparseablePhoneRendersWarningWithParseReason(): void
+    {
+        $html = $this->renderer->render([
+            'can_send' => false,
+            'reason' => SkipReason::UnparseablePhone->value,
+            'context' => ['phone_last4' => '1234'],
+            'phone' => null,
+        ]);
+
+        $this->assertStringContainsString('alert-warning', $html);
+        $this->assertStringContainsString('could not be parsed', $html);
+    }
+
+    public function testModuleOptOutRendersWarningWithOptOutReason(): void
+    {
+        $html = $this->renderer->render([
+            'can_send' => false,
+            'reason' => SkipReason::ModuleOptOut->value,
+            'context' => [],
+            'phone' => '+15551112222',
+        ]);
+
+        $this->assertStringContainsString('alert-warning', $html);
+        $this->assertStringContainsString('opted out', $html);
+    }
+
+    public function testCarrierBlockedRendersWarningWithCarrierReason(): void
+    {
+        $html = $this->renderer->render([
+            'can_send' => false,
+            'reason' => SkipReason::CarrierBlocked->value,
+            'context' => ['carrier_block_reason' => 'smpp_255'],
+            'phone' => '+15551112222',
+        ]);
+
+        $this->assertStringContainsString('alert-warning', $html);
+        $this->assertStringContainsString('carrier', $html);
+    }
+
+    public function testUnknownReasonIsHtmlEscaped(): void
+    {
+        // A future SkipReason value lands in the default branch with the
+        // raw token. Make sure the renderer escapes that token instead of
+        // letting it land in the page as raw HTML.
+        $html = $this->renderer->render([
+            'can_send' => false,
+            'reason' => '<script>alert(1)</script>',
+            'context' => [],
+            'phone' => null,
+        ]);
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testRenderEmptyReturnsJustThePlaceholderDiv(): void
+    {
+        $html = $this->renderer->renderEmpty();
+
+        $this->assertSame(
+            '<div id="' . EligibilityAlertRenderer::PLACEHOLDER_ID . '"></div>',
+            $html
+        );
+    }
+
+    public function testServerAndJsPathsShareTheSamePlaceholderId(): void
+    {
+        // The JS layer relies on this id to find the div; pinning it here
+        // means a rename in the renderer will also fail this test, forcing
+        // the JS listener constant to be updated in the same change.
+        $rendered = $this->renderer->render([
+            'can_send' => true,
+            'reason' => null,
+            'context' => [],
+            'phone' => '+15551112222',
+        ]);
+
+        $this->assertStringContainsString(EligibilityAlertRenderer::PLACEHOLDER_ID, $rendered);
+        $this->assertStringContainsString(
+            EligibilityAlertRenderer::PLACEHOLDER_ID,
+            $this->renderer->renderEmpty()
+        );
+    }
+}

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -142,9 +142,10 @@ class AppointmentReminderServiceTest extends TestCase
             $this->makeAppointment(101, 43, '2026-04-01', '10:00:00', '+15558888888', 'YES'),
         ]);
 
-        // hipaa_allowsms = YES (from main query) but opted_out = true in consent
+        // hipaa_allowsms = YES (from main query) but opted_out = true in
+        // module table — the explicit opt-out overrides the chart YES.
         QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?",
             [43, '+15558888888'],
@@ -161,20 +162,29 @@ class AppointmentReminderServiceTest extends TestCase
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
 
-        $this->assertSkipLogged(101, 43, 'no_active_consent', ['consent_state' => 'opted_out']);
+        $this->assertSkipLogged(101, 43, 'module_opt_out', ['consent_state' => 'opted_out']);
     }
 
-    public function testRunSkipsPatientWithNoConsentRow(): void
+    public function testRunSkipsPatientWithCarrierBlockEvenWithoutOptOut(): void
     {
+        // setCarrierBlock() can leave a row with carrier_blocked=TRUE but
+        // opted_out=FALSE before the paired optOut() runs (or if optOut
+        // failed). The reminder cron must still skip these patients and
+        // surface carrier_block_reason in the log.
         $this->mockUpcomingAppointments([
-            $this->makeAppointment(110, 49, '2026-04-01', '10:00:00', '+15554443322', 'YES'),
+            $this->makeAppointment(120, 60, '2026-04-01', '12:00:00', '+15555550000', 'YES'),
         ]);
         QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?",
-            [49, '+15554443322'],
-            []
+            [60, '+15555550000'],
+            [[
+                'opted_in' => false,
+                'opted_out' => false,
+                'carrier_blocked' => true,
+                'carrier_block_reason' => 'consent_api_sync',
+            ]]
         );
 
         $this->templateService->method('getAppointmentReminderTemplateKey')
@@ -187,7 +197,71 @@ class AppointmentReminderServiceTest extends TestCase
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
 
-        $this->assertSkipLogged(110, 49, 'no_active_consent', ['consent_state' => 'none']);
+        $this->assertSkipLogged(120, 60, 'carrier_blocked', ['carrier_block_reason' => 'consent_api_sync']);
+    }
+
+    public function testRunReportsCarrierBlockedSkipReasonWhenBothFlagsSet(): void
+    {
+        // Steady state: setCarrierBlock() then optOut() leaves both flags
+        // TRUE. The cron must log carrier_blocked (the more specific
+        // cause) so the carrier_block_reason context survives — not
+        // module_opt_out, which would mask it.
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(125, 65, '2026-04-01', '13:00:00', '+15555556666', 'YES'),
+        ]);
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [65, '+15555556666'],
+            [[
+                'opted_in' => false,
+                'opted_out' => true,
+                'carrier_blocked' => true,
+                'carrier_block_reason' => 'smpp_255',
+            ]]
+        );
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+
+        $this->messageService->expects($this->never())->method('sendToPatient');
+
+        $results = $this->service->run();
+
+        $this->assertSame(0, $results['sent']);
+        $this->assertSame(1, $results['skipped']);
+
+        $this->assertSkipLogged(125, 65, 'carrier_blocked', ['carrier_block_reason' => 'smpp_255']);
+    }
+
+    public function testRunSendsReminderWhenChartYesAndNoConsentRow(): void
+    {
+        // Under chart-as-source-of-truth, chart YES with no module-side
+        // exception row is sufficient to send. (Pre-flip behavior skipped
+        // these patients as 'no_active_consent' — this test pins the new
+        // positive case.)
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(110, 49, '2026-04-01', '10:00:00', '+15554443322', 'YES'),
+        ]);
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [49, '+15554443322'],
+            []
+        );
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+        $this->templateService->method('render')->willReturn('Reminder');
+
+        $this->messageService->expects($this->once())->method('sendToPatient');
+
+        $results = $this->service->run();
+
+        $this->assertSame(1, $results['sent']);
+        $this->assertSame(0, $results['skipped']);
     }
 
     // --- hipaa_allowsms = NO -> no reminder ---
@@ -367,13 +441,13 @@ class AppointmentReminderServiceTest extends TestCase
         // First: eligible, send succeeds
         $this->mockActiveConsent(50, '+15550001111');
 
-        // Second: no consent record -> skipped
+        // Second: explicit opt-out -> skipped
         QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?",
             [51, '+15550002222'],
-            []
+            [['opted_in' => true, 'opted_out' => true]]
         );
 
         // Third: eligible, send succeeds
@@ -562,7 +636,7 @@ class AppointmentReminderServiceTest extends TestCase
     private function mockActiveConsent(int $patientId, string $phoneNumber): void
     {
         QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?",
             [$patientId, $phoneNumber],

--- a/tests/Unit/Service/ConsentServiceTest.php
+++ b/tests/Unit/Service/ConsentServiceTest.php
@@ -53,60 +53,6 @@ class ConsentServiceTest extends TestCase
         );
     }
 
-    // --- hasConsent ---
-
-    public function testHasConsentReturnsTrueWhenOptedIn(): void
-    {
-        QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
-                FROM oce_sinch_patient_consent
-                WHERE patient_id = ? AND phone_number = ?",
-            [1, '+15551234567'],
-            [['opted_in' => true, 'opted_out' => false]]
-        );
-
-        $this->assertTrue($this->service->hasConsent(1, '+15551234567'));
-    }
-
-    public function testHasConsentReturnsFalseWhenOptedOut(): void
-    {
-        QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
-                FROM oce_sinch_patient_consent
-                WHERE patient_id = ? AND phone_number = ?",
-            [1, '+15551234567'],
-            [['opted_in' => true, 'opted_out' => true]]
-        );
-
-        $this->assertFalse($this->service->hasConsent(1, '+15551234567'));
-    }
-
-    public function testHasConsentReturnsFalseWhenNoRecord(): void
-    {
-        QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
-                FROM oce_sinch_patient_consent
-                WHERE patient_id = ? AND phone_number = ?",
-            [1, '+15551234567'],
-            []
-        );
-
-        $this->assertFalse($this->service->hasConsent(1, '+15551234567'));
-    }
-
-    public function testHasConsentReturnsFalseWhenNotOptedIn(): void
-    {
-        QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
-                FROM oce_sinch_patient_consent
-                WHERE patient_id = ? AND phone_number = ?",
-            [1, '+15551234567'],
-            [['opted_in' => false, 'opted_out' => false]]
-        );
-
-        $this->assertFalse($this->service->hasConsent(1, '+15551234567'));
-    }
-
     // --- optIn ---
 
     public function testOptInInsertsConsentAndSendsConfirmation(): void
@@ -174,19 +120,55 @@ class ConsentServiceTest extends TestCase
         $this->assertEmpty($consentQueries);
     }
 
+    // --- sendOptInConfirmation ---
+
+    public function testSendOptInConfirmationNormalizesPhoneBeforeSend(): void
+    {
+        $this->templateService->method('render')->willReturn('Welcome!');
+        $this->messageService->expects($this->once())
+            ->method('sendToPatient')
+            ->with(1, '+15551234567', 'Welcome!', $this->anything());
+
+        // Pass a chart-format phone; the service must normalize before
+        // delegating to MessageService so the API receives E.164.
+        $this->service->sendOptInConfirmation(1, '(555) 123-4567');
+    }
+
+    public function testSendOptInConfirmationSkipsUnparseablePhone(): void
+    {
+        $this->messageService->expects($this->never())->method('sendToPatient');
+
+        $this->service->sendOptInConfirmation(1, 'not-a-phone');
+
+        $logs = SystemLogger::getLogs();
+        $warnings = array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'warning'
+                && str_contains($log['message'], 'unparseable phone')
+        );
+        $this->assertNotEmpty($warnings);
+    }
+
     // --- optOut ---
 
-    public function testOptOutSmsSyncsHipaaAllowSms(): void
+    public function testOptOutSmsUpsertsAndSyncsHipaaAllowSms(): void
     {
         $this->service->optOut(1, '+15551234567', 'sms_stop', Channel::SMS);
 
         $queries = QueryUtils::getQueries();
-        $updateQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'UPDATE oce_sinch_patient_consent'));
-        $this->assertNotEmpty($updateQueries);
-
-        // Verify the method param is first bind
-        $update = array_values($updateQueries)[0];
-        $this->assertEquals('sms_stop', $update['binds'][0]);
+        // optOut now upserts so a STOP-first patient (no prior module row)
+        // still gets a persistent opt-out record.
+        $upsertQueries = array_values(array_filter(
+            $queries,
+            fn(array $q): bool => str_contains($q['sql'], 'INSERT INTO oce_sinch_patient_consent')
+                && str_contains($q['sql'], 'ON DUPLICATE KEY UPDATE')
+                && str_contains($q['sql'], 'opted_out')
+        ));
+        $this->assertNotEmpty($upsertQueries);
+        $upsert = $upsertQueries[0];
+        $this->assertSame(1, $upsert['binds'][0]);
+        $this->assertSame('+15551234567', $upsert['binds'][1]);
+        $this->assertSame('sms_stop', $upsert['binds'][2]);
 
         // Verify hipaa_allowsms is synced to NO for SMS channel
         $hipaaQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'UPDATE patient_data SET hipaa_allowsms'));
@@ -225,15 +207,39 @@ class ConsentServiceTest extends TestCase
         $this->assertEquals('NO', $hipaaUpdate['binds'][0]);
     }
 
+    public function testOptOutPersistsRowEvenWhenNoPriorConsentExists(): void
+    {
+        // Under chart-as-source-of-truth, many patients have no module row
+        // until their first opt-out arrives. The upsert must record the
+        // opt-out so a later NO->YES chart toggle doesn't silently undo it.
+        $this->service->optOut(7, '+15554443333', 'sms_stop', Channel::SMS);
+
+        $upsertQueries = array_values(array_filter(
+            QueryUtils::getQueries(),
+            fn(array $q): bool => str_contains($q['sql'], 'INSERT INTO oce_sinch_patient_consent')
+                && str_contains($q['sql'], 'opted_out')
+                && str_contains($q['sql'], 'ON DUPLICATE KEY UPDATE')
+        ));
+        $this->assertCount(1, $upsertQueries);
+        $this->assertSame(7, $upsertQueries[0]['binds'][0]);
+        $this->assertSame('+15554443333', $upsertQueries[0]['binds'][1]);
+        $this->assertSame('sms_stop', $upsertQueries[0]['binds'][2]);
+    }
+
     public function testOptOutWhatsAppDoesNotSyncHipaaAllowSms(): void
     {
         $this->service->optOut(1, '+15551234567', 'sinch_WHATSAPP', Channel::WHATSAPP);
 
         $queries = QueryUtils::getQueries();
 
-        // Consent record should still be updated
-        $updateQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'UPDATE oce_sinch_patient_consent'));
-        $this->assertNotEmpty($updateQueries);
+        // Consent record is still upserted regardless of channel
+        $upsertQueries = array_filter(
+            $queries,
+            fn(array $q): bool => str_contains($q['sql'], 'INSERT INTO oce_sinch_patient_consent')
+                && str_contains($q['sql'], 'ON DUPLICATE KEY UPDATE')
+                && str_contains($q['sql'], 'opted_out')
+        );
+        $this->assertNotEmpty($upsertQueries);
 
         // hipaa_allowsms must NOT be touched for non-SMS channels
         $hipaaQueries = array_filter($queries, fn($q) => str_contains($q['sql'], 'UPDATE patient_data SET hipaa_allowsms'));
@@ -400,27 +406,82 @@ class ConsentServiceTest extends TestCase
         $this->assertNull($this->service->getCarrierBlock(1, '+15551234567'));
     }
 
-    // --- optIn does not clear carrier_blocked ---
+    // --- optIn clears carrier_blocked (re-subscribe deadlock fix) ---
 
-    public function testOptInDoesNotTouchCarrierBlockColumns(): void
+    public function testOptInClearsCarrierBlockColumnsToBreakResubscribeDeadlock(): void
     {
+        // Without this, a STOP→START flow leaves the row in
+        // (opted_out=FALSE, carrier_blocked=TRUE) — and the eligibility gate
+        // refuses every send forever because no other code path clears the
+        // block from a re-subscribe signal.
+        $this->templateService->method('render')->willReturn('Welcome!');
+        $this->messageService->method('sendToPatient');
+
+        $this->service->optIn(1, '+15551234567', 'sms_start');
+
+        $upsertQueries = array_values(array_filter(
+            QueryUtils::getQueries(),
+            fn(array $q): bool => str_contains($q['sql'], 'INSERT INTO oce_sinch_patient_consent')
+                && str_contains($q['sql'], 'opted_in')
+        ));
+        $this->assertNotEmpty($upsertQueries);
+        $sql = $upsertQueries[0]['sql'];
+        $this->assertStringContainsString('carrier_blocked = FALSE', $sql);
+        $this->assertStringContainsString('carrier_blocked_at = NULL', $sql);
+    }
+
+    public function testOptInLogsAuditBreadcrumbWhenClearingPriorCarrierBlock(): void
+    {
+        // Forensics: months later, an oncall debugging "why did this patient
+        // start receiving sends after we blocked them?" must be able to see
+        // that an opt-in cleared a known prior block (and what the original
+        // block reason was) without having to reconstruct from row diffs.
+        QueryUtils::setMockResult(
+            "SELECT carrier_blocked_at, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ? AND carrier_blocked = TRUE",
+            [1, '+15551234567'],
+            [['carrier_blocked_at' => '2026-04-03 10:00:00', 'carrier_block_reason' => 'smpp_255']]
+        );
+        $this->templateService->method('render')->willReturn('Welcome!');
+        $this->messageService->method('sendToPatient');
+
+        $this->service->optIn(1, '+15551234567', 'sms_start');
+
+        $logs = SystemLogger::getLogs();
+        $clearedLogs = array_values(array_filter(
+            $logs,
+            fn(array $log): bool => $log['level'] === 'info'
+                && str_contains($log['message'], 'cleared prior carrier block')
+        ));
+        $this->assertNotEmpty($clearedLogs);
+        $this->assertSame('2026-04-03 10:00:00', $clearedLogs[0]['context']['prior_carrier_blocked_at']);
+        $this->assertSame('smpp_255', $clearedLogs[0]['context']['prior_carrier_block_reason']);
+    }
+
+    public function testOptInDoesNotLogCarrierClearWhenNoPriorBlock(): void
+    {
+        // The audit breadcrumb must not fire on every opt-in — only when
+        // there was actually a block to clear. Otherwise the log noise
+        // would drown the signal.
+        QueryUtils::setMockResult(
+            "SELECT carrier_blocked_at, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ? AND carrier_blocked = TRUE",
+            [1, '+15551234567'],
+            []
+        );
         $this->templateService->method('render')->willReturn('Welcome!');
         $this->messageService->method('sendToPatient');
 
         $this->service->optIn(1, '+15551234567', 'web_form');
 
-        // Verify none of the queries issued by optIn() reference carrier_blocked.
-        // The optIn SQL uses its own INSERT...ON DUPLICATE KEY UPDATE that must not
-        // clear the carrier_blocked flag — that is only cleared by successful delivery.
-        $queries = QueryUtils::getQueries();
-        foreach ($queries as $query) {
-            if (str_contains($query['sql'], 'hipaa_allowsms')) {
-                continue; // Skip the hipaa sync query
-            }
-            if (str_contains($query['sql'], 'oce_sinch_patient_consent')) {
-                $this->assertStringNotContainsString('carrier_blocked', $query['sql']);
-            }
-        }
+        $logs = SystemLogger::getLogs();
+        $clearedLogs = array_filter(
+            $logs,
+            fn(array $log): bool => str_contains($log['message'], 'cleared prior carrier block')
+        );
+        $this->assertEmpty($clearedLogs);
     }
 
     public function testGetCarrierBlockSkipsUnparseablePhone(): void

--- a/tests/Unit/Service/MessageServiceTest.php
+++ b/tests/Unit/Service/MessageServiceTest.php
@@ -51,12 +51,12 @@ class MessageServiceTest extends TestCase
     private function mockPatientEligible(int $patientId, string $phoneNumber): void
     {
         QueryUtils::setMockResult(
-            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
             [$patientId],
             [['hipaa_allowsms' => 'YES']]
         );
         QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?",
             [$patientId, $phoneNumber],
@@ -95,7 +95,7 @@ class MessageServiceTest extends TestCase
     public function testSendToPatientThrowsWhenHipaaDisallowsSms(): void
     {
         QueryUtils::setMockResult(
-            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
             [1],
             [['hipaa_allowsms' => 'NO']]
         );
@@ -113,7 +113,7 @@ class MessageServiceTest extends TestCase
     public function testSendToPatientThrowsWhenHipaaFieldMissing(): void
     {
         QueryUtils::setMockResult(
-            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
             [1],
             []
         );
@@ -128,40 +128,43 @@ class MessageServiceTest extends TestCase
         $this->assertBlockLogged(1, 'hipaa_disallows_sms', ['hipaa_allowsms' => 'unset']);
     }
 
-    public function testSendToPatientThrowsWhenNoConsent(): void
+    public function testSendToPatientAllowsWhenChartYesAndNoModuleRow(): void
     {
+        // Under chart-as-source-of-truth: chart YES + absence of any module
+        // exception row = OK to send. Pre-flip behavior required an explicit
+        // opted_in row; this test pins the new positive case.
         QueryUtils::setMockResult(
-            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
             [1],
             [['hipaa_allowsms' => 'YES']]
         );
         QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?",
             [1, '+15559999999'],
             []
         );
+        $this->mockExistingConversation(1, 'conv-allow');
 
-        try {
-            $this->service->sendToPatient(1, '+15559999999', 'Hello');
-            $this->fail('Expected ValidationException');
-        } catch (ValidationException $e) {
-            $this->assertStringContainsString('has not consented', $e->getMessage());
-        }
+        $this->apiClient->expects($this->once())
+            ->method('sendMessageByChannelIdentity')
+            ->willReturn(['id' => 'msg-allow']);
 
-        $this->assertBlockLogged(1, 'no_active_consent', ['consent_state' => 'none']);
+        $result = $this->service->sendToPatient(1, '+15559999999', 'Hello');
+
+        $this->assertSame('msg-allow', $result['id']);
     }
 
     public function testSendToPatientThrowsWhenOptedOut(): void
     {
         QueryUtils::setMockResult(
-            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
             [1],
             [['hipaa_allowsms' => 'YES']]
         );
         QueryUtils::setMockResult(
-            "SELECT opted_in, opted_out
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
                 FROM oce_sinch_patient_consent
                 WHERE patient_id = ? AND phone_number = ?",
             [1, '+15559999999'],
@@ -172,16 +175,86 @@ class MessageServiceTest extends TestCase
             $this->service->sendToPatient(1, '+15559999999', 'Hello');
             $this->fail('Expected ValidationException');
         } catch (ValidationException $e) {
-            $this->assertStringContainsString('has not consented', $e->getMessage());
+            $this->assertStringContainsString('explicitly opted out', $e->getMessage());
         }
 
-        $this->assertBlockLogged(1, 'no_active_consent', ['consent_state' => 'opted_out']);
+        $this->assertBlockLogged(1, 'module_opt_out', ['consent_state' => 'opted_out']);
+    }
+
+    public function testSendToPatientThrowsWhenCarrierBlockedEvenWithoutOptOut(): void
+    {
+        // setCarrierBlock() writes opted_in=FALSE, opted_out=FALSE,
+        // carrier_blocked=TRUE before the paired optOut() call. If the
+        // optOut() write hasn't happened (or failed), the row exists with
+        // carrier_blocked=TRUE / opted_out=FALSE — sends must still be
+        // blocked, and the carrier_block_reason must surface in the log.
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [1],
+            [['hipaa_allowsms' => 'YES']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [1, '+15559999999'],
+            [[
+                'opted_in' => false,
+                'opted_out' => false,
+                'carrier_blocked' => true,
+                'carrier_block_reason' => 'smpp_255',
+            ]]
+        );
+
+        try {
+            $this->service->sendToPatient(1, '+15559999999', 'Hello');
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('carrier-blocked', $e->getMessage());
+        }
+
+        $this->assertBlockLogged(1, 'carrier_blocked', ['carrier_block_reason' => 'smpp_255']);
+    }
+
+    public function testSendToPatientReportsCarrierBlockedWhenBothFlagsSet(): void
+    {
+        // Steady state of the carrier-block flow: setCarrierBlock() then
+        // optOut() leaves opted_out=TRUE AND carrier_blocked=TRUE. The
+        // gate must report CarrierBlocked, not ModuleOptOut — the carrier
+        // block is the more specific cause and reporting opt-out would
+        // mask the carrier_block_reason context.
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [1],
+            [['hipaa_allowsms' => 'YES']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [1, '+15559999999'],
+            [[
+                'opted_in' => false,
+                'opted_out' => true,
+                'carrier_blocked' => true,
+                'carrier_block_reason' => 'smpp_255',
+            ]]
+        );
+
+        try {
+            $this->service->sendToPatient(1, '+15559999999', 'Hello');
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $e) {
+            $this->assertStringContainsString('carrier-blocked', $e->getMessage());
+        }
+
+        $this->assertBlockLogged(1, 'carrier_blocked', ['carrier_block_reason' => 'smpp_255']);
     }
 
     public function testSendToPatientLogsBlockForUnparseablePhone(): void
     {
         QueryUtils::setMockResult(
-            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
             [1],
             [['hipaa_allowsms' => 'YES']]
         );
@@ -314,7 +387,7 @@ class MessageServiceTest extends TestCase
             [['phone_cell' => '+15551111111']]
         );
         QueryUtils::setMockResult(
-            "SELECT hipaa_allowsms FROM patient_data WHERE pid = ?",
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
             [1],
             [['hipaa_allowsms' => 'NO']]
         );
@@ -382,6 +455,192 @@ class MessageServiceTest extends TestCase
         $results = $this->service->sendBatch([1], 'Test');
 
         $this->assertEquals(1, $results['sent']);
+    }
+
+    // --- diagnose ---
+
+    public function testDiagnoseReturnsCanSendWhenChartYesAndNoModuleException(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'YES', 'phone_cell' => '(555) 111-2222']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [42, '+15551112222'],
+            []
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertTrue($verdict['can_send']);
+        $this->assertNull($verdict['reason']);
+        $this->assertSame('+15551112222', $verdict['phone']);
+    }
+
+    public function testDiagnoseReturnsHipaaDisallowsWhenChartNo(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'NO', 'phone_cell' => '+15551112222']]
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertFalse($verdict['can_send']);
+        $this->assertSame('hipaa_disallows_sms', $verdict['reason']);
+        $this->assertSame('NO', $verdict['context']['hipaa_allowsms']);
+    }
+
+    public function testDiagnoseReturnsHipaaDisallowsWhenChartUnset(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            []
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertFalse($verdict['can_send']);
+        $this->assertSame('hipaa_disallows_sms', $verdict['reason']);
+        $this->assertSame('unset', $verdict['context']['hipaa_allowsms']);
+    }
+
+    public function testDiagnoseReturnsMissingPhoneWhenChartHasNoCell(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'YES', 'phone_cell' => '   ']]
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertFalse($verdict['can_send']);
+        $this->assertSame('missing_phone', $verdict['reason']);
+        $this->assertNull($verdict['phone']);
+    }
+
+    public function testDiagnoseReturnsUnparseablePhoneWhenChartCellInvalid(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'YES', 'phone_cell' => 'not-a-phone']]
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertFalse($verdict['can_send']);
+        $this->assertSame('unparseable_phone', $verdict['reason']);
+    }
+
+    public function testDiagnoseReturnsModuleOptOutWhenExceptionRecorded(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'YES', 'phone_cell' => '+15551112222']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [42, '+15551112222'],
+            [['opted_in' => true, 'opted_out' => true]]
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertFalse($verdict['can_send']);
+        $this->assertSame('module_opt_out', $verdict['reason']);
+        $this->assertSame('opted_out', $verdict['context']['consent_state']);
+    }
+
+    public function testDiagnoseReturnsCarrierBlockedWithReason(): void
+    {
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'YES', 'phone_cell' => '+15551112222']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [42, '+15551112222'],
+            [[
+                'opted_in' => false,
+                'opted_out' => false,
+                'carrier_blocked' => true,
+                'carrier_block_reason' => 'smpp_255',
+            ]]
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertFalse($verdict['can_send']);
+        $this->assertSame('carrier_blocked', $verdict['reason']);
+        $this->assertSame('smpp_255', $verdict['context']['carrier_block_reason']);
+    }
+
+    public function testDiagnoseReportsCarrierBlockedWhenBothFlagsSet(): void
+    {
+        // Steady-state row from the carrier-block flow: both flags TRUE.
+        // diagnose() must surface the carrier_block reason on the calendar
+        // verdict surface, not collapse it into module_opt_out.
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'YES', 'phone_cell' => '+15551112222']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [42, '+15551112222'],
+            [[
+                'opted_in' => false,
+                'opted_out' => true,
+                'carrier_blocked' => true,
+                'carrier_block_reason' => 'smpp_255',
+            ]]
+        );
+
+        $verdict = $this->service->diagnose(42);
+
+        $this->assertFalse($verdict['can_send']);
+        $this->assertSame('carrier_blocked', $verdict['reason']);
+        $this->assertSame('smpp_255', $verdict['context']['carrier_block_reason']);
+    }
+
+    public function testDiagnoseUsesExplicitPhoneWhenProvided(): void
+    {
+        // When the caller passes a phone, diagnose() must check that pair
+        // rather than the chart's phone_cell. This covers send paths that
+        // target a non-chart number.
+        QueryUtils::setMockResult(
+            "SELECT hipaa_allowsms, phone_cell FROM patient_data WHERE pid = ?",
+            [42],
+            [['hipaa_allowsms' => 'YES', 'phone_cell' => '+15550000000']]
+        );
+        QueryUtils::setMockResult(
+            "SELECT opted_in, opted_out, carrier_blocked, carrier_block_reason
+                FROM oce_sinch_patient_consent
+                WHERE patient_id = ? AND phone_number = ?",
+            [42, '+15559998888'],
+            []
+        );
+
+        $verdict = $this->service->diagnose(42, '+15559998888');
+
+        $this->assertTrue($verdict['can_send']);
+        $this->assertSame('+15559998888', $verdict['phone']);
     }
 
     /**

--- a/tests/Unit/SkipReasonTest.php
+++ b/tests/Unit/SkipReasonTest.php
@@ -27,6 +27,7 @@ class SkipReasonTest extends TestCase
         $this->assertSame('missing_phone', SkipReason::MissingPhone->value);
         $this->assertSame('unparseable_phone', SkipReason::UnparseablePhone->value);
         $this->assertSame('hipaa_disallows_sms', SkipReason::HipaaDisallowsSms->value);
-        $this->assertSame('no_active_consent', SkipReason::NoActiveConsent->value);
+        $this->assertSame('module_opt_out', SkipReason::ModuleOptOut->value);
+        $this->assertSame('carrier_blocked', SkipReason::CarrierBlocked->value);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,7 @@ require_once __DIR__ . '/Mocks/MockGlobalsInitializedEvent.php';
 require_once __DIR__ . '/Mocks/MockPatientCreatedEvent.php';
 require_once __DIR__ . '/Mocks/MockPatientUpdatedEvent.php';
 require_once __DIR__ . '/Mocks/MockMenuEvent.php';
+require_once __DIR__ . '/Mocks/MockAppointmentRenderEvent.php';
 require_once __DIR__ . '/Mocks/MockGlobalSetting.php';
 require_once __DIR__ . '/Mocks/MockGlobalsService.php';
 


### PR DESCRIPTION
## Summary

Closes #113.

The previous design required a row in `oce_sinch_patient_consent` with `opted_in=TRUE` before any send to a patient. That made the chart's `hipaa_allowsms` field a derived signal that `PatientConsentListener` (PR #114) was supposed to mirror into the module table. The mirror is unreliable: legacy chart UI write paths (`interface/patient_file/summary/demographics_save.php` and `interface/new/new_patient_save.php`) dispatch `PatientUpdatedEventAux` or no event at all, neither of which the listener subscribes to. Result: staff edits to the chart never reached `oce_sinch_patient_consent`, and patients with chart YES went unreached indefinitely — including every patient on tenants that already had `hipaa_allowsms='YES'` data when the module was installed.

This PR flips the architecture so the chart is the source of truth for the positive signal, and the module table is consulted only for **exceptions** the chart cannot represent (patient texted STOP, channel-native opt-out, carrier block).

## What changed

- **`MessageService::assertPatientEligible()`, `AppointmentReminderService::run()`** — new gate is `hipaa_allowsms='YES'` AND no `opted_out=TRUE` row AND no `carrier_blocked=TRUE` row in the module table. Absence of any module row is fine.
- **`ConsentBlock` helper (new)** — centralizes the row → block evaluation (carrier_blocked before opted_out) so the four call sites — send gate, `MessageService::diagnose()`, reminder cron, welcome listener — cannot drift apart silently. Named `ConsentBlock` (not `ConsentException`) because the value object is not a `\Throwable`; class docblock states this explicitly.
- **`MessageService::assertPatientEligible()` now delegates to `diagnose()`** — the gate only adds a structured WARNING log and a `ValidationException` on top of the shared verdict, so a future check addition (e.g., quiet hours) lands in exactly one place.
- **`SkipReason::NoActiveConsent` → `SkipReason::ModuleOptOut`** — the module-side opt-out check now only fires for explicit opt-outs, not for "no row" or "row exists but no opt-in." Renamed to reflect the new meaning.
- **`SkipReason::CarrierBlocked` (new)** — separately observable in logs so a carrier block does not get conflated with a patient-driven opt-out.
- **`PatientConsentListener`** — stops mirroring chart toggles into the module table. It now only sends the welcome SMS on a NO→YES transition, and skips that send when the patient has a stale module opt-out OR a carrier block (so a chart toggle by staff doesn't silently override either kind of exception). Welcome path goes through `ConsentBlock::evaluate()` for the same drift-free guarantee.
- **`ConsentService::optOut()`** — switched from `UPDATE`-only to `INSERT … ON DUPLICATE KEY UPDATE` so a STOP from a patient with no prior module row leaves a persistent `opted_out=TRUE` record (otherwise the eligibility gate sees no exception on the next send).
- **`ConsentService::optIn()`** — now clears `carrier_blocked` / `carrier_blocked_at` in the same upsert. Without this, a STOP→START / native OPT_IN flow would leave the row in `(opted_out=FALSE, carrier_blocked=TRUE)` and the eligibility gate would refuse every send forever. An audit breadcrumb logs when an opt-in clears a prior block so later forensics don't have to reconstruct from row diffs.
- **`ConsentService::hasConsent()` deleted** — no production callers; the in-line gating in `MessageService` / `AppointmentReminderService` is the authoritative check.
- **`ConsentService::sendOptInConfirmation()`** — promoted to `public` and now normalizes the phone via `PhoneNormalizer::toE164()` before delegating, so the simplified listener can send a welcome SMS with a chart-format phone (e.g., `(555) 123-4567`) and reach the API as E.164.
- **`MessageService::diagnose()` (new) + `AppointmentSmsStatusListener`** — calendar add/edit appointment view now shows staff a small green/yellow alert under the patient field: whether the patient is eligible to receive SMS appointment reminders, and if not, the per-`SkipReason` reason. Subscribes to `AppointmentRenderEvent::RENDER_BELOW_PATIENT`. Translated literals use `xlt()`; the unknown-reason fallback keeps an explicit `htmlspecialchars` on the dynamic value. Diagnose failures are logged and swallowed so a transient issue does not break the appointment form. Server-rendered from the appointment row's `pc_pid`; live update on a popup-driven patient swap is left to a follow-up.
- **`docs/messaging/opt-out.md`** — updated to describe the chart-as-source-of-truth model.

## Acceptance criteria mapping (#113)

The original issue framed this as a backfill problem. Under the new architecture, no backfill is needed:

- ✅ Patients with `hipaa_allowsms='YES'` and a non-blank `phone_cell` immediately become eligible to receive messages — no module row required.
- ✅ Patients with `hipaa_allowsms='NO'` or blank are blocked by the chart check.
- ✅ Patients who already have an opt-out row are still blocked (the `OptedOut` block overrides the chart YES, matching TCPA expectations).
- ✅ No bulk action against existing patients is performed at install time.

## Carrier-block handling

The eligibility gate now treats `carrier_blocked=TRUE` as a first-class exception alongside `opted_out=TRUE`, in `MessageService::assertPatientEligible()`, `AppointmentReminderService::run()`, and `PatientConsentListener` (the welcome-SMS path bypasses the eligibility gate via `skipConsentCheck=true`, so it has its own guard). New `SkipReason::CarrierBlocked` makes the block decision separately observable in logs and on the calendar verdict surface.

What this PR does NOT do — still tracked in #42:

- Proactive reconciliation against the Sinch consent API for blocks we never received a webhook for
- Staff workflow for re-enabling a Sinch-blacklisted number
- Chart-side indicator that a number is Sinch-blocked

## What was reverted

This branch previously contained a `consent:backfill` CLI command (commits `05839ce` and `d970ce0`). That work has been rolled back — backfill is no longer a real problem once the chart is authoritative.

## Test plan

- [x] `composer test` passes (461 tests, 1155 assertions).
- [x] `task check` passes (phpcs, phpstan, rector, composer-require-checker, CLI smoke).
- [ ] Manual: on a tenant with `hipaa_allowsms='YES'` patients and an empty `oce_sinch_patient_consent` table, verify appointment reminders send (previously they were blocked).
- [ ] Manual: opt out a patient via STOP, verify subsequent reminders are blocked even though chart still says YES.
- [ ] Manual: toggle a patient's chart NO→YES, verify the welcome SMS arrives.
- [ ] Manual: with a patient who has a stale module opt-out, toggle chart NO→YES and verify the welcome is skipped (logged at info).
- [ ] Manual: with a patient whose row is `carrier_blocked=TRUE / opted_out=FALSE`, toggle chart NO→YES and verify the welcome is skipped (logged at info, includes `carrier_block_reason`).
- [ ] Manual: open the calendar add/edit appointment view for an eligible patient and confirm the green eligibility alert renders below the patient field; for a blocked patient, confirm the yellow alert with the per-reason label.