### PR TITLE
fix: version Sinch template descriptions by content hash

### DIFF
--- a/src/Module/Common/Json.php
+++ b/src/Module/Common/Json.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Common;
+
+/**
+ * Typed wrapper around PHP's `json_encode` / `json_decode`.
+ *
+ * The legacy functions return `string|false` and `mixed|false` respectively
+ * and rely on the caller to remember `JSON_THROW_ON_ERROR`. Per ocemr-docs
+ * `reference/php-conventions.md` § "No `false`-on-Error APIs", `json_encode`
+ * and `json_decode` are off-limits at call sites — they live here, where the
+ * `false` failure mode is converted to a `JsonException` and the return type
+ * is honest.
+ */
+final class Json
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    public static function encode(mixed $value, int $flags = 0): string
+    {
+        return json_encode($value, JSON_THROW_ON_ERROR | $flags);
+    }
+
+    /**
+     * Decode JSON into an associative array (or scalar / list of same).
+     *
+     * @return mixed
+     * @throws \JsonException
+     */
+    public static function decode(string $json, int $flags = 0): mixed
+    {
+        return json_decode($json, true, 512, JSON_THROW_ON_ERROR | $flags);
+    }
+}

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -170,10 +170,14 @@ class TemplateSyncService
      *
      * Format: `{template_key}@{hash8}`. The hash covers only the fields that
      * actually go into the Sinch payload (see
-     * `ConversationApiClient::formatTemplateForSinch()`): body and required
-     * variables. Local-only fields like `category` and `communication_type`
-     * are deliberately excluded so a metadata-only edit doesn't force a
-     * needless re-approval cycle on regulated channels.
+     * `ConversationApiClient::formatTemplateForSinch()`): the *normalized*
+     * body and the required variables. Local-only fields like `category`
+     * and `communication_type` are deliberately excluded so a metadata-only
+     * edit doesn't force a needless re-approval cycle on regulated channels.
+     *
+     * The body is normalized through `ConversationApiClient::normalizeTemplateBody()`
+     * so cosmetic edits inside `{{ var }}` (whitespace) don't bump the hash —
+     * only changes to the bytes Sinch will actually receive.
      *
      * @param array<string, mixed> $template
      * @throws \JsonException
@@ -185,8 +189,10 @@ class TemplateSyncService
             sort($variables);
         }
 
