### PR TITLE
feat(settings): validate Sinch credentials before saving

### DIFF
--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -22,6 +22,8 @@ use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -131,6 +133,42 @@ class SettingsController
             $apiSecret = $request->request->get('api_secret', '');
             if ($apiSecret !== null && $apiSecret !== '') {
                 $settings['api_secret'] = (string)$apiSecret;
+            }
+
+            // Verify the credentials with Sinch before persisting them, so a
+            // misconfiguration is reported here rather than at message-send
+            // time. The api_secret field is left blank in the UI to keep the
+            // existing value, so fall back to the stored secret in that case.
+            // Skip validation when the user is only changing non-API fields
+            // (e.g. clinic name) — structural validation in ConfigService
+            // will catch a partially filled API section.
+            $secretForValidation = $settings['api_secret'] ?? $this->config->getSinchApiSecret();
+            $hasFullApiConfig = $settings['project_id'] !== ''
+                && $settings['app_id'] !== ''
+                && $settings['api_key'] !== ''
+                && $secretForValidation !== '';
+            try {
+                if ($hasFullApiConfig) {
+                    $this->apiClient->validateCredentials(
+                        $settings['project_id'],
+                        $settings['app_id'],
+                        $settings['api_key'],
+                        $secretForValidation,
+                        $settings['region'],
+                    );
+                }
+            } catch (ValidationException | ApiException $e) {
+                $errorId = ErrorId::generate();
+                $this->logger->warning('Settings credential validation failed', [
+                    'errorId' => $errorId,
+                    'exception' => ExceptionContext::fromThrowable($e),
+                ]);
+                $this->session->setFlash(
+                    'settings_message',
+                    "Credentials could not be verified with Sinch (ref: $errorId). " .
+                        "Settings were not saved. Check logs for details."
+                );
+                return $this->redirect($request);
             }
 
             // Save settings

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -148,11 +148,26 @@ class SettingsController
                 || $settings['app_id'] !== $this->config->getSinchAppId()
                 || $settings['api_key'] !== $this->config->getSinchApiKey()
                 || $settings['region'] !== $this->config->getSinchRegion();
-            $hasFullApiConfig = $settings['project_id'] !== ''
+            $hasApiTuple = $settings['project_id'] !== ''
                 && $settings['app_id'] !== ''
