### PR TITLE
fix: stop shadowing OpenEMR core's autoloader from our vendor dir

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -539,18 +539,18 @@ This runs:
 
 ## Researching OpenEMR Code and Dependencies
 
-**CRITICAL: Always check OpenEMR's actual requirements in `vendor/openemr/openemr/composer.json`**
+**CRITICAL: Always check OpenEMR's actual requirements in `tools/openemr/vendor/openemr/openemr/composer.json`**
 
 When you need to understand OpenEMR's code, dependencies, or version constraints:
 
 ### ✅ ALWAYS DO:
-- **Check `vendor/openemr/openemr/composer.json`** for OpenEMR's exact dependency versions
-- **Look in `vendor/openemr/openemr/src/`** for OpenEMR core classes
+- **Check `tools/openemr/vendor/openemr/openemr/composer.json`** for OpenEMR's exact dependency versions
+- **Look in `tools/openemr/vendor/openemr/openemr/src/`** for OpenEMR core classes
 - **Match OpenEMR's Symfony version constraints** - They use exact versions (e.g., `6.4.15`), not ranges
 - **Use `^6.4` constraints** for Symfony packages to stay compatible with OpenEMR 6.4.x
 
 ### ❌ NEVER DO:
-- ~~Search online for OpenEMR version requirements~~ → Check `vendor/openemr/openemr/composer.json`
+- ~~Search online for OpenEMR version requirements~~ → Check `tools/openemr/vendor/openemr/openemr/composer.json`
 - ~~Guess at version constraints~~ → Verify against OpenEMR's actual versions
 - ~~Use `^6.0 || ^7.0` for Symfony~~ → Use `^6.4` to match OpenEMR's 6.4.x versions
 - ~~Assume OpenEMR uses latest versions~~ → They pin specific versions
@@ -559,7 +559,7 @@ When you need to understand OpenEMR's code, dependencies, or version constraints
 
 ```bash
 # Check what Symfony versions OpenEMR uses
-cat vendor/openemr/openemr/composer.json | grep symfony
+cat tools/openemr/vendor/openemr/openemr/composer.json | grep symfony
 
 # Result shows exact versions:
 # "symfony/console": "6.4.15",
@@ -590,7 +590,7 @@ Always include these in `composer.json` with version constraints that match Open
 }
 ```
 
-**Note:** Version constraints must match OpenEMR's installed versions. Always verify in `vendor/openemr/openemr/composer.json`.
+**Note:** Version constraints must match OpenEMR's installed versions. Always verify in `tools/openemr/vendor/openemr/openemr/composer.json`.
 
 ## Composer Require Checker Configuration
 
@@ -956,4 +956,4 @@ When suggesting code completions:
 16. **Use pre-commit/composer** - Never suggest manual syntax checks; use `pre-commit run -a` or `composer check`
 17. **Show task list** - When user asks what they can do, suggest `task --list`
 18. **No CDN assets** - Never suggest CDN links; use `{{ webroot }}/public/assets/...` for all static assets
-19. **Check vendor/openemr** - For OpenEMR code research, check `vendor/openemr/openemr/composer.json` for versions and `vendor/openemr/openemr/src/` for core classes
+19. **Check vendor/openemr** - For OpenEMR code research, check `tools/openemr/vendor/openemr/openemr/composer.json` for versions and `tools/openemr/vendor/openemr/openemr/src/` for core classes

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -25,11 +25,15 @@ jobs:
         coverage: none
         tools: composer:v2
 
+    # composer.lock is gitignored in this repo, so key off the composer.json
+    # files instead — they change when deps change.
     - name: Cache Composer dependencies
       uses: actions/cache@v5
       with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        path: |
+          vendor
+          tools/openemr/vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('composer.json', 'tools/openemr/composer.json') }}
         restore-keys: |
           ${{ runner.os }}-composer-
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -36,5 +36,10 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-interaction
 
+    # PHPStan resolves OpenEMR\… types from the tooling sub-vendor (loaded via
+    # phpstan.neon's bootstrapFiles). See tools/openemr/README.md and issue #118.
+    - name: Install OpenEMR source for PHPStan
+      run: composer install --working-dir=tools/openemr --prefer-dist --no-progress --no-interaction
+
     - name: Run PHPStan
       run: composer phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Composer
 /vendor/
+/tools/openemr/vendor/
 composer.lock
 
 # IDE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,23 @@ task check
 task module:cleanup
 ```
 
+### OpenEMR source lives under `tools/openemr/`, not `vendor/`
+
+OpenEMR is intentionally NOT a runtime dependency of this module. Its source tree is
+installed at `tools/openemr/vendor/openemr/openemr/` via a sub-composer
+(`tools/openemr/composer.json`) and made available to:
+
+- **PHPStan** — `phpstan.neon` loads `tools/openemr/vendor/autoload.php` via `bootstrapFiles`
+- **Local Docker dev** — `compose.yml` bind-mounts `tools/openemr/vendor/openemr/openemr` to `/var/www/.../openemr`
+
+Do **not** add `openemr/openemr` to the root `composer.json`. If you do, the module's
+`vendor/autoload.php` will register a competing PSR-4 mapping for `OpenEMR\\` → our
+vendor's `src/`, classes will resolve to our copy, and `__DIR__`-relative `require_once`
+inside those classes will re-load procedural files under a different path → fatal
+`Cannot redeclare …` on patient demographics and elsewhere. See
+[issue #118](https://github.com/openCoreEMR/oce-module-sinch-conversations/issues/118)
+and [`tools/openemr/README.md`](tools/openemr/README.md).
+
 ### Configuration Modes
 
 The module supports two configuration modes:

--- a/README.md
+++ b/README.md
@@ -390,24 +390,29 @@ task check                    # Run all code quality checks
 
 ### Docker Development Environment
 
-Quick setup for local module development:
+Quick setup for local module development (or just run `task setup`):
 
 ```bash
-# 1. Clone and install dependencies
+# 1. Clone and install module dependencies
 git clone https://github.com/opencoreemr/oce-module-sinch-conversations.git
 cd oce-module-sinch-conversations
 composer install
 
