### PR TITLE
refactor(logging): introduce ExceptionContext::fromThrowable()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ This document describes the architectural patterns and conventions for OpenEMR m
 
 **Logging:**
 - Use PSR-3 context arrays — never string concatenation or interpolation in log messages
-- Pass exceptions as `'exception' => ExceptionContext::fromThrowable($e)` in context (passing `$e` directly serialises to `"{}"` because OpenEMR's `SystemLogger` `json_encode`s context objects and `\Throwable` exposes no public properties)
+- Pass exceptions as `'exception' => ExceptionContext::fromThrowable($e)` in context (import from `OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext`). Passing `$e` directly serialises to `"{}"` because OpenEMR's `SystemLogger` `json_encode`s context objects and `\Throwable` exposes no public properties.
 - See [Exceptions](docs/development/exceptions.md) for full patterns
 
 ### Common Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ This document describes the architectural patterns and conventions for OpenEMR m
 
 **Logging:**
 - Use PSR-3 context arrays — never string concatenation or interpolation in log messages
-- Pass exceptions as `'exception' => $e` in context
+- Pass exceptions as `'exception' => ExceptionContext::fromThrowable($e)` in context (passing `$e` directly serialises to `"{}"` because OpenEMR's `SystemLogger` `json_encode`s context objects and `\Throwable` exposes no public properties)
 - See [Exceptions](docs/development/exceptions.md) for full patterns
 
 ### Common Commands

--- a/docs/development/exceptions.md
+++ b/docs/development/exceptions.md
@@ -189,6 +189,8 @@ $this->logger->error("Failed to poll conversation {$conversationId}: " . $e->get
 $this->logger->info("Sent keyword auto-response to: {$phoneNumber}");
 
 // Good — PSR-3 context
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+
 $this->logger->error('Failed to poll conversation', [
     'conversationId' => $conversationId,
     'exception' => ExceptionContext::fromThrowable($e),

--- a/docs/development/exceptions.md
+++ b/docs/development/exceptions.md
@@ -156,6 +156,8 @@ Instead, generate a traceable error ID, log the full error with context, and sho
 $this->session->setFlash('error', "Failed: " . $e->getMessage());
 
 // Good — traceable error ID, structured context in logs
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+
 $errorId = uniqid('err-');
 $this->logger->error('Failed to send message', [
     'errorId' => $errorId,

--- a/docs/development/exceptions.md
+++ b/docs/development/exceptions.md
@@ -160,7 +160,7 @@ $errorId = uniqid('err-');
 $this->logger->error('Failed to send message', [
     'errorId' => $errorId,
     'phone' => $phoneNumber,
-    'exception' => $e,
+    'exception' => ExceptionContext::fromThrowable($e),
 ]);
 $this->session->setFlash('error', "An error occurred (ref: {$errorId}). Contact support if this persists.");
 ```
@@ -189,7 +189,7 @@ $this->logger->info("Sent keyword auto-response to: {$phoneNumber}");
 // Good — PSR-3 context
 $this->logger->error('Failed to poll conversation', [
     'conversationId' => $conversationId,
-    'exception' => $e,
+    'exception' => ExceptionContext::fromThrowable($e),
 ]);
 $this->logger->info('Sent keyword auto-response', ['phone' => $phoneNumber]);
 ```
@@ -197,8 +197,24 @@ $this->logger->info('Sent keyword auto-response', ['phone' => $phoneNumber]);
 **Rules:**
 - Log message is a static string — no variables interpolated into it
 - All variable data goes in the context array
-- Pass exceptions as `'exception' => $e` — Monolog extracts the full stack trace
+- Pass exceptions as `'exception' => ExceptionContext::fromThrowable($e)` — see [Logging Throwables](#logging-throwables) below
 - Use descriptive keys (`'patientId'`, `'phone'`, `'conversationId'`), not generic ones (`'id'`, `'value'`)
+
+## Logging Throwables
+
+OpenEMR's `SystemLogger` `json_encode`s context object values. `\Throwable` exposes no public properties, so passing `'exception' => $e` directly produces `"exception":"{}"` in the log — useless for debugging.
+
+Always route exceptions through `ExceptionContext::fromThrowable()`:
+
+```php
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+
+$this->logger->error('Failed to do thing', [
+    'exception' => ExceptionContext::fromThrowable($e),
+]);
+```
+
+The helper produces `class`, `message`, `file:line`, `trace`, and recurses into `getPrevious()`. The previous-exception chain matters: services often re-throw a domain exception wrapping the underlying cause (e.g. `ValidationException` wrapping a Sinch `ApiException`). Without recursing, the log loses the real reason.
 
 ## API Exception Handling
 
@@ -208,7 +224,7 @@ When calling Sinch APIs, wrap in try-catch and convert to appropriate exceptions
 try {
     $response = $this->client->sendMessage($payload);
 } catch (GuzzleException $e) {
-    $this->logger->error('Sinch API call failed', ['exception' => $e]);
+    $this->logger->error('Sinch API call failed', ['exception' => ExceptionContext::fromThrowable($e)]);
     throw new ApiException("Failed to send message: " . $e->getMessage(), 0, $e);
 }
 ```

--- a/src/Module/Console/ModuleInstaller.php
+++ b/src/Module/Console/ModuleInstaller.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Console;
 
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenEMR\Common\Database\QueryUtils;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -340,7 +341,7 @@ class ModuleInstaller
             $errorId = \OpenCoreEMR\Modules\SinchConversations\ErrorId::generate();
             (new \OpenEMR\Common\Logging\SystemLogger())->error(
                 'ModuleManagerListener error',
-                ['errorId' => $errorId, 'action' => $action, 'exception' => $e]
+                ['errorId' => $errorId, 'action' => $action, 'exception' => ExceptionContext::fromThrowable($e)]
             );
             $this->output->writeln(
                 "  <comment>ModuleManagerListener ($action) failed (ref: $errorId)</comment>"

--- a/src/Module/Controller/ConversationController.php
+++ b/src/Module/Controller/ConversationController.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessagePollingService;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use OpenCoreEMR\Modules\SinchConversations\Service\PhoneNormalizer;
@@ -159,7 +160,7 @@ class ConversationController
             $this->logger->error('Failed to send reply', [
                 'conversationId' => $conversationId,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             $this->session->setFlash('conversation_message', "Error sending message (ref: $errorId)");
         }

--- a/src/Module/Controller/EligibilityController.php
+++ b/src/Module/Controller/EligibilityController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use Psr\Log\LoggerInterface;
@@ -65,7 +66,7 @@ class EligibilityController
         } catch (\Throwable $e) {
             $this->logger->error('Failed to diagnose SMS eligibility for endpoint request', [
                 'patientId' => $pid,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return $this->htmlResponse($this->renderer->renderEmpty());
         }

--- a/src/Module/Controller/InboxController.php
+++ b/src/Module/Controller/InboxController.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessagePollingService;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
@@ -118,7 +119,7 @@ class InboxController
             $errorId = ErrorId::generate();
             $this->logger->error('Failed to refresh messages', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             $this->session->setFlash('inbox_message', "Error refreshing messages (ref: $errorId)");
         }

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
@@ -142,7 +143,7 @@ class SettingsController
             $errorId = ErrorId::generate();
             $this->logger->error('Error saving settings', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             $this->session->setFlash('settings_message', "Error saving settings (ref: $errorId). Please try again.");
             return $this->redirect($request);
@@ -216,7 +217,7 @@ class SettingsController
             $errorId = ErrorId::generate();
             $this->logger->error('API connection test failed', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse([
                 'success' => false,
@@ -307,7 +308,7 @@ class SettingsController
             $this->logger->error('Failed to send test SMS', [
                 'phone' => $phoneNumber,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse([
                 'success' => false,
@@ -374,7 +375,7 @@ class SettingsController
             $errorId = ErrorId::generate();
             $this->logger->error('Template sync failed', [
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse([
                 'success' => false,

--- a/src/Module/Controller/WebhookController.php
+++ b/src/Module/Controller/WebhookController.php
@@ -17,6 +17,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Controller;
 use OpenCoreEMR\Modules\SinchConversations\Channel;
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenCoreEMR\Modules\SinchConversations\Service\KeywordHandlerService;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageOptions;
@@ -83,7 +84,7 @@ class WebhookController
             $this->logger->error('Webhook authentication error', [
                 'errorId' => $errorId,
                 'clientIp' => $clientIp,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return new JsonResponse(
                 ['error' => 'Internal error', 'errorId' => $errorId],
@@ -241,7 +242,7 @@ class WebhookController
             );
         } catch (\Throwable $e) {
             $this->logger->warning('Failed to prune expired webhook nonces', [
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
         }
 
@@ -378,7 +379,7 @@ class WebhookController
             $this->logger->error('Failed to process inbound message', [
                 'messageId' => $messageId,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
 
             return new JsonResponse(
@@ -416,7 +417,7 @@ class WebhookController
             $this->logger->error('Failed to process delivery report', [
                 'messageId' => $messageId,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
 
             return new JsonResponse(
@@ -435,7 +436,7 @@ class WebhookController
             $this->logger->error('Carrier block detection failed (delivery status already recorded)', [
                 'messageId' => $messageId,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
         }
 
@@ -514,7 +515,7 @@ class WebhookController
                     'patientId' => $patientId,
                     'identity' => $identity,
                     'errorId' => $errorId,
-                    'exception' => $e,
+                    'exception' => ExceptionContext::fromThrowable($e),
                 ]);
             }
         }
@@ -595,7 +596,7 @@ class WebhookController
             $this->logger->error('Failed to process OPT_IN', [
                 'identity' => $identity,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
 
             return new JsonResponse(
@@ -912,7 +913,7 @@ class WebhookController
             $this->logger->error('Failed to send keyword response', [
                 'phone' => $normalized,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return "Failed to send auto-response (ref: $errorId)";
         }

--- a/src/Module/Listener/AppointmentSmsStatusListener.php
+++ b/src/Module/Listener/AppointmentSmsStatusListener.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Listener;
 
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Render\EligibilityAlertRenderer;
 use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -71,7 +72,7 @@ class AppointmentSmsStatusListener
         } catch (\Throwable $e) {
             $this->logger->error('Failed to diagnose SMS eligibility for calendar render', [
                 'patientId' => $pid,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             echo $this->renderer->renderEmpty();
             return;

--- a/src/Module/Listener/PatientConsentListener.php
+++ b/src/Module/Listener/PatientConsentListener.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 namespace OpenCoreEMR\Modules\SinchConversations\Listener;
 
 use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\Service\ConsentService;
 use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -129,7 +130,7 @@ class PatientConsentListener
         } catch (\Throwable $e) {
             $this->logger->error('Failed to send opt-in confirmation', [
                 'patientId' => $pid,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
         }
     }

--- a/src/Module/Logging/ExceptionContext.php
+++ b/src/Module/Logging/ExceptionContext.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Helper for serialising Throwables into PSR-3 log context arrays.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Logging;
+
+use Throwable;
+
+final class ExceptionContext
+{
+    /**
+     * Convert a Throwable (and its previous-exception chain) to a JSON-serialisable array.
+     *
+     * OpenEMR's SystemLogger calls json_encode() on object context values, and
+     * Throwables expose no public properties — so passing $e directly results
+     * in "{}" in the log. This helper produces an explicit, useful shape.
+     *
+     * The previous-exception chain matters: services often re-throw a domain
+     * exception wrapping the underlying cause (e.g. ValidationException wrapping
+     * a Sinch ApiException). Without recursing, the log loses the real reason.
+     *
+     * @return array{class: class-string, message: string, file: string, trace: string, previous?: array<string, mixed>}
+     */
+    public static function fromThrowable(Throwable $e): array
+    {
+        $context = [
+            'class' => $e::class,
+            'message' => $e->getMessage(),
+            'file' => $e->getFile() . ':' . $e->getLine(),
+            'trace' => $e->getTraceAsString(),
+        ];
+
+        $previous = $e->getPrevious();
+        if ($previous instanceof Throwable) {
+            $context['previous'] = self::fromThrowable($previous);
+        }
+
+        return $context;
+    }
+}

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -20,6 +20,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -118,7 +119,7 @@ class AppointmentReminderService
                 $results['errors'][] = "Event {$pcEid}: template render failed: " . $e->getMessage();
                 $this->logger->error('Appointment reminder template render failed', [
                     'pc_eid' => $pcEid,
-                    'exception' => $e,
+                    'exception' => ExceptionContext::fromThrowable($e),
                 ]);
                 continue;
             }
@@ -138,7 +139,7 @@ class AppointmentReminderService
                 $this->logger->error('Appointment reminder send failed', [
                     'pc_eid' => $pcEid,
                     'patient_id' => $patientId,
-                    'exception' => $e,
+                    'exception' => ExceptionContext::fromThrowable($e),
                 ]);
             }
         }
@@ -205,7 +206,10 @@ class AppointmentReminderService
             $sql = "DELETE FROM oce_sinch_appointment_reminders WHERE sent_at < DATE_SUB(NOW(), INTERVAL 90 DAY)";
             QueryUtils::sqlStatementThrowException($sql, []);
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to purge expired appointment reminders', ['exception' => $e]);
+            $this->logger->error(
+                'Failed to purge expired appointment reminders',
+                ['exception' => ExceptionContext::fromThrowable($e)]
+            );
         }
     }
 

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\ModuleConfig\ConfigService as LibConfigService;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Logging\SystemLogger;
 
@@ -102,7 +103,7 @@ class ConfigService
 
             $this->logger->info('Sinch Conversations settings saved successfully');
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to save settings', ['exception' => $e]);
+            $this->logger->error('Failed to save settings', ['exception' => ExceptionContext::fromThrowable($e)]);
             throw new ValidationException("Failed to save settings", 0, $e);
         }
     }

--- a/src/Module/Service/ConsentService.php
+++ b/src/Module/Service/ConsentService.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\Channel;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 
@@ -129,7 +130,7 @@ class ConsentService
             $this->logger->error('Failed to send opt-in confirmation', [
                 'patientId' => $patientId,
                 'phone' => $phoneNumber,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return false;
         }

--- a/src/Module/Service/ConsentSyncService.php
+++ b/src/Module/Service/ConsentSyncService.php
@@ -20,6 +20,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -102,7 +103,7 @@ class ConsentSyncService
                         'patientId' => $patientId,
                         'phone' => $normalized,
                         'errorId' => $errorId,
-                        'exception' => $e,
+                        'exception' => ExceptionContext::fromThrowable($e),
                     ]);
                 }
             }
@@ -181,7 +182,7 @@ class ConsentSyncService
                     'patientId' => $patientId,
                     'phone' => $phone,
                     'errorId' => $errorId,
-                    'exception' => $e,
+                    'exception' => ExceptionContext::fromThrowable($e),
                 ]);
             }
         }

--- a/src/Module/Service/MessagePollingService.php
+++ b/src/Module/Service/MessagePollingService.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -171,7 +172,7 @@ class MessagePollingService
             $this->logger->error('Failed to send keyword response', [
                 'phone' => $phoneNumber,
                 'errorId' => $errorId,
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             return ['phone' => $phoneNumber, 'error' => "Failed (ref: $errorId)"];
         }

--- a/src/Module/Service/MessageService.php
+++ b/src/Module/Service/MessageService.php
@@ -17,6 +17,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 use OpenCoreEMR\Modules\SinchConversations\Channel;
 use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
@@ -64,7 +65,10 @@ class MessageService
                 $options->toApiOptions()
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to send message via Sinch API', ['exception' => $e]);
+            $this->logger->error(
+                'Failed to send message via Sinch API',
+                ['exception' => ExceptionContext::fromThrowable($e)]
+            );
             throw new ValidationException('Failed to send message', 0, $e);
         }
 

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 use OpenEMR\Common\Database\QueryUtils;
@@ -67,7 +68,7 @@ class TemplateSyncService
             ]);
         } catch (\Throwable $e) {
             $this->logger->warning('Could not list existing templates, will attempt to create all', [
-                'exception' => $e,
+                'exception' => ExceptionContext::fromThrowable($e),
             ]);
             $existingByDescription = [];
         }
@@ -114,7 +115,7 @@ class TemplateSyncService
                 $this->logger->error('Failed to sync template', [
                     'templateKey' => $template['template_key'],
                     'errorId' => $errorId,
-                    'exception' => $e,
+                    'exception' => ExceptionContext::fromThrowable($e),
                 ]);
 
                 // Stop on first failure

--- a/tests/Unit/Logging/ExceptionContextTest.php
+++ b/tests/Unit/Logging/ExceptionContextTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Unit tests for ExceptionContext
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Logging;
+
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ExceptionContextTest extends TestCase
+{
+    public function testFromThrowableProducesExpectedShape(): void
+    {
+        $line = __LINE__ + 1;
+        $e = new RuntimeException('boom');
+
+        $context = ExceptionContext::fromThrowable($e);
+
+        $this->assertSame(RuntimeException::class, $context['class']);
+        $this->assertSame('boom', $context['message']);
+        $this->assertSame(__FILE__ . ':' . $line, $context['file']);
+        $this->assertNotEmpty($context['trace']);
+        $this->assertArrayNotHasKey('previous', $context, 'no previous chain when none was set');
+    }
+
+    public function testFromThrowableRecursesPreviousChain(): void
+    {
+        $root = new RuntimeException('root cause');
+        $middle = new RuntimeException('middle wrap', 0, $root);
+        $top = new RuntimeException('outer', 0, $middle);
+
+        $context = ExceptionContext::fromThrowable($top);
+
+        $this->assertSame('outer', $context['message']);
+        $this->assertArrayHasKey('previous', $context);
+        $this->assertSame('middle wrap', $context['previous']['message']);
+        $this->assertArrayHasKey('previous', $context['previous']);
+        $this->assertSame('root cause', $context['previous']['previous']['message']);
+        $this->assertArrayNotHasKey('previous', $context['previous']['previous']);
+    }
+
+    public function testFromThrowableProducesJsonEncodableArray(): void
+    {
+        $context = ExceptionContext::fromThrowable(new RuntimeException('encode me', 0, new RuntimeException('inner')));
+
+        $json = json_encode($context);
+
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true);
+        $this->assertSame('encode me', $decoded['message']);
+        $this->assertSame('inner', $decoded['previous']['message']);
+    }
+}


### PR DESCRIPTION
## Summary

OpenEMR's `SystemLogger` calls `json_encode()` on object context values. `\Throwable` exposes no public properties, so passing `'exception' => \$e` serialises to `"exception":"{}"` in the log — useless for debugging.

This PR adds `OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext` whose `fromThrowable()` static method produces an explicit, JSON-serialisable shape (`class`, `message`, `file:line`, `trace`) and recurses into `getPrevious()`. The previous-exception chain matters because services frequently re-throw a domain exception wrapping the underlying cause (e.g. `ValidationException` wrapping a Sinch `ApiException`); without recursing, the log loses the real reason.

The helper is applied across every PSR-3 logging call in `src/Module/`. `CLAUDE.md` and `docs/development/exceptions.md` are updated so the documented pattern matches the code.

Split out from #122 so the Sinch v2 schema fix can land independently of the cross-cutting logging change.

## Test plan

- [x] `task check` — phpcs/phpstan/rector/composer-require-checker all green
- [x] `task test` — 494/494 pass
- [ ] Manual: trigger an error path that wraps an exception (e.g. settings save with invalid input) and confirm the apache error log contains `class`, `message`, `file:line`, `trace`, and a populated `previous` entry instead of `"exception":"{}"`