### PR TITLE
docs(listener): correct stale PatientConsentListener coverage note

### DIFF
--- a/src/Module/Listener/PatientConsentListener.php
+++ b/src/Module/Listener/PatientConsentListener.php
@@ -9,17 +9,29 @@
  * transition, so they know they will start receiving SMS from the clinic.
  *
  * Coverage note: this listener subscribes to PatientUpdatedEvent /
- * PatientCreatedEvent. Both chart UI save paths reach those events:
- * demographics_save.php updates flow through updatePatientData() →
- * PatientService::databaseUpdate(), which dispatches PatientUpdatedEvent
- * with a real findByPid() pre-update snapshot; and new_patient_save.php
- * dispatches PatientCreatedEvent after newPatientData() via the
- * notifier added in upstream openemr/openemr#12083 (backported to
- * oce-800 in opencoreemr/openemr-internal#484). Either path will fire
- * the welcome SMS on a NO->YES transition. Eligibility is independent
- * regardless: MessageService::assertPatientEligible() reads
- * hipaa_allowsms live at send time, so reminders are reachable as soon
- * as the chart shows YES.
+ * PatientCreatedEvent.
+ *
+ * Update path (demographics_save.php): updates flow through
+ * updatePatientData() → PatientService::databaseUpdate(), which
+ * dispatches PatientUpdatedEvent with a findByPid() pre-update
+ * snapshot. The welcome SMS fires on a NO->YES hipaa_allowsms
+ * transition. This has been the behavior since updatePatientData()
+ * was rerouted through PatientService.
+ *
+ * Create path (new_patient_save.php): newPatientData() does raw
+ * REPLACE INTO patient_data and historically did not fire
+ * PatientCreatedEvent. Upstream openemr/openemr#12083 added a
+ * dispatch after the insert returns; the welcome SMS fires when
+ * hipaa_allowsms is YES at creation (no prior state to compare
+ * against). The fix is on upstream master but is not yet in a
+ * tagged release as of v8_0_0_3, so vanilla OpenEMR builds at or
+ * below v8_0_0_3 still miss the welcome SMS for chart-UI creates.
+ *
+ * Eligibility is independent of either event:
+ * MessageService::assertPatientEligible() reads hipaa_allowsms live
+ * at send time, so appointment reminders are reachable as soon as
+ * the chart shows YES regardless of which save path was used or
+ * which OpenEMR build is running.
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com

--- a/src/Module/Listener/PatientConsentListener.php
+++ b/src/Module/Listener/PatientConsentListener.php
@@ -9,15 +9,17 @@
  * transition, so they know they will start receiving SMS from the clinic.
  *
  * Coverage note: this listener subscribes to PatientUpdatedEvent /
- * PatientCreatedEvent. Several legacy chart save paths
- * (interface/patient_file/summary/demographics_save.php and
- * interface/new/new_patient_save.php) dispatch PatientUpdatedEventAux or
- * no event at all, so a NO->YES toggle through those UI paths will not
- * fire the welcome SMS. The patient is still eligible for reminders the
- * moment the chart shows YES — MessageService::assertPatientEligible()
- * reads hipaa_allowsms live at send time, independent of any event. The
- * welcome SMS is therefore best-effort; reliable coverage is tracked
- * separately. Eligibility coverage is not affected.
+ * PatientCreatedEvent. Both chart UI save paths reach those events:
+ * demographics_save.php updates flow through updatePatientData() →
+ * PatientService::databaseUpdate(), which dispatches PatientUpdatedEvent
+ * with a real findByPid() pre-update snapshot; and new_patient_save.php
+ * dispatches PatientCreatedEvent after newPatientData() via the
+ * notifier added in upstream openemr/openemr#12083 (backported to
+ * oce-800 in opencoreemr/openemr-internal#484). Either path will fire
+ * the welcome SMS on a NO->YES transition. Eligibility is independent
+ * regardless: MessageService::assertPatientEligible() reads
+ * hipaa_allowsms live at send time, so reminders are reachable as soon
+ * as the chart shows YES.
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com


### PR DESCRIPTION
The coverage note on `PatientConsentListener` claimed both legacy chart save paths (`demographics_save.php` and `new_patient_save.php`) skip the modern `PatientUpdatedEvent` / `PatientCreatedEvent`, so the welcome SMS would not fire on a `hipaa_allowsms` `NO`→`YES` toggle through those UI paths. That was wrong.

- **`demographics_save.php` (update):** updates flow through `updatePatientData()` → `PatientService::databaseUpdate()`, which already dispatches `PatientUpdatedEvent` with a `findByPid()` pre-update snapshot. There was never a gap on the update side; a draft PR (openemr/openemr#12090) tried to add a redundant dispatch and was closed when reviewers caught the duplicate.
- **`new_patient_save.php` (create):** was a real gap (`newPatientData()` does raw `REPLACE INTO patient_data` and never reaches `PatientService`). Upstream openemr/openemr#12083 added a `PatientCreatedEvent` dispatch after `newPatientData()` returns, and openCoreEMR/openemr-internal#484 backported the fix to `oce-800`.

Updates the docblock to reflect actual current coverage. No code behavior change.

Closes #117

## Assisted-by

Assisted-by: Claude Code