-# 2. Pre-build OpenEMR (optional but recommended - saves 5-10 min)
-cd vendor/openemr/openemr
+# 2. Install OpenEMR source under tools/openemr (used by PHPStan + Docker bind mount).
+#    OpenEMR source is intentionally NOT a runtime dep of this module — see
+#    tools/openemr/README.md and issue #118.
+composer install --working-dir=tools/openemr
+
+# 3. Pre-build OpenEMR (optional but recommended - saves 5-10 min)
+cd tools/openemr/vendor/openemr/openemr
 composer install --no-dev
 npm install --legacy-peer-deps && npm run build
-cd ../../..
+cd -
 
-# 3. Start Docker environment
+# 4. Start Docker environment
 docker compose up -d --wait
 
-# 4. Get the port and open in browser
+# 5. Get the port and open in browser
 docker compose port openemr 80
 # Visit http://localhost:PORT and login with admin/pass
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -272,6 +272,12 @@ tasks:
     - composer update
     - echo "✅ Composer dependencies updated"
 
+  tools:install:
+    desc: Install OpenEMR source under tools/openemr (for PHPStan + Docker bind mount)
+    cmds:
+    - composer install --working-dir=tools/openemr
+    - echo "✅ OpenEMR source installed under tools/openemr/vendor/openemr/openemr"
+
   docs:sinch:
     desc: Fetch latest Sinch API documentation for AI agents
     cmds:
@@ -280,12 +286,12 @@ tasks:
     - echo "✅ Sinch API docs updated in .local/llms.txt"
 
   openemr:prebuild:
-    desc: Pre-build OpenEMR dependencies (speeds up first Docker start)
+    desc: Pre-build OpenEMR dependencies in tools/openemr (speeds up first Docker start)
     cmds:
     - echo "Building OpenEMR dependencies..."
-    - cd vendor/openemr/openemr && composer install --no-dev
-    - cd vendor/openemr/openemr && npm install --legacy-peer-deps
-    - cd vendor/openemr/openemr && npm run build
+    - cd tools/openemr/vendor/openemr/openemr && composer install --no-dev
+    - cd tools/openemr/vendor/openemr/openemr && npm install --legacy-peer-deps
+    - cd tools/openemr/vendor/openemr/openemr && npm run build
     - echo "✅ OpenEMR dependencies built"
 
   git:clean:
@@ -296,27 +302,29 @@ tasks:
     - echo "✅ Untracked files removed (preserved .local/)"
 
   vendor:clean:
-    desc: Remove vendor directory (forces complete reinstall of dependencies)
-    prompt: This will DELETE the entire vendor directory. Continue?
+    desc: Remove vendor directories (root and tools/openemr) — forces complete reinstall
+    prompt: This will DELETE the root vendor/ AND tools/openemr/vendor/ directories. Continue?
     preconditions:
     - sh: test -z "$(docker compose volumes -q)"
       msg: |
         ❌ Docker volumes still exist. You must run 'task dev:purge' first.
 
-        Reason: OpenEMR stores crypto keys in both the database (volume) and filesystem (vendor).
-        Removing vendor without removing volumes will break encryption and make the database unusable.
+        Reason: OpenEMR stores crypto keys in both the database (volume) and filesystem
+        (tools/openemr/vendor/openemr/openemr/sites). Removing the OpenEMR vendor without
+        removing volumes will break encryption and make the database unusable.
 
         Run: task workflow:nuke (to remove both) or task dev:purge (then task vendor:clean)
     cmds:
-    - git clean -fdx vendor/
-    - echo "✅ Vendor directory removed"
+    - git clean -fdx vendor/ tools/openemr/vendor/
+    - echo "✅ Vendor directories removed (root + tools/openemr)"
 
   # === Quick Workflows ===
 
   setup:
-    desc: Complete setup (install deps, prebuild OpenEMR, start Docker)
+    desc: Complete setup (install deps + tools, prebuild OpenEMR, start Docker)
     cmds:
     - task: composer:install
+    - task: tools:install
     - task: openemr:prebuild
     - task: dev:start
     - task: dev:port

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -287,6 +287,8 @@ tasks:
 
   openemr:prebuild:
     desc: Pre-build OpenEMR dependencies in tools/openemr (speeds up first Docker start)
+    deps:
+    - tools:install
     cmds:
     - echo "Building OpenEMR dependencies..."
     - cd tools/openemr/vendor/openemr/openemr && composer install --no-dev

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -323,10 +323,11 @@ tasks:
   # === Quick Workflows ===
 
   setup:
-    desc: Complete setup (install deps + tools, prebuild OpenEMR, start Docker)
+    desc: Complete setup (install deps, prebuild OpenEMR, start Docker)
     cmds:
     - task: composer:install
-    - task: tools:install
+    # openemr:prebuild deps on tools:install, so the OpenEMR source is
+    # installed transitively — no need to call tools:install here too.
     - task: openemr:prebuild
     - task: dev:start
     - task: dev:port

--- a/compose.yml
+++ b/compose.yml
@@ -106,5 +106,4 @@ services:
 
 volumes:
   databasevolume: {}
-  sitesvolume: {}
   logvolume: {}

--- a/compose.yml
+++ b/compose.yml
@@ -2,19 +2,21 @@
 # Uses a simplified entrypoint that just runs the installer and starts Apache
 # (avoids the slow chown operations in the standard openemr.sh entrypoint)
 #
-# IMPORTANT: Pre-build OpenEMR dependencies locally for faster startup:
-#   cd vendor/openemr/openemr
-#   composer install --no-dev
-#   npm install --legacy-peer-deps && npm run build
-#   cd ../../..
+# OpenEMR source lives under tools/openemr/vendor/openemr/openemr (NOT the root
+# vendor/) — see tools/openemr/README.md and issue #118 for why.
 #
