### PR TITLE
fix: sync templates against Sinch v2 schema and surface real errors

### DIFF
--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -108,19 +108,23 @@ class TemplateSyncService
             } catch (\Throwable $e) {
                 $errorId = ErrorId::generate();
                 $results['failed']++;
+                // Surface upstream API messages so operators can see the validation
+                // reason (e.g. "Translation must specify a message"), but for any
+                // other exception class show a generic message + errorId — internal
+                // exceptions can leak file paths or other internals.
+                $uiMessage = $e instanceof ApiException
+                    ? $e->getMessage()
+                    : "Internal error (ref: $errorId)";
                 $results['errors'][] = [
                     'template_key' => $template['template_key'],
                     'errorId' => $errorId,
+                    'error' => $uiMessage,
                 ];
                 $this->logger->error('Failed to sync template', [
                     'templateKey' => $template['template_key'],
                     'errorId' => $errorId,
                     'exception' => ExceptionContext::fromThrowable($e),
                 ]);
-
-                // Stop on first failure
-                $this->logger->warning('Stopping template sync due to failure');
-                break;
             }
         }
 

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -596,6 +596,10 @@ class ConversationApiClient
             ];
         }
 
+        // Sinch Templates v2 takes the message body fields (e.g. `text_message`)
+        // as direct fields on the translation object, not wrapped in a `message`
+        // envelope. See https://developers.sinch.com/docs/conversation/templates.md
+        // (Version 2 example).
         return [
             'description' => $templateData['description'] ?? $templateData['template_name'],
             'default_translation' => 'en-US',
@@ -604,10 +608,8 @@ class ConversationApiClient
                     'language_code' => 'en-US',
                     'version' => '1',
                     'variables' => $variables,
-                    'message' => [
-                        'text_message' => [
-                            'text' => $this->convertTemplateVariables($templateData['body']),
-                        ],
+                    'text_message' => [
+                        'text' => $this->convertTemplateVariables($templateData['body']),
                     ],
                 ],
             ],

--- a/templates/settings/config.html.twig
+++ b/templates/settings/config.html.twig
@@ -340,14 +340,20 @@
                     alertDiv.className = 'alert ' + (data.success ? 'alert-success' : 'alert-warning');
                     alertDiv.textContent = data.message;
 