-                && $settings['api_key'] !== ''
-                && $secretForValidation !== ''
-                && in_array($settings['region'], ConfigService::SUPPORTED_REGIONS, true);
+                && $settings['api_key'] !== '';
+
+            // Reject saves that would persist API fields with no usable
+            // secret (no value typed in the form and none on file). Without
+            // this gate, validation would be skipped and the partial config
+            // saved silently, defeating the point of validation.
+            if ($hasApiTuple && $secretForValidation === '') {
+                $this->session->setFlash(
+                    'settings_message',
+                    "API Secret is required to configure Sinch credentials. Settings were not saved."
+                );
+                return $this->redirect($request);
+            }
+
+            // $hasApiTuple → $secretForValidation !== '' here (the guard
+            // above returned when an API tuple lacked a secret).
+            $hasFullApiConfig = $hasApiTuple
+                && in_array($settings['region'], ConversationApiClient::SUPPORTED_REGIONS, true);
             try {
                 if ($apiFieldChanged && $hasFullApiConfig) {
                     $this->apiClient->validateCredentials(

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -151,7 +151,8 @@ class SettingsController
             $hasFullApiConfig = $settings['project_id'] !== ''
                 && $settings['app_id'] !== ''
                 && $settings['api_key'] !== ''
-                && $secretForValidation !== '';
+                && $secretForValidation !== ''
+                && in_array($settings['region'], ConfigService::SUPPORTED_REGIONS, true);
             try {
                 if ($apiFieldChanged && $hasFullApiConfig) {
                     $this->apiClient->validateCredentials(

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -137,18 +137,23 @@ class SettingsController
 
             // Verify the credentials with Sinch before persisting them, so a
             // misconfiguration is reported here rather than at message-send
-            // time. The api_secret field is left blank in the UI to keep the
-            // existing value, so fall back to the stored secret in that case.
-            // Skip validation when the user is only changing non-API fields
-            // (e.g. clinic name) — structural validation in ConfigService
-            // will catch a partially filled API section.
+            // time. The settings form re-posts the existing API field values
+            // even when the user is only editing clinic info, so detect a
+            // real API edit by comparing the posted tuple to what's stored
+            // (and treat any typed api_secret as an edit, since the UI
+            // leaves that field blank when keeping the existing value).
             $secretForValidation = $settings['api_secret'] ?? $this->config->getSinchApiSecret();
+            $apiFieldChanged = isset($settings['api_secret'])
+                || $settings['project_id'] !== $this->config->getSinchProjectId()
+                || $settings['app_id'] !== $this->config->getSinchAppId()
+                || $settings['api_key'] !== $this->config->getSinchApiKey()
+                || $settings['region'] !== $this->config->getSinchRegion();
             $hasFullApiConfig = $settings['project_id'] !== ''
                 && $settings['app_id'] !== ''
                 && $settings['api_key'] !== ''
                 && $secretForValidation !== '';
             try {
-                if ($hasFullApiConfig) {
+                if ($apiFieldChanged && $hasFullApiConfig) {
                     $this->apiClient->validateCredentials(
                         $settings['project_id'],
                         $settings['app_id'],

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -22,6 +22,9 @@ use OpenEMR\Common\Logging\SystemLogger;
 
 class ConfigService
 {
+    /** @var list<string> */
+    public const SUPPORTED_REGIONS = ['us', 'eu'];
+
     private readonly LibConfigService $libConfigService;
     private readonly SystemLogger $logger;
 
@@ -120,7 +123,7 @@ class ConfigService
         // Validate region
         if (isset($settings['region'])) {
             $region = (string)$settings['region'];
-            if (!in_array($region, ['us', 'eu'], true)) {
+            if (!in_array($region, self::SUPPORTED_REGIONS, true)) {
                 throw new ValidationException("Region must be 'us' or 'eu'");
             }
         }

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -122,7 +122,10 @@ class ConfigService
         if (isset($settings['region'])) {
             $region = (string)$settings['region'];
             if (!in_array($region, ConversationApiClient::SUPPORTED_REGIONS, true)) {
-                throw new ValidationException("Region must be 'us' or 'eu'");
+                throw new ValidationException(sprintf(
+                    "Region must be one of: %s",
+                    implode(', ', ConversationApiClient::SUPPORTED_REGIONS),
+                ));
             }
         }
 

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -17,14 +17,12 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 use OpenCoreEMR\ModuleConfig\ConfigService as LibConfigService;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Logging\SystemLogger;
 
 class ConfigService
 {
-    /** @var list<string> */
-    public const SUPPORTED_REGIONS = ['us', 'eu'];
-
     private readonly LibConfigService $libConfigService;
     private readonly SystemLogger $logger;
 
@@ -123,7 +121,7 @@ class ConfigService
         // Validate region
         if (isset($settings['region'])) {
             $region = (string)$settings['region'];
-            if (!in_array($region, self::SUPPORTED_REGIONS, true)) {
+            if (!in_array($region, ConversationApiClient::SUPPORTED_REGIONS, true)) {
                 throw new ValidationException("Region must be 'us' or 'eu'");
             }
         }

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -20,6 +20,7 @@ use OpenCoreEMR\Modules\SinchConversations\Common\ArrayPath;
 use OpenCoreEMR\Modules\SinchConversations\Common\Json;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Logging\SystemLogger;
 
 class ConversationApiClient
@@ -471,12 +472,73 @@ class ConversationApiClient
      */
     public function getOAuth2Token(): string
     {
-        $region = $this->config->getSinchRegion();
-        $keyId = $this->config->getSinchApiKey();
-        $keySecret = $this->config->getSinchApiSecret();
+        return $this->requestOAuth2Token(
+            $this->config->getSinchRegion(),
+            $this->config->getSinchApiKey(),
+            $this->config->getSinchApiSecret(),
+        );
+    }
 
+    /**
+     * Validate Sinch credentials by exchanging them for an OAuth2 token and
+     * confirming the project/app are accessible. Used by the settings save
+     * flow to verify credentials before persisting them, so callers must
+     * pass the candidate values explicitly rather than read $this->config.
+     *
+     * @throws ValidationException When required fields are empty
+     * @throws ApiException When OAuth or app lookup fails
+     */
+    public function validateCredentials(
+        string $projectId,
+        string $appId,
+        string $apiKey,
+        string $apiSecret,
+        string $region,
+    ): void {
+        if ($projectId === '') {
+            throw new ValidationException('Project ID is required');
+        }
+        if ($appId === '') {
+            throw new ValidationException('App ID is required');
+        }
+        if ($apiKey === '') {
+            throw new ValidationException('API Key is required');
+        }
+        if ($apiSecret === '') {
+            throw new ValidationException('API Secret is required');
+        }
+        if ($region === '') {
+            throw new ValidationException('Region is required');
+        }
+
+        $accessToken = $this->requestOAuth2Token($region, $apiKey, $apiSecret);
+
+        try {
+            $response = $this->httpClient->get(
+                "/v1/projects/{$projectId}/apps/{$appId}",
+                [
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                        'Authorization' => "Bearer {$accessToken}",
+                    ],
+                ]
+            );
+        } catch (GuzzleException $e) {
+            $this->logger->error('Credential validation: app lookup failed', ['exception' => $e]);
+            throw new ApiException('Failed to verify app access', 0, $e);
+        }
+
+        $this->handleResponse($response);
+    }
+
+    private function requestOAuth2Token(string $region, string $keyId, string $keySecret): string
+    {
         if (empty($keyId) || empty($keySecret)) {
             throw new ApiException("API Key ID and Secret are required for OAuth2 authentication");
+        }
+
+        if ($region === '') {
+            throw new ApiException("Region is required for OAuth2 authentication");
         }
 
         try {

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -28,6 +28,9 @@ class ConversationApiClient
 {
     private const BASE_URL = 'https://us.conversation.api.sinch.com';
     private const CONSENT_MAX_PAGES = 100;
+
+    /** @var list<string> Sinch Conversations regions this client can talk to */
+    public const SUPPORTED_REGIONS = ['us', 'eu'];
     private readonly Client $httpClient;
     private readonly SystemLogger $logger;
     private ?string $cachedAccessToken = null;
@@ -545,8 +548,12 @@ class ConversationApiClient
             throw new ApiException("API Key ID and Secret are required for OAuth2 authentication");
         }
 
-        if ($region === '') {
-            throw new ApiException("Region is required for OAuth2 authentication");
+        if (!in_array($region, self::SUPPORTED_REGIONS, true)) {
+            throw new ApiException(sprintf(
+                "Unsupported Sinch region '%s'; supported regions are: %s",
+                $region,
+                implode(', ', self::SUPPORTED_REGIONS),
+            ));
         }
 
         try {

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -19,6 +19,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use OpenCoreEMR\Modules\SinchConversations\Common\ArrayPath;
 use OpenCoreEMR\Modules\SinchConversations\Common\Json;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -513,9 +514,14 @@ class ConversationApiClient
 
         $accessToken = $this->requestOAuth2Token($region, $apiKey, $apiSecret);
 
+        // Build the regional URL explicitly. The shared httpClient is bound
+        // to a hardcoded US base_uri, so a relative path would always hit
+        // us.conversation.api.sinch.com regardless of $region.
+        $url = "https://{$region}.conversation.api.sinch.com/v1/projects/{$projectId}/apps/{$appId}";
+
         try {
             $response = $this->httpClient->get(
-                "/v1/projects/{$projectId}/apps/{$appId}",
+                $url,
                 [
                     'headers' => [
                         'Content-Type' => 'application/json',
@@ -524,7 +530,9 @@ class ConversationApiClient
                 ]
             );
         } catch (GuzzleException $e) {
-            $this->logger->error('Credential validation: app lookup failed', ['exception' => $e]);
+            $this->logger->error('Credential validation: app lookup failed', [
+                'exception' => ExceptionContext::fromThrowable($e),
+            ]);
             throw new ApiException('Failed to verify app access', 0, $e);
         }
 

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -595,7 +595,9 @@ class ConversationApiClient
             $this->logger->debug("OAuth2 token obtained successfully");
             return $accessToken;
         } catch (GuzzleException $e) {
-            $this->logger->error('OAuth2 request failed', ['exception' => $e]);
+            $this->logger->error('OAuth2 request failed', [
+                'exception' => ExceptionContext::fromThrowable($e),
+            ]);
             throw new ApiException('OAuth2 request failed', 0, $e);
         }
     }

--- a/tests/Unit/Client/ConversationApiClientTest.php
+++ b/tests/Unit/Client/ConversationApiClientTest.php
@@ -22,6 +22,7 @@ use GuzzleHttp\Psr7\Response;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -246,6 +247,87 @@ class ConversationApiClientTest extends TestCase
         $this->expectException(ApiException::class);
         $this->expectExceptionMessage('Project ID is not configured');
         $client->testConnection();
+    }
+
+    // --- validateCredentials tests ---
+
+    public function testValidateCredentialsSuccess(): void
+    {
+        $client = $this->createClientWithoutToken([
+            new Response(200, [], '{"access_token": "validate-token"}'),
+            new Response(200, [], '{"id": "test-app", "display_name": "Test App"}'),
+        ]);
+
+        $client->validateCredentials('proj-x', 'app-x', 'key-x', 'secret-x', 'us');
+
+        $this->assertCount(2, $this->requestHistory);
+        $this->assertStringContainsString(
+            'auth.sinch.com/oauth2/token',
+            (string) $this->requestHistory[0]['request']->getUri()
+        );
+        $this->assertStringContainsString(
+            '/v1/projects/proj-x/apps/app-x',
+            (string) $this->requestHistory[1]['request']->getUri()
+        );
+        $this->assertSame(
+            'Bearer validate-token',
+            $this->requestHistory[1]['request']->getHeaderLine('Authorization')
+        );
+    }
+
+    public function testValidateCredentialsThrowsOnOAuthFailure(): void
+    {
+        $client = $this->createClientWithoutToken([
+            new Response(401, [], json_encode([
+                'error' => 'invalid_client',
+                'error_description' => 'Bad credentials',
+            ]) ?: '{}'),
+        ]);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Bad credentials');
+        $client->validateCredentials('proj-x', 'app-x', 'bad-key', 'bad-secret', 'us');
+    }
+
+    public function testValidateCredentialsThrowsOnAppLookupFailure(): void
+    {
+        $client = $this->createClientWithoutToken([
+            new Response(200, [], '{"access_token": "validate-token"}'),
+            new Response(404, [], json_encode([
+                'error' => ['message' => 'App not found'],
+            ]) ?: '{}'),
+        ]);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('App not found');
+        $client->validateCredentials('proj-x', 'missing-app', 'key-x', 'secret-x', 'us');
+    }
+
+    public function testValidateCredentialsThrowsOnEmptyProjectId(): void
+    {
+        $client = $this->createClientWithoutToken([]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Project ID is required');
+        $client->validateCredentials('', 'app-x', 'key-x', 'secret-x', 'us');
+    }
+
+    public function testValidateCredentialsThrowsOnEmptyAppId(): void
+    {
+        $client = $this->createClientWithoutToken([]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('App ID is required');
+        $client->validateCredentials('proj-x', '', 'key-x', 'secret-x', 'us');
+    }
+
+    public function testValidateCredentialsThrowsOnEmptySecret(): void
+    {
+        $client = $this->createClientWithoutToken([]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('API Secret is required');
+        $client->validateCredentials('proj-x', 'app-x', 'key-x', '', 'us');
     }
 
     // --- handleResponse error tests ---

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -23,6 +23,7 @@ use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
+use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
@@ -162,12 +163,16 @@ class SettingsControllerTest extends TestCase
         $_POST['project_id'] = 'new-proj';
         $_POST['app_id'] = 'new-app';
         $_POST['api_key'] = 'new-key';
+        $_POST['api_secret'] = 'new-secret';
         $_POST['region'] = 'eu';
         $_POST['default_channel'] = 'SMS';
         $_POST['clinic_name'] = 'New Clinic';
         $_POST['clinic_phone'] = '+15550000000';
         CsrfUtils::setVerifyResult(true);
 
+        $this->apiClient->expects($this->once())
+            ->method('validateCredentials')
+            ->with('new-proj', 'new-app', 'new-key', 'new-secret', 'eu');
         $this->configService->expects($this->once())->method('saveSettings');
         $this->session->expects($this->once())
             ->method('setFlash')
@@ -176,6 +181,50 @@ class SettingsControllerTest extends TestCase
         $response = $this->controller->dispatch('save');
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testSaveAbortsWhenCredentialValidationFails(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['csrf_token'] = 'valid';
+        $_POST['project_id'] = 'new-proj';
+        $_POST['app_id'] = 'new-app';
+        $_POST['api_key'] = 'new-key';
+        $_POST['api_secret'] = 'new-secret';
+        $_POST['region'] = 'us';
+        CsrfUtils::setVerifyResult(true);
+
+        $this->apiClient->method('validateCredentials')
+            ->willThrowException(new ApiException('OAuth2 authentication failed: Bad credentials', 401));
+        $this->configService->expects($this->never())->method('saveSettings');
+        $this->session->expects($this->once())
+            ->method('setFlash')
+            ->with(
+                'settings_message',
+                $this->callback(function (string $message): bool {
+                    return str_contains($message, 'could not be verified')
+                        && str_contains($message, '(ref:')
+                        && !str_contains($message, 'Bad credentials');
+                })
+            );
+
+        $response = $this->controller->dispatch('save');
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testSaveSkipsValidationWhenOnlyNonApiFieldsChange(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['csrf_token'] = 'valid';
+        $_POST['clinic_name'] = 'Renamed Clinic';
+        // No project_id/app_id/api_key in POST → validation skipped
+        CsrfUtils::setVerifyResult(true);
+
+        $this->apiClient->expects($this->never())->method('validateCredentials');
+        $this->configService->expects($this->once())->method('saveSettings');
+
+        $this->controller->dispatch('save');
     }
 
     public function testSaveExcludesAllFieldsWhenExternalConfig(): void

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -213,15 +213,44 @@ class SettingsControllerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $response);
     }
 
-    public function testSaveSkipsValidationWhenOnlyNonApiFieldsChange(): void
+    public function testSaveSkipsValidationWhenApiFieldsUnchanged(): void
     {
+        // The real settings form re-posts existing API values even on a
+        // clinic-name-only edit. Validation must skip in that case so an
+        // unrelated edit doesn't make a network call (or get blocked when
+        // Sinch is down).
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST['csrf_token'] = 'valid';
+        $_POST['project_id'] = 'proj-1';
+        $_POST['app_id'] = 'app-1';
+        $_POST['api_key'] = 'key-1';
+        $_POST['region'] = 'us';
+        $_POST['api_secret'] = ''; // Left blank → keep stored secret
         $_POST['clinic_name'] = 'Renamed Clinic';
-        // No project_id/app_id/api_key in POST → validation skipped
         CsrfUtils::setVerifyResult(true);
 
         $this->apiClient->expects($this->never())->method('validateCredentials');
+        $this->configService->expects($this->once())->method('saveSettings');
+
+        $this->controller->dispatch('save');
+    }
+
+    public function testSaveValidatesWhenApiKeyChanges(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['csrf_token'] = 'valid';
+        $_POST['project_id'] = 'proj-1';
+        $_POST['app_id'] = 'app-1';
+        $_POST['api_key'] = 'rotated-key';
+        $_POST['region'] = 'us';
+        $_POST['api_secret'] = ''; // Reuses stored secret
+        CsrfUtils::setVerifyResult(true);
+
+        // api_key changed → validation runs, reusing the stored secret
+        // (decoded value of base64('secret-1') from setUp).
+        $this->apiClient->expects($this->once())
+            ->method('validateCredentials')
+            ->with('proj-1', 'app-1', 'rotated-key', $this->anything(), 'us');
         $this->configService->expects($this->once())->method('saveSettings');
 
         $this->controller->dispatch('save');

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -235,6 +235,47 @@ class SettingsControllerTest extends TestCase
         $this->controller->dispatch('save');
     }
 
+    public function testSaveRejectsApiTupleWithoutSecret(): void
+    {
+        // First-time API config: no secret stored, none typed. The save
+        // must be refused with a clear local message rather than silently
+        // persisting a project/app/key tuple that can never authenticate.
+        $config = new GlobalConfig(new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_REGION => 'us',
+        ]), new MockConfigFactory());
+        $controller = new SettingsController(
+            $config,
+            $this->configService,
+            $this->apiClient,
+            $this->syncService,
+            $this->session,
+            $this->twig,
+            new SystemLogger()
+        );
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['csrf_token'] = 'valid';
+        $_POST['project_id'] = 'new-proj';
+        $_POST['app_id'] = 'new-app';
+        $_POST['api_key'] = 'new-key';
+        $_POST['region'] = 'us';
+        $_POST['api_secret'] = '';
+        CsrfUtils::setVerifyResult(true);
+
+        $this->apiClient->expects($this->never())->method('validateCredentials');
+        $this->configService->expects($this->never())->method('saveSettings');
+        $this->session->expects($this->once())
+            ->method('setFlash')
+            ->with(
+                'settings_message',
+                $this->stringContains('API Secret is required')
+            );
+
+        $response = $controller->dispatch('save');
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
     public function testSaveValidatesWhenApiKeyChanges(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';

--- a/tests/Unit/Service/ConfigServiceTest.php
+++ b/tests/Unit/Service/ConfigServiceTest.php
@@ -42,7 +42,7 @@ class ConfigServiceTest extends TestCase
     public function testSaveSettingsRejectsInvalidRegion(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("Region must be 'us' or 'eu'");
+        $this->expectExceptionMessage('Region must be one of: us, eu');
 
         $this->service->saveSettings(['region' => 'invalid']);
     }


### PR DESCRIPTION
## Summary

Closes #104.

The settings save flow now verifies that the supplied Sinch credentials
can exchange for an OAuth2 token and read the configured app before any
of them are written to globals. Misconfiguration shows up at submit time
with a clear "credentials could not be verified" message instead of
silently accepting the values and failing later at first message send.

- `ConversationApiClient::validateCredentials($projectId, $appId, $apiKey, $apiSecret, $region)` takes credentials as parameters (independent of `GlobalConfig`) so candidate values can be checked before persistence. It performs an OAuth2 token exchange against `${region}.auth.sinch.com` and a `GET /v1/projects/{id}/apps/{id}` with the resulting bearer token.
- `SettingsController::handleSave` runs validation whenever the resolved API tuple is fully populated (form values, falling back to the stored secret when the secret field is left blank). On failure it flashes a generic error with a traceable error ID and returns without calling `ConfigService::saveSettings`. Saves that touch only non-API fields (e.g. clinic name) skip the network call.
- The OAuth2 HTTP call is extracted to a private `requestOAuth2Token($region, $keyId, $keySecret)` helper so both `getOAuth2Token()` and `validateCredentials()` share it.

## Test plan

- [x] `task check` (lint, phpstan, phpcs, rector, composer-require-checker, CLI smoke test)
- [x] `composer test` (526 tests, 1347 assertions)
- [ ] Manual UI: save with bad api_secret → flash shows validation failure, settings not persisted
- [ ] Manual UI: save with valid credentials → success flash, settings persisted
- [ ] Manual UI: save only clinic_name → succeeds, no Sinch call