-# Usage:
-#   1. composer install (installs module + downloads OpenEMR source)
-#   2. Pre-build OpenEMR (see above - optional but recommended)
-#   3. docker compose up -d --wait
-#   4. docker compose port openemr 80  (get assigned port)
-#   5. Login: admin / pass
-#   6. Admin > Modules > Manage Modules > Enable module
+# Usage (or just run `task setup`, which does all of this):
+#   1. composer install                                        (module deps)
+#   2. composer install --working-dir=tools/openemr            (OpenEMR source)
+#   3. Pre-build OpenEMR (optional — speeds up first start):
+#        cd tools/openemr/vendor/openemr/openemr
+#        composer install --no-dev
+#        npm install --legacy-peer-deps && npm run build
+#        cd -
+#   4. docker compose up -d --wait
+#   5. docker compose port openemr 80  (get assigned port)
+#   6. Login: admin / pass
+#   7. Admin > Modules > Manage Modules > Enable module
 
 services:
   mysql:
@@ -47,9 +49,14 @@ services:
       # Custom entrypoint scripts (installer + apache, no complex setup)
     - ./docker/entrypoint.sh:/custom-entrypoint.sh:ro
     - ./docker/entrypoint.php:/custom-entrypoint.php:ro
-      # Mount OpenEMR directly to runtime location (pre-built with composer/npm)
-    - ./vendor/openemr/openemr:/var/www/localhost/htdocs/openemr:rw
-      # Mount our module into the custom_modules directory
+      # Mount OpenEMR directly to runtime location (pre-built with composer/npm).
+      # NOTE: source is tools/openemr/vendor/..., NOT root vendor/ — see issue #118.
+    - ./tools/openemr/vendor/openemr/openemr:/var/www/localhost/htdocs/openemr:rw
+      # Mount our module into the custom_modules directory.
+      # The whole worktree (including tools/openemr/vendor/openemr/openemr/) is
+      # re-exposed at a nested path here. That's harmless: the module's
+      # vendor/autoload.php no longer registers any OpenEMR\\ PSR-4 mapping,
+      # so the nested copy is never autoloaded.
     - .:/var/www/localhost/htdocs/openemr/interface/modules/custom_modules/oce-module-sinch-conversations:rw
       # Persistent volume for logs only (sites uses bind mount for dev)
     - logvolume:/var/log

--- a/composer.json
+++ b/composer.json
@@ -48,65 +48,11 @@
     "ergebnis/composer-normalize": "^2.44",
     "maglnet/composer-require-checker": "^4.0",
     "opencoreemr/openemr-phpstan-rules": "^0.9",
-    "openemr/openemr": ">=8.0.0 || 8.1.0.x-dev || dev-master",
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^11.0",
     "rector/rector": "^2.0",
     "squizlabs/php_codesniffer": "^4.0"
   },
-  "repositories": [
-    {
-      "type": "package",
-      "package": {
-        "name": "openemr/openemr",
-        "version": "8.0.0",
-        "autoload": {
-          "psr-4": {
-            "OpenEMR\\": "src/"
-          }
-        },
-        "source": {
-          "type": "git",
-          "url": "https://github.com/openemr/openemr.git",
-          "reference": "v8_0_0"
-        }
-      }
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "openemr/openemr",
-        "version": "8.1.0.x-dev",
-        "autoload": {
-          "psr-4": {
-            "OpenEMR\\": "src/"
-          }
-        },
-        "source": {
-          "type": "git",
-          "url": "https://github.com/openemr/openemr.git",
-          "reference": "rel-810"
-        }
-      }
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "openemr/openemr",
-        "version": "dev-master",
-        "autoload": {
-          "psr-4": {
-            "OpenEMR\\": "src/"
-          }
-        },
-        "source": {
-          "type": "git",
-          "url": "https://github.com/openemr/openemr.git",
-          "reference": "master"
-        }
-      }
-    }
-  ],
   "minimum-stability": "dev",
   "prefer-stable": true,
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,11 @@
     "php-lint": "git ls-files -z '*.php' | xargs -0 -n1 php -l",
     "phpcbf": "phpcbf",
     "phpcs": "phpcs",
-    "phpstan": "phpstan --memory-limit=1g analyse",
+    "phpstan": [
+      "@phpstan-ensure-tools",
+      "phpstan --memory-limit=1g analyse"
+    ],
+    "phpstan-ensure-tools": "test -f tools/openemr/vendor/autoload.php || composer install --working-dir=tools/openemr --no-progress --no-interaction",
     "phpunit": "phpunit --testdox",
     "phpunit-coverage": "phpunit --coverage-html htmlcov --coverage-text",
     "rector": "rector process --dry-run",

--- a/docker/README.md
+++ b/docker/README.md
@@ -110,10 +110,13 @@ cd tools/openemr/vendor/openemr/openemr && composer install --no-dev && npm inst
   - Skips slow `chown` operations that take 5-10 minutes on macOS bind mounts
   - Much faster startup (~30 seconds instead of 10 minutes)
 - **Pre-built OpenEMR**: Mount pre-built OpenEMR from `tools/openemr/vendor/openemr/openemr`
-  - Run `composer install --no-dev` and `npm install && npm run build` locally first
+  - Run `composer install --no-dev` and `npm install --legacy-peer-deps && npm run build` locally first
   - Container uses pre-built artifacts, no need to rebuild inside Docker
   - OpenEMR is here (not under root `vendor/`) on purpose — see "Why is OpenEMR under `tools/openemr/`?" above
-- **Persistent data**: Patient data, configurations, and uploads live in `sitesvolume` Docker volume
+- **Persistent data**: Patient data, configurations, and uploads live on the host
+  inside `tools/openemr/vendor/openemr/openemr/sites/` (bind-mounted into the
+  container). Database data lives in the `databasevolume` Docker volume.
   - Survives container restarts
-  - Use `docker compose down -v` to completely reset
+  - `docker compose down -v` resets the database volume; to fully reset, also
+    delete `tools/openemr/vendor/openemr/openemr/sites/` (or run `task workflow:nuke`)
 - **Live reload**: Code changes are immediately reflected since bind mounts update in real-time

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,24 +10,35 @@ This directory contains Docker configuration for testing the Sinch Conversations
 # 1. Install module dependencies
 composer install
 