-                    // Show details if available
+                    // Show details if available — build with DOM nodes so error
+                    // strings (which originate from upstream APIs) cannot inject HTML.
                     if (data.details && data.details.errors && data.details.errors.length > 0) {
-                        let errorHtml = '<hr><strong>Errors:</strong><ul>';
+                        alertDiv.appendChild(document.createElement('hr'));
+                        const heading = document.createElement('strong');
+                        heading.textContent = {{ 'Errors:'|xlj }};
+                        alertDiv.appendChild(heading);
+                        const list = document.createElement('ul');
                         data.details.errors.forEach(error => {
-                            errorHtml += '<li>' + error.template_key + ': ' + error.error + '</li>';
+                            const item = document.createElement('li');
+                            item.textContent = error.template_key + ': ' + error.error;
+                            list.appendChild(item);
                         });
-                        errorHtml += '</ul>';
-                        alertDiv.innerHTML = data.message + errorHtml;
+                        alertDiv.appendChild(list);
                     }
                 })
                 .catch(error => {

--- a/tests/Unit/Client/ConversationApiClientTest.php
+++ b/tests/Unit/Client/ConversationApiClientTest.php
@@ -488,7 +488,46 @@ class ConversationApiClientTest extends TestCase
         $this->assertSame('new-tmpl', $result['id']);
         $body = json_decode((string) $this->requestHistory[1]['request']->getBody(), true);
         $this->assertSame('en-US', $body['default_translation']);
-        $this->assertStringContainsString('{{patient_name}}', $body['translations'][0]['message']['text_message']['text']);
+        $this->assertStringContainsString('{{patient_name}}', $body['translations'][0]['text_message']['text']);
+    }
+
+    /**
+     * Pin the Sinch Templates v2 request payload shape.
+     *
+     * v2 takes message body fields (e.g. `text_message`) as direct fields on
+     * the translation object, not wrapped in a `message` envelope. Sinch
+     * rejects the wrapped shape with HTTP 400 "Translation must specify a
+     * message." See https://developers.sinch.com/docs/conversation/templates.md
+     */
+    public function testCreateTemplateUsesV2TranslationShape(): void
+    {
+        $client = $this->createClientWithoutToken([
+            new Response(200, [], '{"access_token": "tmpl-token"}'),
+            new Response(200, [], '{"id": "tmpl-shape"}'),
+        ]);
+
+        $client->createTemplate([
+            'template_key' => 'shape_test',
+            'template_name' => 'Shape Test',
+            'description' => 'Pin v2 shape',
+            'body' => 'Hello {{ name }}',
+            'required_variables' => ['name'],
+        ]);
+
+        $body = json_decode((string) $this->requestHistory[1]['request']->getBody(), true);
+
+        $this->assertSame('Pin v2 shape', $body['description']);
+        $this->assertSame('en-US', $body['default_translation']);
+        $this->assertCount(1, $body['translations']);
+
+        $translation = $body['translations'][0];
+        $this->assertSame('en-US', $translation['language_code']);
+        $this->assertSame('1', $translation['version']);
+        $this->assertSame([['key' => 'name', 'preview_value' => 'Name']], $translation['variables']);
+
+        $this->assertArrayHasKey('text_message', $translation, 'text_message must be a direct field on the translation');
+        $this->assertSame('Hello {{name}}', $translation['text_message']['text']);
+        $this->assertArrayNotHasKey('message', $translation, 'v2 does not accept a message envelope');
     }
 
     // --- Retry logic tests ---

--- a/tests/Unit/Service/TemplateSyncServiceTest.php
+++ b/tests/Unit/Service/TemplateSyncServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Unit tests for TemplateSyncService
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
+use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
+use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class TemplateSyncServiceTest extends TestCase
+{
+    private GlobalConfig $config;
+    private ConversationApiClient&MockObject $apiClient;
+    private TemplateSyncService $service;
+
+    protected function setUp(): void
+    {
+        QueryUtils::clearQueries();
+        QueryUtils::clearMockResults();
+        SystemLogger::clearLogs();
+
+        $this->config = new GlobalConfig(new MockGlobalsAccessor([]), new MockConfigFactory());
+        $this->apiClient = $this->createMock(ConversationApiClient::class);
+        $this->service = new TemplateSyncService($this->config, $this->apiClient);
+    }
+
+    /**
+     * A failing template in the middle of the list must not abort the whole sync.
+     * Regression test for issue #121.
+     */
+    public function testSyncContinuesAfterTemplateFailure(): void
+    {
+        $this->apiClient->method('listTemplates')->willReturn([]);
+
+        // First create throws; subsequent ones succeed. Without the fix
+        // (the `break` after first failure), only one createTemplate call
+        // would be observed and `failed` would be 1 with all later templates
+        // counted as 0/0/0.
+        $createCalls = 0;
+        $this->apiClient->method('createTemplate')
+            ->willReturnCallback(function (array $template) use (&$createCalls): array {
+                $createCalls++;
+                if ($createCalls === 1) {
+                    throw new ApiException('Translation must specify a message.', 400);
+                }
+                return ['id' => 'sinch-tmpl-' . $createCalls];
+            });
+
+        $results = $this->service->syncAllTemplates();
+
+        $this->assertGreaterThan(1, $results['total'], 'fixture should have multiple templates');
+        $this->assertSame(1, $results['failed'], 'only the first template should be marked failed');
+        $this->assertSame($results['total'], $createCalls, 'every template after the failure was still attempted');
+
+        $this->assertCount(1, $results['errors']);
+        $error = $results['errors'][0];
+        $this->assertArrayHasKey('template_key', $error);
+        $this->assertArrayHasKey('errorId', $error);
+        $this->assertSame(
+            'Translation must specify a message.',
+            $error['error'],
+            'underlying exception message must be surfaced for the UI'
+        );
+    }
+
+    /**
+     * Non-API exceptions (e.g. internal TypeError) must NOT leak their message
+     * into the UI — only `ApiException` messages, which originate from the
+     * Sinch API and are safe operator-facing validation errors, are surfaced
+     * verbatim. Everything else gets a generic message + errorId.
+     */
+    public function testNonApiExceptionDoesNotLeakMessageToUi(): void
+    {
+        $this->apiClient->method('listTemplates')->willReturn([]);
+        $this->apiClient->method('createTemplate')
+            ->willThrowException(new RuntimeException('/var/www/html/secret/path/to/internal.php on line 42'));
+
+        $results = $this->service->syncAllTemplates();
+
+        $error = $results['errors'][0];
+        $this->assertStringNotContainsString('/var/www/html', $error['error']);
+        $this->assertStringContainsString($error['errorId'], $error['error']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #121.

Two bugs prevented the **Sync Templates** action from working:

- `ConversationApiClient::formatTemplateForSinch()` wrapped `text_message` inside a `message` envelope. Sinch v2 puts message body fields directly on the translation object — the wrapped shape is rejected with HTTP 400 *"Translation must specify a message."*
- `TemplateSyncService::syncAllTemplates()` had a `break` after the first failure, so a single bad template prevented the other 13 from syncing. Drop the `break` and continue accumulating errors.

The `errors[]` entry now carries `$e->getMessage()` so the Settings UI shows the real reason instead of "undefined". The UI builds the error list with DOM nodes / `textContent` rather than `innerHTML`, so error strings (which originate from upstream APIs) cannot inject HTML.

The cross-cutting "exception serialises to `{}`" logging fix moved to PR #123 and is already on main; this branch was rebased on top of it.

## Test plan

- [x] `task test` — 499/499 pass (added `TemplateSyncServiceTest::testSyncContinuesAfterTemplateFailure` and `ConversationApiClientTest::testCreateTemplateUsesV2TranslationShape`)
- [x] `task check` — phpcs/phpstan/rector/composer-require-checker all green
- [x] Manual: against a live Sinch project, click **Sync Templates** in Settings — all 14 templates land in `oce_sinch_message_templates` (verified: `0 created, 14 updated, 0 skipped, 0 failed out of 14 total`)
- [x] Manual: with one template intentionally failing, the other 13 still sync and the JSON the Settings UI consumes carries the real upstream message:
  ```
  { "total": 14, "updated": 13, "failed": 1,
    "errors": [{ "template_key": "opt_in_confirmation",
                 "error": "Translation must specify a message." }] }
  ```
  Note: the live Sinch v2 endpoint accepted every malformed payload tried (empty body, undeclared variables, 5KB body, 500-char description), so this was verified by injecting a stub `ConversationApiClient` whose `createTemplate` throws `ApiException` for one template. The unit test `testSyncContinuesAfterTemplateFailure` covers the same path.