### PR TITLE
fix(settings): hide Default Channel field until WhatsApp/RCS are supported

### DIFF
--- a/templates/settings/config.html.twig
+++ b/templates/settings/config.html.twig
@@ -148,21 +148,7 @@
                 <h3>{{ 'Messaging Configuration'|xlt }}</h3>
             </div>
 
-            <div class="mb-3">
-                <label for="default_channel" class="form-label">{{ 'Default Channel'|xlt }}{% if not is_external_config %} <span class="text-danger">*</span>{% endif %}</label>
-                <select class="form-select" id="default_channel" name="default_channel" {% if is_external_config %}disabled{% else %}required{% endif %}>
-                    <option value="SMS" {% if settings.default_channel == 'SMS' %}selected{% endif %}>
-                        {{ 'SMS'|xlt }}
-                    </option>
-                    <option value="WHATSAPP" {% if settings.default_channel == 'WHATSAPP' %}selected{% endif %}>
-                        {{ 'WhatsApp'|xlt }}
-                    </option>
-                    <option value="RCS" {% if settings.default_channel == 'RCS' %}selected{% endif %}>
-                        {{ 'RCS'|xlt }}
-                    </option>
-                </select>
-                <div class="help-text">{{ 'Default messaging channel for new conversations'|xlt }}</div>
-            </div>
+            {# Default Channel is hidden until WhatsApp/RCS are supported. SMS is the only option. #}
 
             <div class="mb-3">
                 <label for="clinic_name" class="form-label">{{ 'Clinic Name'|xlt }}</label>


### PR DESCRIPTION
## Summary

The settings page rendered a Default Channel dropdown with SMS, WhatsApp, and RCS, but only SMS is wired up end-to-end. Removing the form group prevents users from picking channels that don't actually work.

## Why this is safe

- `SettingsController::save` already defaults `default_channel` to `'SMS'` when the field is absent from the POST body (`src/Module/Controller/SettingsController.php:122`).
- `GlobalConfig::getDefaultChannel()` falls back to `'SMS'` when the global is unset (`src/Module/GlobalConfig.php:120`).
- The `Channel` enum and `ConfigService` validator keep `WHATSAPP`/`RCS` cases — `ConsentService` still references them for inbound webhook handling.

Re-exposing the dropdown later is a single template revert.

## Test plan

- [x] `task check` passes
- [ ] Open Admin > Config > OpenCoreEMR Sinch Conversations and confirm the Default Channel field is gone
- [ ] Save the settings form and confirm the stored `oce_sinch_conversations_default_channel` global remains `SMS`