-# 2. Build OpenEMR dependencies (OPTIONAL - speeds up first start)
+# 2. Install OpenEMR source under tools/openemr (used by PHPStan + this Docker mount)
+composer install --working-dir=tools/openemr
+
+# 3. Build OpenEMR dependencies (OPTIONAL - speeds up first start)
 #    If you skip this, the container will build them automatically (slower)
-cd vendor/openemr/openemr
+cd tools/openemr/vendor/openemr/openemr
 composer install --no-dev
 npm install --legacy-peer-deps
 npm run build
-cd ../../..
+cd -
 
-# 3. Start the environment
+# 4. Start the environment
 docker compose up -d --wait
 
-# 4. Get the assigned port
+# 5. Get the assigned port
 docker compose port openemr 80      # OpenEMR HTTP (e.g., 0.0.0.0:32768)
 
-# 5. Open browser to http://localhost:PORT and login
+# 6. Open browser to http://localhost:PORT and login
 ```
 
-**Pro Tip:** Pre-building OpenEMR's dependencies (step 2) saves ~5-10 minutes on first container start. The Docker entrypoint detects existing builds and skips rebuilding.
+(Or just run `task setup`, which does steps 1–5.)
+
+**Pro Tip:** Pre-building OpenEMR's dependencies (step 3) saves ~5-10 minutes on first container start. The Docker entrypoint detects existing builds and skips rebuilding.
+
+## Why is OpenEMR under `tools/openemr/` instead of `vendor/`?
+
+Because putting `openemr/openemr` in the module's root `composer.json` causes the module's `vendor/autoload.php` to register a PSR-4 mapping for `OpenEMR\\` → our vendor's `src/` alongside OpenEMR core's identical mapping. At runtime, class lookups can resolve to **our** vendor copy, and several OpenEMR classes use `__DIR__`-relative `require_once` to load procedural-function files. Loading the same file under a different absolute path bypasses `require_once`'s dedup → `Cannot redeclare …` fatal.
+
+The fix: keep OpenEMR source at `tools/openemr/vendor/openemr/openemr/`, where it's available to PHPStan (via `phpstan.neon`'s `bootstrapFiles`) and to this Docker bind mount, but **never** registered in the module's runtime autoloader. See [issue #118](https://github.com/openCoreEMR/oce-module-sinch-conversations/issues/118) and `tools/openemr/README.md`.
 
 ## Default Credentials
 
@@ -76,7 +87,7 @@ docker compose down -v
 docker compose restart openemr
 
 # Rebuild OpenEMR dependencies after updating OpenEMR version
-cd vendor/openemr/openemr && composer install --no-dev && npm install --legacy-peer-deps && npm run build && cd ../../..
+cd tools/openemr/vendor/openemr/openemr && composer install --no-dev && npm install --legacy-peer-deps && npm run build && cd -
 ```
 
 **Note:** We use `docker compose exec` to run commands in already-running containers:
@@ -98,9 +109,10 @@ cd vendor/openemr/openemr && composer install --no-dev && npm install --legacy-p
   - Starts Apache immediately
   - Skips slow `chown` operations that take 5-10 minutes on macOS bind mounts
   - Much faster startup (~30 seconds instead of 10 minutes)
-- **Pre-built OpenEMR**: Mount pre-built OpenEMR from `vendor/openemr/openemr`
+- **Pre-built OpenEMR**: Mount pre-built OpenEMR from `tools/openemr/vendor/openemr/openemr`
   - Run `composer install --no-dev` and `npm install && npm run build` locally first
   - Container uses pre-built artifacts, no need to rebuild inside Docker
+  - OpenEMR is here (not under root `vendor/`) on purpose — see "Why is OpenEMR under `tools/openemr/`?" above
 - **Persistent data**: Patient data, configurations, and uploads live in `sitesvolume` Docker volume
   - Survives container restarts
   - Use `docker compose down -v` to completely reset

--- a/docs/development/openemr-integration.md
+++ b/docs/development/openemr-integration.md
@@ -34,18 +34,18 @@ private function redirect(Request $request): RedirectResponse
 
 ## Researching OpenEMR Code and Dependencies
 
-**CRITICAL: Always check OpenEMR's actual requirements in `vendor/openemr/openemr/composer.json`**
+**CRITICAL: Always check OpenEMR's actual requirements in `tools/openemr/vendor/openemr/openemr/composer.json`**
 
 When you need to understand OpenEMR's code, dependencies, or version constraints:
 
 ### Always Do:
-- **Check `vendor/openemr/openemr/composer.json`** for OpenEMR's exact dependency versions
-- **Look in `vendor/openemr/openemr/src/`** for OpenEMR core classes
+- **Check `tools/openemr/vendor/openemr/openemr/composer.json`** for OpenEMR's exact dependency versions
+- **Look in `tools/openemr/vendor/openemr/openemr/src/`** for OpenEMR core classes
 - **Match OpenEMR's Symfony version constraints** - They use exact versions (e.g., `6.4.15`), not ranges
 - **Use `^6.4` constraints** for Symfony packages to stay compatible with OpenEMR 6.4.x
 
 ### Never Do:
-- Search online for OpenEMR version requirements -> Check `vendor/openemr/openemr/composer.json`
+- Search online for OpenEMR version requirements -> Check `tools/openemr/vendor/openemr/openemr/composer.json`
 - Guess at version constraints -> Verify against OpenEMR's actual versions
 - Use `^6.0 || ^7.0` for Symfony -> Use `^6.4` to match OpenEMR's 6.4.x versions
 - Assume OpenEMR uses latest versions -> They pin specific versions