+        $body = (string) ($template['body'] ?? '');
+
         $canonical = Json::encode([
-            'body' => $template['body'] ?? '',
+            'body' => ConversationApiClient::normalizeTemplateBody($body),
             'required_variables' => $variables,
         ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -78,8 +78,9 @@ class TemplateSyncService
                 // Match Sinch templates by a content-versioned description
                 // (`template_key@<hash>`) so a body change produces a new
                 // Sinch template instead of silently reusing the old one.
-                // Legacy bare-name descriptions from pre-versioning syncs
-                // are intentionally ignored — first sync after upgrade
+                // Any Sinch description without the `@<hash>` suffix —
+                // including pre-versioning descriptions from older syncs —
+                // is intentionally ignored, so the first sync after upgrade
                 // creates fresh versioned entries.
                 $template['description'] = $this->versionedDescription($template);
 

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -75,11 +75,16 @@ class TemplateSyncService
 
         foreach ($templateDefinitions as $template) {
             try {
-                $description = $template['description'] ?? $template['template_name'];
+                // Match Sinch templates by a content-versioned description
+                // (`template_key@<hash>`) so a body change produces a new
+                // Sinch template instead of silently reusing the old one.
+                // Legacy bare-name descriptions from pre-versioning syncs
+                // are intentionally ignored — first sync after upgrade
+                // creates fresh versioned entries.
+                $template['description'] = $this->versionedDescription($template);
 
-                // Check if template already exists in Sinch
-                if (isset($existingByDescription[$description])) {
-                    $sinchTemplate = $existingByDescription[$description];
+                if (isset($existingByDescription[$template['description']])) {
+                    $sinchTemplate = $existingByDescription[$template['description']];
                     $sinchTemplateId = $sinchTemplate['id'] ?? null;
 
                     $this->logger->debug('Template already exists in Sinch', [
@@ -87,7 +92,6 @@ class TemplateSyncService
                         'sinchId' => $sinchTemplateId,
                     ]);
 
-                    // Save/update locally with existing Sinch ID
                     if ($sinchTemplateId) {
                         $this->saveTemplateLocally($template, $sinchTemplateId);
                         $results['skipped']++;
@@ -95,7 +99,6 @@ class TemplateSyncService
                     }
                 }
 
-                // Template doesn't exist, sync it
                 $this->syncTemplate($template);
 
                 // Check if template already existed locally
@@ -158,6 +161,36 @@ class TemplateSyncService
 
         // Then save or update it in the local database
         $this->saveTemplateLocally($template, $sinchTemplateId);
+    }
+
+    /**
+     * Build a content-versioned Sinch description for a template definition.
+     *
+     * Format: `{template_key}@{hash8}`. The hash covers the fields that
+     * affect what Sinch (and downstream carriers) actually need to re-approve:
+     * body, required variables, category, and communication type. A change
+     * to any of these produces a new Sinch template rather than silently
+     * reusing the old one.
+     *
+     * @param array<string, mixed> $template
+     */
+    private function versionedDescription(array $template): string
+    {
+        $variables = $template['required_variables'] ?? [];
+        if (is_array($variables)) {
+            sort($variables);
+        }
+
+        $canonical = json_encode([
+            'body' => $template['body'] ?? '',
+            'required_variables' => $variables,
+            'category' => $template['category'] ?? '',
+            'communication_type' => $template['communication_type'] ?? '',
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $hash = substr(hash('sha256', (string) $canonical), 0, 8);
+
+        return $template['template_key'] . '@' . $hash;
     }
 
     /**

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -167,13 +167,15 @@ class TemplateSyncService
     /**
      * Build a content-versioned Sinch description for a template definition.
      *
-     * Format: `{template_key}@{hash8}`. The hash covers the fields that
-     * affect what Sinch (and downstream carriers) actually need to re-approve:
-     * body, required variables, category, and communication type. A change
-     * to any of these produces a new Sinch template rather than silently
-     * reusing the old one.
+     * Format: `{template_key}@{hash8}`. The hash covers only the fields that
+     * actually go into the Sinch payload (see
+     * `ConversationApiClient::formatTemplateForSinch()`): body and required
+     * variables. Local-only fields like `category` and `communication_type`
+     * are deliberately excluded so a metadata-only edit doesn't force a
+     * needless re-approval cycle on regulated channels.
      *
      * @param array<string, mixed> $template
+     * @throws \JsonException
      */
     private function versionedDescription(array $template): string
     {
@@ -185,11 +187,9 @@ class TemplateSyncService
         $canonical = json_encode([
             'body' => $template['body'] ?? '',
             'required_variables' => $variables,
-            'category' => $template['category'] ?? '',
-            'communication_type' => $template['communication_type'] ?? '',
-        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
-        $hash = substr(hash('sha256', (string) $canonical), 0, 8);
+        $hash = substr(hash('sha256', $canonical), 0, 8);
 
         return $template['template_key'] . '@' . $hash;
     }

--- a/src/Module/Service/TemplateSyncService.php
+++ b/src/Module/Service/TemplateSyncService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
+use OpenCoreEMR\Modules\SinchConversations\Common\Json;
 use OpenCoreEMR\Modules\SinchConversations\ErrorId;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
@@ -184,10 +185,10 @@ class TemplateSyncService
             sort($variables);
         }
 
-        $canonical = json_encode([
+        $canonical = Json::encode([
             'body' => $template['body'] ?? '',
             'required_variables' => $variables,
-        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
         $hash = substr(hash('sha256', $canonical), 0, 8);
 

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -609,7 +609,7 @@ class ConversationApiClient
                     'version' => '1',
                     'variables' => $variables,
                     'text_message' => [
-                        'text' => $this->convertTemplateVariables($templateData['body']),
+                        'text' => self::normalizeTemplateBody($templateData['body']),
                     ],
                 ],
             ],
@@ -617,14 +617,15 @@ class ConversationApiClient
     }
 
     /**
-     * Convert {{ variable }} syntax to {{variable}} (Sinch format)
+     * Normalize a template body to the exact text Sinch will receive:
+     * `{{ variable_name }}` → `{{variable_name}}` (Sinch's required form).
      *
-     * @param string $body
-     * @return string
+     * Exposed publicly so that anything which needs to reason about the
+     * payload Sinch actually stores (e.g. content-versioned descriptions
+     * in TemplateSyncService) hashes the same string this client sends.
      */
-    private function convertTemplateVariables(string $body): string
+    public static function normalizeTemplateBody(string $body): string
     {
-        // Convert {{ variable_name }} to {{variable_name}}
         return preg_replace('/\{\{\s*(\w+)\s*\}\}/', '{{$1}}', $body) ?? $body;
     }
 

--- a/tests/Unit/Common/JsonTest.php
+++ b/tests/Unit/Common/JsonTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Common;
+
+use JsonException;
+use OpenCoreEMR\Modules\SinchConversations\Common\Json;
+use PHPUnit\Framework\TestCase;
+
+class JsonTest extends TestCase
+{
+    public function testEncodeReturnsString(): void
+    {
+        $this->assertSame('{"a":1}', Json::encode(['a' => 1]));
+    }
+
+    public function testEncodeAcceptsExtraFlags(): void
+    {
+        // Default behaviour escapes forward slashes; passing
+        // JSON_UNESCAPED_SLASHES through the wrapper must suppress that.
+        $this->assertSame('"a\/b"', Json::encode('a/b'));
+        $this->assertSame('"a/b"', Json::encode('a/b', JSON_UNESCAPED_SLASHES));
+    }
+
+    public function testEncodeThrowsOnUnencodableValue(): void
+    {
+        $this->expectException(JsonException::class);
+        Json::encode("\xB1\x31");
+    }
+
+    public function testDecodeReturnsAssociativeArray(): void
+    {
+        $this->assertSame(['a' => 1, 'b' => [2, 3]], Json::decode('{"a":1,"b":[2,3]}'));
+    }
+
+    public function testDecodeThrowsOnInvalidJson(): void
+    {
+        $this->expectException(JsonException::class);
+        Json::decode('{not json');
+    }
+}

--- a/tests/Unit/Service/TemplateSyncServiceTest.php
+++ b/tests/Unit/Service/TemplateSyncServiceTest.php
@@ -184,6 +184,26 @@ class TemplateSyncServiceTest extends TestCase
     }
 
     /**
+     * Whitespace inside `{{ var }}` is normalized away before the body is
+     * sent to Sinch (`ConversationApiClient::normalizeTemplateBody()`), so
+     * the hash must compare normalized bodies. Otherwise a cosmetic edit
+     * like `{{patient_name}}` → `{{ patient_name }}` triggers a needless
+     * re-approval.
+     */
+    public function testHashIsStableAcrossVariableWhitespace(): void
+    {
+        $reflect = new \ReflectionMethod(TemplateSyncService::class, 'versionedDescription');
+
+        $compact = ['template_key' => 'k', 'body' => 'Hi {{patient_name}}', 'required_variables' => ['patient_name']];
+        $spaced = ['template_key' => 'k', 'body' => 'Hi {{ patient_name }}', 'required_variables' => ['patient_name']];
+
+        $this->assertSame(
+            $reflect->invoke($this->service, $compact),
+            $reflect->invoke($this->service, $spaced),
+        );
+    }
+
+    /**
      * Non-API exceptions (e.g. internal TypeError) must NOT leak their message
      * into the UI — only `ApiException` messages, which originate from the
      * Sinch API and are safe operator-facing validation errors, are surfaced

--- a/tests/Unit/Service/TemplateSyncServiceTest.php
+++ b/tests/Unit/Service/TemplateSyncServiceTest.php
@@ -83,12 +83,6 @@ class TemplateSyncServiceTest extends TestCase
     }
 
     /**
-     * Non-API exceptions (e.g. internal TypeError) must NOT leak their message
-     * into the UI — only `ApiException` messages, which originate from the
-     * Sinch API and are safe operator-facing validation errors, are surfaced
-     * verbatim. Everything else gets a generic message + errorId.
-     */
-    /**
      * Re-syncing the same templates after they exist in Sinch with their
      * content-versioned descriptions must skip every one — no createTemplate
      * calls. Regression guard for issue #124: the description match must
@@ -125,11 +119,12 @@ class TemplateSyncServiceTest extends TestCase
     }
 
     /**
-     * If a Sinch template exists under the legacy bare-name description
-     * (from a pre-versioning sync), the new code must NOT adopt it — first
-     * sync after upgrade creates fresh content-versioned templates.
+     * If Sinch already holds a template under the pre-versioning description
+     * (whatever was in the config's `description` field, typically human
+     * prose), the new matcher must NOT adopt it — first sync after upgrade
+     * creates fresh content-versioned templates.
      */
-    public function testLegacyBareDescriptionIsIgnored(): void
+    public function testLegacyNonVersionedDescriptionIsIgnored(): void
     {
         $configPath = dirname(__DIR__, 3) . '/config/templates.php';
         $definitions = require $configPath;
@@ -188,6 +183,12 @@ class TemplateSyncServiceTest extends TestCase
         $this->assertSame(0, $results['skipped']);
     }
 
+    /**
+     * Non-API exceptions (e.g. internal TypeError) must NOT leak their message
+     * into the UI — only `ApiException` messages, which originate from the
+     * Sinch API and are safe operator-facing validation errors, are surfaced
+     * verbatim. Everything else gets a generic message + errorId.
+     */
     public function testNonApiExceptionDoesNotLeakMessageToUi(): void
     {
         $this->apiClient->method('listTemplates')->willReturn([]);

--- a/tests/Unit/Service/TemplateSyncServiceTest.php
+++ b/tests/Unit/Service/TemplateSyncServiceTest.php
@@ -88,6 +88,106 @@ class TemplateSyncServiceTest extends TestCase
      * Sinch API and are safe operator-facing validation errors, are surfaced
      * verbatim. Everything else gets a generic message + errorId.
      */
+    /**
+     * Re-syncing the same templates after they exist in Sinch with their
+     * content-versioned descriptions must skip every one — no createTemplate
+     * calls. Regression guard for issue #124: the description match must
+     * line up with what we previously sent.
+     */
+    public function testResyncWithUnchangedContentSkipsAll(): void
+    {
+        $createCalls = 0;
+        $sentDescriptions = [];
+        $this->apiClient->method('listTemplates')->willReturn([]);
+        $this->apiClient->method('createTemplate')
+            ->willReturnCallback(function (array $template) use (&$createCalls, &$sentDescriptions): array {
+                $sentDescriptions[] = $template['description'];
+                $createCalls++;
+                return ['id' => 'sinch-tmpl-' . $createCalls];
+            });
+
+        $first = $this->service->syncAllTemplates();
+        $this->assertSame($first['total'], $createCalls, 'first sync should create every template');
+
+        $apiClient2 = $this->createMock(ConversationApiClient::class);
+        $existing = [];
+        foreach ($sentDescriptions as $i => $desc) {
+            $existing[] = ['id' => 'sinch-tmpl-' . ($i + 1), 'description' => $desc];
+        }
+        $apiClient2->method('listTemplates')->willReturn($existing);
+        $apiClient2->expects($this->never())->method('createTemplate');
+
+        $service2 = new TemplateSyncService($this->config, $apiClient2);
+        $second = $service2->syncAllTemplates();
+
+        $this->assertSame($second['total'], $second['skipped'], 'every template should be skipped on re-sync');
+        $this->assertSame(0, $second['failed']);
+    }
+
+    /**
+     * If a Sinch template exists under the legacy bare-name description
+     * (from a pre-versioning sync), the new code must NOT adopt it — first
+     * sync after upgrade creates fresh content-versioned templates.
+     */
+    public function testLegacyBareDescriptionIsIgnored(): void
+    {
+        $configPath = dirname(__DIR__, 3) . '/config/templates.php';
+        $definitions = require $configPath;
+        $legacyExisting = [];
+        foreach ($definitions as $i => $def) {
+            $legacyExisting[] = [
+                'id' => 'legacy-' . ($i + 1),
+                'description' => $def['description'] ?? $def['template_name'],
+            ];
+        }
+
+        $this->apiClient->method('listTemplates')->willReturn($legacyExisting);
+        $createCalls = 0;
+        $this->apiClient->method('createTemplate')
+            ->willReturnCallback(function (array $template) use (&$createCalls): array {
+                $createCalls++;
+                $this->assertStringContainsString('@', $template['description']);
+                return ['id' => 'sinch-tmpl-' . $createCalls];
+            });
+
+        $results = $this->service->syncAllTemplates();
+
+        $this->assertSame($results['total'], $createCalls, 'legacy descriptions must not satisfy the match');
+        $this->assertSame(0, $results['skipped']);
+    }
+
+    /**
+     * A stale versioned description in Sinch (different hash) must be treated
+     * as a miss and trigger creation of a new Sinch template — this is the
+     * core multi-tenant safety property: a body change actually reaches Sinch.
+     */
+    public function testStaleVersionedDescriptionTriggersNewCreation(): void
+    {
+        $configPath = dirname(__DIR__, 3) . '/config/templates.php';
+        $definitions = require $configPath;
+        $stale = [];
+        foreach ($definitions as $i => $def) {
+            $stale[] = [
+                'id' => 'stale-' . ($i + 1),
+                'description' => $def['template_key'] . '@deadbeef',
+            ];
+        }
+
+        $this->apiClient->method('listTemplates')->willReturn($stale);
+        $createCalls = 0;
+        $this->apiClient->method('createTemplate')
+            ->willReturnCallback(function (array $template) use (&$createCalls): array {
+                $createCalls++;
+                $this->assertStringEndsNotWith('@deadbeef', $template['description']);
+                return ['id' => 'sinch-tmpl-' . $createCalls];
+            });
+
+        $results = $this->service->syncAllTemplates();
+
+        $this->assertSame($results['total'], $createCalls);
+        $this->assertSame(0, $results['skipped']);
+    }
+
     public function testNonApiExceptionDoesNotLeakMessageToUi(): void
     {
         $this->apiClient->method('listTemplates')->willReturn([]);


### PR DESCRIPTION
## Summary

- Encode a short content hash into the Sinch template `description` (`template_key@<hash8>`) so a body change produces a fresh Sinch template instead of silently colliding with the old one.
- Drop the implicit "first sync wins" behavior that left stale template content stuck in Sinch across module upgrades and across tenants sharing a Sinch project.
- Legacy bare-name descriptions are intentionally ignored — first sync after upgrade creates fresh versioned entries.
- Add a typed `Common\Json` wrapper and route the new call site through it, per ocemr-docs § "No `false`-on-Error APIs". Migration of the rest of the module is tracked in #126.

Fixes #124.

## Tradeoff

For WhatsApp / regulated channels, every new template requires Sinch (and sometimes carrier) re-approval. Versioning makes that cost explicit and proportional to *real* content change (hash-based — only `body` and `required_variables`, the fields actually sent to Sinch). For SMS-only deployments it's effectively free. Cleanup of orphaned old Sinch templates is out of scope and tracked separately.

## Test plan

- [x] `task check` (phpcs, phpcbf, PHPStan, rector, composer-require-checker, CLI smoke) — green
- [x] `composer test` — 508 tests, 1304 assertions, OK
- [x] New unit tests cover: re-sync with unchanged content skips all; legacy non-versioned description is ignored; stale `@<old-hash>` triggers fresh creation; `Json::encode/decode` wrapper round-trips and throws on bad input
- [ ] Manual: against a real Sinch project, verify `created`/`skipped` counts match expectation across (a) initial sync, (b) no-op re-sync, (c) sync after editing one body