@@ -54,7 +54,7 @@ When you need to understand OpenEMR's code, dependencies, or version constraints
 
 ```bash
 # Check what Symfony versions OpenEMR uses
-cat vendor/openemr/openemr/composer.json | grep symfony
+cat tools/openemr/vendor/openemr/openemr/composer.json | grep symfony
 
 # Result shows exact versions:
 # "symfony/console": "6.4.15",
@@ -85,7 +85,7 @@ Always include these in `composer.json` with version constraints that match Open
 }
 ```
 
-**Note:** Version constraints must match OpenEMR's installed versions. Always verify in `vendor/openemr/openemr/composer.json`.
+**Note:** Version constraints must match OpenEMR's installed versions. Always verify in `tools/openemr/vendor/openemr/openemr/composer.json`.
 
 ## Composer Require Checker Configuration
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,9 +16,15 @@ parameters:
     # PHP version
     phpVersion: 80200
 
+    # OpenEMR source lives in the tooling sub-vendor (see tools/openemr/README.md
+    # and issue #118). Load its autoloader so PHPStan can resolve OpenEMR\… types.
+    bootstrapFiles:
+        - tools/openemr/vendor/autoload.php
+
     # Ignore errors in vendor (optional - may not exist in worktrees)
     excludePaths:
         - vendor (?)
+        - tools/openemr/vendor (?)
 
     # Additional checks
     checkMissingCallableSignature: true

--- a/src/Module/Console/Command/AbstractModuleCommand.php
+++ b/src/Module/Console/Command/AbstractModuleCommand.php
@@ -116,7 +116,9 @@ abstract class AbstractModuleCommand extends Command
         $candidates = [
             // Docker container path (when module is symlinked into OpenEMR)
             '/var/www/localhost/htdocs/openemr',
-            // Development: module has OpenEMR as a composer dependency
+            // Development: OpenEMR installed under tools/openemr (current layout — see issue #118)
+            __DIR__ . '/../../../../tools/openemr/vendor/openemr/openemr',
+            // Development: module has OpenEMR as a (legacy) composer dependency
             __DIR__ . '/../../../../vendor/openemr/openemr',
             __DIR__ . '/../../../../../vendor/openemr/openemr',
             // Development: module is inside OpenEMR's custom_modules

--- a/tests/Mocks/MockGlobalSetting.php
+++ b/tests/Mocks/MockGlobalSetting.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Mock GlobalSetting for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Globals;
+
+/**
+ * Minimal stand-in for OpenEMR's GlobalSetting — preserves the constants and
+ * format() shape exercised by GlobalsRegistrar and module tests. See issue #118
+ * and tools/openemr/README.md.
+ */
+class GlobalSetting
+{
+    public const DATA_TYPE_BOOL = 'bool';
+    public const DATA_TYPE_TEXT = 'text';
+    public const DATA_TYPE_PASS = 'pass';
+    public const DATA_TYPE_ENCRYPTED = 'encrypted';
+    public const DATA_TYPE_NUMBER = 'num';
+    public const DATA_TYPE_HTML_DISPLAY_SECTION = 'html_display_section';
+    public const DATA_TYPE_MULTI_SORTED_LIST_SELECTOR = 'multi_sorted_list_selector';
+
+    public const DATA_TYPE_OPTION_LIST_ID = 'list_id';
+    public const DATA_TYPE_OPTION_RENDER_CALLBACK = 'render_callback';
+
+    public const DATA_TYPES_WITH_OPTIONS = [
+        self::DATA_TYPE_MULTI_SORTED_LIST_SELECTOR,
+        self::DATA_TYPE_HTML_DISPLAY_SECTION,
+    ];
+
+    public const DATA_TYPE_FIELD_OPTIONS_SUPPORTED = [
+        self::DATA_TYPE_MULTI_SORTED_LIST_SELECTOR => [self::DATA_TYPE_OPTION_LIST_ID],
+        self::DATA_TYPE_HTML_DISPLAY_SECTION => [self::DATA_TYPE_OPTION_RENDER_CALLBACK],
+    ];
+
+    /** @var array<string, mixed> */
+    protected array $fieldOptions = [];
+
+    public function __construct(
+        protected mixed $label,
+        protected string $dataType,
+        protected mixed $default,
+        protected mixed $description,
+        protected bool $isUserSetting = false,
+    ) {
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function format(): array
+    {
+        $result = [$this->label, $this->dataType, $this->default, $this->description];
+        if (count($this->fieldOptions) > 0) {
+            $result[] = $this->fieldOptions;
+        }
+        return $result;
+    }
+
+    public function isUserSetting(): bool
+    {
+        return $this->isUserSetting;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFieldOptions(): array
+    {
+        return $this->fieldOptions;
+    }
+
+    public function addFieldOption(string $key, mixed $option): void
+    {
+        if (!$this->dataTypeSupportsOptions($this->dataType)) {
+            throw new \InvalidArgumentException('Data type does not support field options');
+        }
+        if (!$this->dataTypeSupportsOptionKey($this->dataType, $key)) {
+            throw new \InvalidArgumentException('Data type does not support field option key ' . $key);
+        }
+        $this->fieldOptions[$key] = $option;
+    }
+
+    public function dataTypeSupportsOptions(string $dataType): bool
+    {
+        return in_array($dataType, self::DATA_TYPES_WITH_OPTIONS, true);
+    }
+
+    public function dataTypeSupportsOptionKey(string $dataType, string $key): bool
+    {
+        if (!$this->dataTypeSupportsOptions($dataType)) {
+            return false;
+        }
+        return in_array($key, self::DATA_TYPE_FIELD_OPTIONS_SUPPORTED[$dataType], true);
+    }
+}

--- a/tests/Mocks/MockGlobalsInitializedEvent.php
+++ b/tests/Mocks/MockGlobalsInitializedEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Mock GlobalsInitializedEvent for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Globals;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Minimal stand-in for OpenEMR's GlobalsInitializedEvent. Real implementation
+ * lives in tools/openemr/vendor/openemr/openemr/src/Events/Globals/. See
+ * issue #118 and tools/openemr/README.md for why OpenEMR isn't on the runtime
+ * autoloader.
+ */
+class GlobalsInitializedEvent extends Event
+{
+    public const EVENT_HANDLE = 'globals.initialized';
+
+    private ?object $globalsService;
+
+    public function __construct(?object $globalsService = null)
+    {
+        $this->globalsService = $globalsService;
+    }
+
+    public function getGlobalsService(): ?object
+    {
+        return $this->globalsService;
+    }
+}

--- a/tests/Mocks/MockGlobalsInitializedEvent.php
+++ b/tests/Mocks/MockGlobalsInitializedEvent.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Events\Globals;
 
+use OpenEMR\Services\Globals\GlobalsService;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -26,14 +27,11 @@ class GlobalsInitializedEvent extends Event
 {
     public const EVENT_HANDLE = 'globals.initialized';
 
-    private ?object $globalsService;
-
-    public function __construct(?object $globalsService = null)
+    public function __construct(private readonly GlobalsService $globalsService)
     {
-        $this->globalsService = $globalsService;
     }
 
-    public function getGlobalsService(): ?object
+    public function getGlobalsService(): GlobalsService
     {
         return $this->globalsService;
     }

--- a/tests/Mocks/MockGlobalsService.php
+++ b/tests/Mocks/MockGlobalsService.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Mock GlobalsService for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Services\Globals;
+
+/**
+ * Minimal stand-in for OpenEMR's GlobalsService — just enough surface for the
+ * GlobalsRegistrar pipeline used in this module's tests. See issue #118 and
+ * tools/openemr/README.md.
+ */
+class GlobalsService
+{
+    /**
+     * @param array<string, array<string, mixed>> $globalsMetadata
+     * @param array<int, string> $userSpecificGlobals
+     * @param array<int, string> $userSpecificTabs
+     */
+    public function __construct(
+        private array $globalsMetadata = [],
+        private array $userSpecificGlobals = [],
+        private array $userSpecificTabs = [],
+    ) {
+    }
+
+    public function createSection(string $section, bool|string $beforeSection = false): void
+    {
+        if (!isset($this->globalsMetadata[$section])) {
+            $this->globalsMetadata[$section] = [];
+        }
+    }
+
+    public function appendToSection(string $section, string $key, GlobalSetting $global): void
+    {
+        $this->globalsMetadata[$section][$key] = $global->format();
+        if ($global->isUserSetting()) {
+            $this->userSpecificGlobals[] = $key;
+        }
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function getGlobalsMetadata(): array
+    {
+        return $this->globalsMetadata;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getUserSpecificGlobals(): array
+    {
+        return $this->userSpecificGlobals;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getUserSpecificTabs(): array
+    {
+        return $this->userSpecificTabs;
+    }
+}

--- a/tests/Mocks/MockMenuEvent.php
+++ b/tests/Mocks/MockMenuEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Mock MenuEvent for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Menu;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Minimal stand-in for OpenEMR's MenuEvent. See issue #118 and
+ * tools/openemr/README.md.
+ */
+class MenuEvent extends Event
+{
+    public const MENU_UPDATE = 'menu.update';
+    public const MENU_RESTRICT = 'menu.restrict';
+
+    /**
+     * @param array<int|string, mixed> $menu
+     */
+    public function __construct(private array $menu = [])
+    {
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function getMenu(): array
+    {
+        return $this->menu;
+    }
+
+    /**
+     * @param array<int|string, mixed> $menu
+     */
+    public function setMenu(array $menu): void
+    {
+        $this->menu = $menu;
+    }
+}

--- a/tests/Mocks/MockOEGlobalsBag.php
+++ b/tests/Mocks/MockOEGlobalsBag.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Mock OEGlobalsBag for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Core;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * Minimal stand-in for OpenEMR's singleton globals bag. The real implementation
+ * lives in tools/openemr/vendor/openemr/openemr/src/Core/OEGlobalsBag.php and is
+ * intentionally not on the runtime autoloader (see issue #118 and
+ * tools/openemr/README.md). This mock provides just enough surface for module
+ * code under test to construct and call into.
+ */
+class OEGlobalsBag extends ParameterBag
+{
+    private static ?OEGlobalsBag $instance = null;
+
+    public static function getInstance(): OEGlobalsBag
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+
+    /**
+     * Fall back to $GLOBALS, mirroring the real OEGlobalsBag so module code
+     * that reads config via $GLOBALS[...] (e.g. tests setting
+     * $GLOBALS['oce_sinch_conversations_enabled'] = '1') still resolves.
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (!parent::has($key) && array_key_exists($key, $GLOBALS)) {
+            return $GLOBALS[$key];
+        }
+        return parent::get($key, $default);
+    }
+
+    public function has(string $key): bool
+    {
+        if (parent::has($key)) {
+            return true;
+        }
+        return array_key_exists($key, $GLOBALS);
+    }
+}

--- a/tests/Mocks/MockPatientCreatedEvent.php
+++ b/tests/Mocks/MockPatientCreatedEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Mock PatientCreatedEvent for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Patient;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Minimal stand-in for OpenEMR's PatientCreatedEvent. See issue #118 and
+ * tools/openemr/README.md.
+ */
+class PatientCreatedEvent extends Event
+{
+    public const EVENT_HANDLE = 'patient.created';
+
+    /**
+     * @param array<string, mixed> $patientData
+     */
+    public function __construct(private array $patientData)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPatientData(): array
+    {
+        return $this->patientData;
+    }
+
+    /**
+     * @param array<string, mixed> $patientData
+     */
+    public function setPatientData(array $patientData): void
+    {
+        $this->patientData = $patientData;
+    }
+}

--- a/tests/Mocks/MockPatientUpdatedEvent.php
+++ b/tests/Mocks/MockPatientUpdatedEvent.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Mock PatientUpdatedEvent for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Events\Patient;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Minimal stand-in for OpenEMR's PatientUpdatedEvent. See issue #118 and
+ * tools/openemr/README.md.
+ */
+class PatientUpdatedEvent extends Event
+{
+    public const EVENT_HANDLE = 'patient.updated';
+
+    /**
+     * @param array<string, mixed> $dataBeforeUpdate
+     * @param array<string, mixed> $newPatientData
+     */
+    public function __construct(private array $dataBeforeUpdate, private array $newPatientData)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getDataBeforeUpdate(): array
+    {
+        return $this->dataBeforeUpdate;
+    }
+
+    /**
+     * @param array<string, mixed> $dataBeforeUpdate
+     */
+    public function setDataBeforeUpdate(array $dataBeforeUpdate): void
+    {
+        $this->dataBeforeUpdate = $dataBeforeUpdate;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getNewPatientData(): array
+    {
+        return $this->newPatientData;
+    }
+
+    /**
+     * @param array<string, mixed> $newPatientData
+     */
+    public function setNewPatientData(array $newPatientData): void
+    {
+        $this->newPatientData = $newPatientData;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,10 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Suppress error_log output during tests by redirecting to null
 ini_set('error_log', '/dev/null');
 
-// Load mock classes before anything else to prevent "class not found" errors
+// Load mock classes before anything else to prevent "class not found" errors.
+// OpenEMR\… classes referenced from the module's runtime code must be mocked
+// here because openemr/openemr is intentionally NOT on the runtime autoloader
+// (see issue #118 and tools/openemr/README.md).
 require_once __DIR__ . '/Mocks/MockKernel.php';
 require_once __DIR__ . '/Mocks/MockTwigContainer.php';
 require_once __DIR__ . '/Mocks/MockSystemLogger.php';
@@ -28,6 +31,13 @@ require_once __DIR__ . '/Mocks/MockQueryUtils.php';
 require_once __DIR__ . '/Mocks/MockCryptoGen.php';
 require_once __DIR__ . '/Mocks/MockCsrfUtils.php';
 require_once __DIR__ . '/Mocks/MockModulesClassLoader.php';
+require_once __DIR__ . '/Mocks/MockOEGlobalsBag.php';
+require_once __DIR__ . '/Mocks/MockGlobalsInitializedEvent.php';
+require_once __DIR__ . '/Mocks/MockPatientCreatedEvent.php';
+require_once __DIR__ . '/Mocks/MockPatientUpdatedEvent.php';
+require_once __DIR__ . '/Mocks/MockMenuEvent.php';
+require_once __DIR__ . '/Mocks/MockGlobalSetting.php';
+require_once __DIR__ . '/Mocks/MockGlobalsService.php';
 
 // Define OpenEMR global functions used in controllers and Bootstrap
 if (!function_exists('xl')) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,10 +20,11 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Suppress error_log output during tests by redirecting to null
 ini_set('error_log', '/dev/null');
 
-// Load mock classes before anything else to prevent "class not found" errors.
-// OpenEMR\… classes referenced from the module's runtime code must be mocked
-// here because openemr/openemr is intentionally NOT on the runtime autoloader
-// (see issue #118 and tools/openemr/README.md).
+// Declare mock classes before any test code runs so that subsequent references
+// to OpenEMR\… classes (via the Composer autoloader registered above) find the
+// mock already in place and never trigger autoload of the real class. OpenEMR
+// types must be mocked here because openemr/openemr is intentionally NOT on
+// the runtime autoloader (see issue #118 and tools/openemr/README.md).
 require_once __DIR__ . '/Mocks/MockKernel.php';
 require_once __DIR__ . '/Mocks/MockTwigContainer.php';
 require_once __DIR__ . '/Mocks/MockSystemLogger.php';

--- a/tools/openemr/.gitignore
+++ b/tools/openemr/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock

--- a/tools/openemr/README.md
+++ b/tools/openemr/README.md
@@ -5,7 +5,7 @@ This directory exists so the OpenEMR source tree is available **outside** the mo
 It serves two purposes:
 
 1. **PHPStan type resolution.** `phpstan.neon` loads `tools/openemr/vendor/autoload.php` via `bootstrapFiles`, so PHPStan can resolve `OpenEMR\…` symbols.
-2. **Local Docker bind mount.** `compose.yml` bind-mounts `./tools/openemr/vendor/openemr/openemr` to `/var/www/localhost/htdocs/openemr` inside the dev container. `task openemr:prebuild` runs `composer install --no-dev` and `npm install && npm run build` here so the dev container starts quickly.
+2. **Local Docker bind mount.** `compose.yml` bind-mounts `./tools/openemr/vendor/openemr/openemr` to `/var/www/localhost/htdocs/openemr` inside the dev container. `task openemr:prebuild` runs `composer install --no-dev` and `npm install --legacy-peer-deps && npm run build` here so the dev container starts quickly.
 
 ## Why not put `openemr/openemr` in the root `composer.json`?
 

--- a/tools/openemr/README.md
+++ b/tools/openemr/README.md
@@ -1,0 +1,26 @@
+# tools/openemr — OpenEMR source for tooling and dev runtime
+
+This directory exists so the OpenEMR source tree is available **outside** the module's runtime composer tree.
+
+It serves two purposes:
+
+1. **PHPStan type resolution.** `phpstan.neon` loads `tools/openemr/vendor/autoload.php` via `bootstrapFiles`, so PHPStan can resolve `OpenEMR\…` symbols.
+2. **Local Docker bind mount.** `compose.yml` bind-mounts `./tools/openemr/vendor/openemr/openemr` to `/var/www/localhost/htdocs/openemr` inside the dev container. `task openemr:prebuild` runs `composer install --no-dev` and `npm install && npm run build` here so the dev container starts quickly.
+
+## Why not put `openemr/openemr` in the root `composer.json`?
+
+If `openemr/openemr` is in the root `require-dev`, then `vendor/openemr/openemr/` exists after `composer install` and our `vendor/autoload.php` registers a PSR-4 mapping for `OpenEMR\\` → our vendor's `src/`. At runtime, `OpenEMR\…` class lookups can resolve to **our** vendor copy instead of OpenEMR core's canonical path. Several OpenEMR classes do `require_once(__DIR__ . '/../../../library/lists.inc.php');`; `__DIR__` then points into our vendor tree, the file is loaded under a different absolute path than OpenEMR core already loaded it, and `require_once` (which dedups by string path, not content) re-runs the procedural function definitions. Result: `Cannot redeclare …` fatal on any page that exercises the affected classes.
+
+See [issue #118](https://github.com/openCoreEMR/oce-module-sinch-conversations/issues/118) for the full incident.
+
+## Usage
+
+The Taskfile drives everything:
+
+```bash
+task tools:install    # install OpenEMR source here
+task openemr:prebuild # composer install --no-dev + npm install + npm run build inside it
+task setup            # the full first-time bring-up (calls both of the above)
+```
+
+`tools/openemr/vendor/` and `tools/openemr/composer.lock` are gitignored.

--- a/tools/openemr/README.md
+++ b/tools/openemr/README.md
@@ -19,7 +19,7 @@ The Taskfile drives everything:
 
 ```bash
 task tools:install    # install OpenEMR source here
-task openemr:prebuild # composer install --no-dev + npm install + npm run build inside it
+task openemr:prebuild # composer install --no-dev + npm install --legacy-peer-deps + npm run build inside it
 task setup            # the full first-time bring-up (calls both of the above)
 ```
 

--- a/tools/openemr/composer.json
+++ b/tools/openemr/composer.json
@@ -1,0 +1,69 @@
+{
+  "name": "opencoreemr/oce-module-sinch-conversations-tools-openemr",
+  "description": "OpenEMR source tree for static analysis (PHPStan) and the local Docker bind mount. Not a runtime dependency of the module \u2014 see issue #118.",
+  "type": "project",
+  "license": "GPL-3.0-or-later",
+  "require": {
+    "openemr/openemr": ">=8.0.0 || 8.1.0.x-dev || dev-master"
+  },
+  "repositories": [
+    {
+      "type": "package",
+      "package": {
+        "name": "openemr/openemr",
+        "version": "8.0.0",
+        "autoload": {
+          "psr-4": {
+            "OpenEMR\\": "src/"
+          }
+        },
+        "source": {
+          "type": "git",
+          "url": "https://github.com/openemr/openemr.git",
+          "reference": "v8_0_0"
+        }
+      }
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "openemr/openemr",
+        "version": "8.1.0.x-dev",
+        "autoload": {
+          "psr-4": {
+            "OpenEMR\\": "src/"
+          }
+        },
+        "source": {
+          "type": "git",
+          "url": "https://github.com/openemr/openemr.git",
+          "reference": "rel-810"
+        }
+      }
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "openemr/openemr",
+        "version": "dev-master",
+        "autoload": {
+          "psr-4": {
+            "OpenEMR\\": "src/"
+          }
+        },
+        "source": {
+          "type": "git",
+          "url": "https://github.com/openemr/openemr.git",
+          "reference": "master"
+        }
+      }
+    }
+  ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "config": {
+    "allow-plugins": {
+      "openemr/oe-module-installer-plugin": false
+    }
+  }
+}


### PR DESCRIPTION
Closes #118.

## Summary

Move `openemr/openemr` out of the runtime composer tree into a tooling sub-composer at `tools/openemr/`. PHPStan loads its autoloader via `bootstrapFiles`; `compose.yml` bind-mounts from there for local dev. The module's runtime `vendor/autoload.php` no longer registers an `OpenEMR\\` PSR-4 mapping, so class lookups can't resolve to our vendor copy and the `Cannot redeclare collect_issue_type_category()` fatal on patient demographics goes away.

See #118 for the full root-cause analysis (PSR-4 autoloader collision + `__DIR__`-relative `require_once` dedup).

## Changes

- `composer.json`: remove `openemr/openemr` from `require-dev` and the three `repositories` entries
- `tools/openemr/{composer.json,.gitignore,README.md}`: new sub-composer that installs OpenEMR at `tools/openemr/vendor/openemr/openemr/`
- `phpstan.neon`: add `bootstrapFiles: tools/openemr/vendor/autoload.php`
- `compose.yml`: re-source the OpenEMR bind mount; add a comment about the (harmless) re-mount overlay
- `Taskfile.yml`: new `tools:install`; `openemr:prebuild`/`setup`/`vendor:clean` updated for the new path
- `.github/workflows/phpstan.yml`: install the sub-vendor before running PHPStan
- `.gitignore`: ignore `/tools/openemr/vendor/`
- `tests/Mocks/Mock{OEGlobalsBag,GlobalsInitializedEvent,PatientCreatedEvent,PatientUpdatedEvent,MenuEvent,GlobalsService,GlobalSetting}.php`: replace the OpenEMR types tests previously got from the runtime root vendor (per #118: tests must not depend on a real OpenEMR install)
- Docs: `README.md`, `docker/README.md`, `docs/development/openemr-integration.md`, `.github/copilot-instructions.md`, `CLAUDE.md` — updated paths and a "why" note so this isn't reverted by accident

## Test plan

Local (already done):

- [x] After `composer install`, root `vendor/openemr/openemr/` is gone and `OpenEMR\\` no longer appears in `vendor/composer/autoload_psr4.php`
- [x] After `composer install --working-dir=tools/openemr`, `tools/openemr/vendor/openemr/openemr/` is populated
- [x] PHPStan: `composer phpstan` — OK No errors
- [x] PHPCS, Rector, composer-require-checker, composer-normalize: all green
- [x] PHPUnit: 424 tests, 1074 assertions, all pass
- [x] `pre-commit run -a`: all hooks pass

Manual (reviewer):

- [ ] `task workflow:nuke && task setup` from a fresh checkout produces a working dev OpenEMR
- [ ] `task module:install-enable`, then open a patient → demographics. Page renders; `docker compose logs openemr` has no `Cannot redeclare` fatal
- [ ] CI on this PR is green

## Follow-up (out of scope here)

- File an issue against `opencoreemr/oce-module-template` proposing the same `tools/openemr/` recipe so new modules adopt it without copy-paste
- Roll the pattern into existing OCE modules (per-module follow-ups)