### PR TITLE
fix(reminders): expand recurring appointments into per-occurrence SMS reminders

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -47,6 +47,7 @@
     "attr",
     "text",
     "date",
+    "fetchAllEvents",
     "random_bytes"
   ],
   "php-core-extensions": [

--- a/ModuleManagerListener.php
+++ b/ModuleManagerListener.php
@@ -20,6 +20,8 @@
 
 declare(strict_types=1);
 
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+use OpenCoreEMR\Modules\SinchConversations\Schema\ReminderTableMigration;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 
@@ -81,7 +83,12 @@ class ModuleManagerListener
             $errorId = \OpenCoreEMR\Modules\SinchConversations\ErrorId::generate();
             (new SystemLogger())->error(
                 'Background service lifecycle action failed',
-                ['errorId' => $errorId, 'method' => $methodName, 'mod_id' => $modId, 'exception' => $e]
+                [
+                    'errorId' => $errorId,
+                    'method' => $methodName,
+                    'mod_id' => $modId,
+                    'exception' => ExceptionContext::fromThrowable($e),
+                ]
             );
             return "Background service $methodName failed (ref: $errorId). Check logs for details.";
         }
@@ -112,7 +119,7 @@ class ModuleManagerListener
     private function enable(): void
     {
         $this->registerBackgroundService();
-        $this->migrateAppointmentRemindersSchema();
+        ReminderTableMigration::ensureUpgraded();
         $this->setBackgroundServiceActive(true);
     }
 
@@ -189,77 +196,5 @@ class ModuleManagerListener
             SQL;
 
         QueryUtils::sqlStatementThrowException($sql, [self::SERVICE_NAME]);
-    }
-
-    /**
-     * In-place upgrade for the appointment reminders dedup table.
-     *
-     * Earlier versions used UNIQUE KEY (pc_eid). That blocks all but the
-     * first occurrence of a recurring appointment from ever sending an
-     * SMS reminder. The new key is (pc_eid, occurrence_date). Module
-     * installers run table.sql on install only, so existing tenants need
-     * an in-place migration on enable.
-     *
-     * Idempotent: detects the new shape via INFORMATION_SCHEMA and
-     * returns immediately if the column already exists.
-     *
-     * Pre-existing dedup rows backfill `occurrence_date` from the parent
-     * event's `pc_eventDate`. For one-shots that's the correct value.
-     * For pre-existing recurring rows (which never sent more than one
-     * reminder anyway under the old key) the backfill is a best-effort
-     * that may cause one occurrence-mismatch dedup; the 90-day TTL on
-     * these rows bounds the impact.
-     *
-     * @throws \Throwable on database failure
-     */
-    private function migrateAppointmentRemindersSchema(): void
-    {
-        $columns = QueryUtils::fetchRecords(
-            'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
-             WHERE TABLE_SCHEMA = DATABASE()
-               AND TABLE_NAME = ?
-               AND COLUMN_NAME = ?',
-            ['oce_sinch_appointment_reminders', 'occurrence_date']
-        );
-        if (count($columns) > 0) {
-            return;
-        }
-
-        // Verify the table itself exists — if it doesn't, install hasn't
-        // happened yet and table.sql will create the new shape directly.
-        $tables = QueryUtils::fetchRecords(
-            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
-             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
-            ['oce_sinch_appointment_reminders']
-        );
-        if (count($tables) === 0) {
-            return;
-        }
-
-        QueryUtils::sqlStatementThrowException(
-            'ALTER TABLE `oce_sinch_appointment_reminders`
-                ADD COLUMN `occurrence_date` DATE NULL AFTER `pc_eid`'
-        );
-
-        QueryUtils::sqlStatementThrowException(
-            'UPDATE `oce_sinch_appointment_reminders` r
-             INNER JOIN `openemr_postcalendar_events` e ON e.pc_eid = r.pc_eid
-             SET r.occurrence_date = e.pc_eventDate
-             WHERE r.occurrence_date IS NULL'
-        );
-
-        // Drop any rows the join above could not backfill — they reference
-        // events that no longer exist, so dedup state is moot.
-        QueryUtils::sqlStatementThrowException(
-            'DELETE FROM `oce_sinch_appointment_reminders` WHERE `occurrence_date` IS NULL'
-        );
-
-        QueryUtils::sqlStatementThrowException(
-            'ALTER TABLE `oce_sinch_appointment_reminders`
-                MODIFY `occurrence_date` DATE NOT NULL,
-                DROP INDEX `unique_event_reminder`,
-                ADD UNIQUE KEY `unique_event_occurrence` (`pc_eid`, `occurrence_date`),
-                ADD INDEX `idx_occurrence_date` (`occurrence_date`)'
-        );
     }
 }

--- a/ModuleManagerListener.php
+++ b/ModuleManagerListener.php
@@ -112,6 +112,7 @@ class ModuleManagerListener
     private function enable(): void
     {
         $this->registerBackgroundService();
+        $this->migrateAppointmentRemindersSchema();
         $this->setBackgroundServiceActive(true);
     }
 
@@ -188,5 +189,77 @@ class ModuleManagerListener
             SQL;
 
         QueryUtils::sqlStatementThrowException($sql, [self::SERVICE_NAME]);
+    }
+
+    /**
+     * In-place upgrade for the appointment reminders dedup table.
+     *
+     * Earlier versions used UNIQUE KEY (pc_eid). That blocks all but the
+     * first occurrence of a recurring appointment from ever sending an
+     * SMS reminder. The new key is (pc_eid, occurrence_date). Module
+     * installers run table.sql on install only, so existing tenants need
+     * an in-place migration on enable.
+     *
+     * Idempotent: detects the new shape via INFORMATION_SCHEMA and
+     * returns immediately if the column already exists.
+     *
+     * Pre-existing dedup rows backfill `occurrence_date` from the parent
+     * event's `pc_eventDate`. For one-shots that's the correct value.
+     * For pre-existing recurring rows (which never sent more than one
+     * reminder anyway under the old key) the backfill is a best-effort
+     * that may cause one occurrence-mismatch dedup; the 90-day TTL on
+     * these rows bounds the impact.
+     *
+     * @throws \Throwable on database failure
+     */
+    private function migrateAppointmentRemindersSchema(): void
+    {
+        $columns = QueryUtils::fetchRecords(
+            'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ?
+               AND COLUMN_NAME = ?',
+            ['oce_sinch_appointment_reminders', 'occurrence_date']
+        );
+        if (count($columns) > 0) {
+            return;
+        }
+
+        // Verify the table itself exists — if it doesn't, install hasn't
+        // happened yet and table.sql will create the new shape directly.
+        $tables = QueryUtils::fetchRecords(
+            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders']
+        );
+        if (count($tables) === 0) {
+            return;
+        }
+
+        QueryUtils::sqlStatementThrowException(
+            'ALTER TABLE `oce_sinch_appointment_reminders`
+                ADD COLUMN `occurrence_date` DATE NULL AFTER `pc_eid`'
+        );
+
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `oce_sinch_appointment_reminders` r
+             INNER JOIN `openemr_postcalendar_events` e ON e.pc_eid = r.pc_eid
+             SET r.occurrence_date = e.pc_eventDate
+             WHERE r.occurrence_date IS NULL'
+        );
+
+        // Drop any rows the join above could not backfill — they reference
+        // events that no longer exist, so dedup state is moot.
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `oce_sinch_appointment_reminders` WHERE `occurrence_date` IS NULL'
+        );
+
+        QueryUtils::sqlStatementThrowException(
+            'ALTER TABLE `oce_sinch_appointment_reminders`
+                MODIFY `occurrence_date` DATE NOT NULL,
+                DROP INDEX `unique_event_reminder`,
+                ADD UNIQUE KEY `unique_event_occurrence` (`pc_eid`, `occurrence_date`),
+                ADD INDEX `idx_occurrence_date` (`occurrence_date`)'
+        );
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -48,7 +48,7 @@ parameters:
                 - src/Module/Console/Command/AbstractModuleCommand.php
 
         # OpenEMR global functions not available for static analysis
-        - '#Function (xl|xlt|xla|xlj|text|attr) not found#'
+        - '#Function (xl|xlt|xla|xlj|text|attr|fetchAllEvents) not found#'
 
         # Never-read properties are intentional (event handlers, etc.)
         - '#Property .+ is never read, only written#'

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -360,7 +360,18 @@ class Bootstrap
         return new Service\AppointmentReminderService(
             $this->globalsConfig,
             $this->getTemplateService(),
-            $this->getMessageService()
+            $this->getMessageService(),
+            $this->getUpcomingAppointmentFinder()
         );
+    }
+
+    /**
+     * Get Upcoming Appointment Finder
+     *
+     * Production wraps core OpenEMR's recurrence-aware fetchAllEvents().
+     */
+    public function getUpcomingAppointmentFinder(): Service\UpcomingAppointmentFinder
+    {
+        return new Service\CoreAppointmentFinder();
     }
 }

--- a/src/Module/Listener/AppointmentSmsStatusJsListener.php
+++ b/src/Module/Listener/AppointmentSmsStatusJsListener.php
@@ -47,8 +47,7 @@ class AppointmentSmsStatusJsListener
     public function onRenderJavascript(AppointmentRenderEvent $event): void
     {
         unset($event); // signature is fixed by the dispatcher; nothing in $event is needed here
-        $webrootValue = OEGlobalsBag::getInstance()->get('webroot');
-        $webroot = is_string($webrootValue) ? $webrootValue : '';
+        $webroot = OEGlobalsBag::getInstance()->getString('webroot');
         $url = $webroot . '/interface/modules/custom_modules/' . Bootstrap::MODULE_NAME . '/public/eligibility.php';
 
         // Embed every dynamic value as JSON so any future webroot change

--- a/src/Module/Schema/ReminderTableMigration.php
+++ b/src/Module/Schema/ReminderTableMigration.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Schema;
 
+use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
 
 final class ReminderTableMigration
 {
@@ -44,7 +46,7 @@ final class ReminderTableMigration
     private const OLD_UNIQUE_INDEX = 'unique_event_reminder';
     private const NEW_UNIQUE_INDEX = 'unique_event_occurrence';
     private const DATE_INDEX = 'idx_occurrence_date';
-    private const LOCK_NAME = 'oce_sinch_reminder_migration';
+    private const LOCK_NAME_PREFIX = 'oce_sinch_reminder_migration';
     private const LOCK_TIMEOUT_SECONDS = 30;
 
     /**
@@ -55,9 +57,16 @@ final class ReminderTableMigration
      *
      * Concurrency: this method runs from both `ModuleManagerListener::enable()`
      * and the reminder cron, which can race (admin clicks Enable while a cron
-     * tick is mid-run). A MySQL session-level advisory lock (`GET_LOCK`)
-     * serialises the migration so two callers don't both attempt
-     * `ADD COLUMN` / `DROP INDEX` and one fail with a duplicate-DDL error.
+     * tick is mid-run). A MySQL advisory lock (`GET_LOCK`) serialises the
+     * migration so two callers don't both attempt `ADD COLUMN` / `DROP INDEX`
+     * and one fail with a duplicate-DDL error.
+     *
+     * `GET_LOCK` is server-wide, not database-scoped. On a shared MySQL
+     * instance hosting multiple tenant databases, a bare lock name would
+     * collide across tenants. The lock name therefore includes the current
+     * `DATABASE()` so each tenant's migration serialises against itself
+     * only.
+     *
      * The fast-path probe at the top avoids taking the lock entirely once
      * the table is fully migrated.
      *
@@ -75,7 +84,9 @@ final class ReminderTableMigration
             return;
         }
 
-        if (!self::acquireLock()) {
+        $lockName = self::buildLockName();
+
+        if (!self::acquireLock($lockName)) {
             // Another process is already migrating. Wait was up to
             // LOCK_TIMEOUT_SECONDS; if they finished in that window the
             // table is now migrated and we can return cleanly. Otherwise
@@ -87,7 +98,7 @@ final class ReminderTableMigration
             }
             throw new \RuntimeException(sprintf(
                 'Could not acquire migration advisory lock "%s" within %ds',
-                self::LOCK_NAME,
+                $lockName,
                 self::LOCK_TIMEOUT_SECONDS
             ));
         }
@@ -102,7 +113,7 @@ final class ReminderTableMigration
 
             self::runMigrationSteps($shape);
         } finally {
-            self::releaseLock();
+            self::releaseLock($lockName);
         }
     }
 
@@ -119,57 +130,58 @@ final class ReminderTableMigration
     private static function runMigrationSteps(array $shape): void
     {
         if (!$shape['column_exists']) {
-            QueryUtils::sqlStatementThrowException(
-                'ALTER TABLE `' . self::TABLE . '`
-                    ADD COLUMN `' . self::COLUMN . '` DATE NULL AFTER `pc_eid`'
-            );
+            QueryUtils::sqlStatementThrowException(<<<'SQL'
+                ALTER TABLE `oce_sinch_appointment_reminders`
+                    ADD COLUMN `occurrence_date` DATE NULL AFTER `pc_eid`
+                SQL);
         }
 
         // Backfill from the parent event date for any rows still missing
         // the column value. Safe to run unconditionally — if everything is
         // already populated the UPDATE matches zero rows.
-        QueryUtils::sqlStatementThrowException(
-            'UPDATE `' . self::TABLE . '` r
-             INNER JOIN `openemr_postcalendar_events` e ON e.pc_eid = r.pc_eid
-             SET r.`' . self::COLUMN . '` = e.pc_eventDate
-             WHERE r.`' . self::COLUMN . '` IS NULL'
-        );
+        QueryUtils::sqlStatementThrowException(<<<'SQL'
+            UPDATE `oce_sinch_appointment_reminders` r
+            INNER JOIN `openemr_postcalendar_events` e ON e.pc_eid = r.pc_eid
+            SET r.`occurrence_date` = e.pc_eventDate
+            WHERE r.`occurrence_date` IS NULL
+            SQL);
 
         // Drop any rows the join above could not backfill — they reference
         // events that no longer exist, so dedup state is moot.
-        QueryUtils::sqlStatementThrowException(
-            'DELETE FROM `' . self::TABLE . '` WHERE `' . self::COLUMN . '` IS NULL'
-        );
+        QueryUtils::sqlStatementThrowException(<<<'SQL'
+            DELETE FROM `oce_sinch_appointment_reminders` WHERE `occurrence_date` IS NULL
+            SQL);
 
         // MODIFY runs when the column was already nullable, OR when this
         // call just added it (ADD COLUMN above creates it as NULL so the
         // backfill UPDATE can populate existing rows before the NOT NULL
         // constraint locks in).
         if ($shape['column_nullable'] || !$shape['column_exists']) {
-            QueryUtils::sqlStatementThrowException(
-                'ALTER TABLE `' . self::TABLE . '`
-                    MODIFY `' . self::COLUMN . '` DATE NOT NULL'
-            );
+            QueryUtils::sqlStatementThrowException(<<<'SQL'
+                ALTER TABLE `oce_sinch_appointment_reminders`
+                    MODIFY `occurrence_date` DATE NOT NULL
+                SQL);
         }
 
         if ($shape['old_unique_index_exists']) {
-            QueryUtils::sqlStatementThrowException(
-                'ALTER TABLE `' . self::TABLE . '` DROP INDEX `' . self::OLD_UNIQUE_INDEX . '`'
-            );
+            QueryUtils::sqlStatementThrowException(<<<'SQL'
+                ALTER TABLE `oce_sinch_appointment_reminders`
+                    DROP INDEX `unique_event_reminder`
+                SQL);
         }
 
         if (!$shape['new_unique_index_exists']) {
-            QueryUtils::sqlStatementThrowException(
-                'ALTER TABLE `' . self::TABLE . '`
-                    ADD UNIQUE KEY `' . self::NEW_UNIQUE_INDEX . '` (`pc_eid`, `' . self::COLUMN . '`)'
-            );
+            QueryUtils::sqlStatementThrowException(<<<'SQL'
+                ALTER TABLE `oce_sinch_appointment_reminders`
+                    ADD UNIQUE KEY `unique_event_occurrence` (`pc_eid`, `occurrence_date`)
+                SQL);
         }
 
         if (!$shape['date_index_exists']) {
-            QueryUtils::sqlStatementThrowException(
-                'ALTER TABLE `' . self::TABLE . '`
-                    ADD INDEX `' . self::DATE_INDEX . '` (`' . self::COLUMN . '`)'
-            );
+            QueryUtils::sqlStatementThrowException(<<<'SQL'
+                ALTER TABLE `oce_sinch_appointment_reminders`
+                    ADD INDEX `idx_occurrence_date` (`occurrence_date`)
+                SQL);
         }
     }
 
@@ -204,18 +216,38 @@ final class ReminderTableMigration
             [self::TABLE, self::COLUMN]
         );
         $columnExists = count($columns) > 0;
-        $columnNullable = $columnExists
-            && (string) ($columns[0]['IS_NULLABLE'] ?? '') === 'YES';
+        // INFORMATION_SCHEMA contracts IS_NULLABLE as 'YES' or 'NO'.
+        // Narrow rather than cast so a non-string value surfaces as a
+        // hard failure instead of silently flipping to "non-nullable".
+        $columnNullable = false;
+        if ($columnExists) {
+            $isNullable = $columns[0]['IS_NULLABLE'] ?? null;
+            if (!is_string($isNullable)) {
+                throw new \RuntimeException(sprintf(
+                    'INFORMATION_SCHEMA.COLUMNS.IS_NULLABLE was not a string for %s.%s',
+                    self::TABLE,
+                    self::COLUMN
+                ));
+            }
+            $columnNullable = strtoupper($isNullable) === 'YES';
+        }
 
         $indexRows = QueryUtils::fetchRecords(
             'SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS
              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
             [self::TABLE]
         );
-        $indexNames = array_map(
-            static fn(array $row): string => (string) ($row['INDEX_NAME'] ?? ''),
-            $indexRows
-        );
+        $indexNames = [];
+        foreach ($indexRows as $row) {
+            $name = $row['INDEX_NAME'] ?? null;
+            if (!is_string($name)) {
+                throw new \RuntimeException(sprintf(
+                    'INFORMATION_SCHEMA.STATISTICS.INDEX_NAME was not a string for %s',
+                    self::TABLE
+                ));
+            }
+            $indexNames[] = $name;
+        }
         $oldUnique = in_array(self::OLD_UNIQUE_INDEX, $indexNames, true);
         $newUnique = in_array(self::NEW_UNIQUE_INDEX, $indexNames, true);
         $dateIndex = in_array(self::DATE_INDEX, $indexNames, true);
@@ -237,29 +269,68 @@ final class ReminderTableMigration
     }
 
     /**
-     * Acquire a MySQL session-level advisory lock.
+     * Build the per-tenant advisory lock name.
+     *
+     * `GET_LOCK` is server-wide (not database-scoped). On a shared MySQL
+     * instance hosting multiple tenants, a bare lock name would let one
+     * tenant's migration block another's. Suffix with `DATABASE()` so
+     * each tenant serialises against itself only.
+     */
+    private static function buildLockName(): string
+    {
+        $row = QueryUtils::fetchRecords('SELECT DATABASE() AS db');
+        $db = $row[0]['db'] ?? null;
+        if (!is_string($db) || $db === '') {
+            // No current database — without a tenant suffix the lock would
+            // collide across tenants on a shared MySQL instance, which is
+            // exactly what the per-tenant scheme exists to prevent. Refuse.
+            throw new \RuntimeException(
+                'SELECT DATABASE() returned no value; cannot build per-tenant migration lock name'
+            );
+        }
+        return self::LOCK_NAME_PREFIX . ':' . $db;
+    }
+
+    /**
+     * Acquire a MySQL advisory lock.
      *
      * `GET_LOCK` returns 1 on success, 0 on timeout, NULL on error or
      * when the connection's wait was killed. Treat anything other than
      * 1 as "not acquired".
      */
-    private static function acquireLock(): bool
+    private static function acquireLock(string $lockName): bool
     {
         $row = QueryUtils::fetchRecords(
             'SELECT GET_LOCK(?, ?) AS got',
-            [self::LOCK_NAME, self::LOCK_TIMEOUT_SECONDS]
+            [$lockName, self::LOCK_TIMEOUT_SECONDS]
         );
-        return (int) ($row[0]['got'] ?? 0) === 1;
+        $got = $row[0]['got'] ?? null;
+        // GET_LOCK returns 1, 0, or NULL. Mock layers may surface a string;
+        // coerce only after narrowing to a scalar so non-scalar surprises
+        // (driver bugs, mocks gone wrong) bubble up as a hard failure.
+        return is_int($got) ? $got === 1 : (is_string($got) && $got === '1');
     }
 
     /**
      * Release the advisory lock acquired by acquireLock().
+     *
+     * Errors here are logged but never re-thrown: this runs from
+     * `finally`, and re-throwing would mask whatever exception caused
+     * `runMigrationSteps()` to fail. The lock will free when the
+     * session terminates regardless.
      */
-    private static function releaseLock(): void
+    private static function releaseLock(string $lockName): void
     {
-        QueryUtils::sqlStatementThrowException(
-            'DO RELEASE_LOCK(?)',
-            [self::LOCK_NAME]
-        );
+        try {
+            QueryUtils::sqlStatementThrowException('DO RELEASE_LOCK(?)', [$lockName]);
+        } catch (\Throwable $e) {
+            (new SystemLogger())->warning(
+                'Failed to release reminder migration advisory lock; will free at session end',
+                [
+                    'lock_name' => $lockName,
+                    'exception' => ExceptionContext::fromThrowable($e),
+                ]
+            );
+        }
     }
 }

--- a/src/Module/Schema/ReminderTableMigration.php
+++ b/src/Module/Schema/ReminderTableMigration.php
@@ -44,12 +44,22 @@ final class ReminderTableMigration
     private const OLD_UNIQUE_INDEX = 'unique_event_reminder';
     private const NEW_UNIQUE_INDEX = 'unique_event_occurrence';
     private const DATE_INDEX = 'idx_occurrence_date';
+    private const LOCK_NAME = 'oce_sinch_reminder_migration';
+    private const LOCK_TIMEOUT_SECONDS = 30;
 
     /**
      * Bring the dedup table to the target shape.
      *
      * Idempotent and partial-migration safe. No-op once the table is fully
      * migrated, or when the table doesn't exist yet (install hasn't run).
+     *
+     * Concurrency: this method runs from both `ModuleManagerListener::enable()`
+     * and the reminder cron, which can race (admin clicks Enable while a cron
+     * tick is mid-run). A MySQL session-level advisory lock (`GET_LOCK`)
+     * serialises the migration so two callers don't both attempt
+     * `ADD COLUMN` / `DROP INDEX` and one fail with a duplicate-DDL error.
+     * The fast-path probe at the top avoids taking the lock entirely once
+     * the table is fully migrated.
      *
      * @throws \Throwable on database failure
      */
@@ -65,6 +75,49 @@ final class ReminderTableMigration
             return;
         }
 
+        if (!self::acquireLock()) {
+            // Another process is already migrating. Wait was up to
+            // LOCK_TIMEOUT_SECONDS; if they finished in that window the
+            // table is now migrated and we can return cleanly. Otherwise
+            // surface the timeout — the caller (cron / enable) will log
+            // and we'll retry next tick.
+            $shape = self::probeShape();
+            if ($shape !== null && $shape['fully_migrated']) {
+                return;
+            }
+            throw new \RuntimeException(sprintf(
+                'Could not acquire migration advisory lock "%s" within %ds',
+                self::LOCK_NAME,
+                self::LOCK_TIMEOUT_SECONDS
+            ));
+        }
+
+        try {
+            // Re-probe under the lock — the previous holder may have
+            // completed the migration while we waited.
+            $shape = self::probeShape();
+            if ($shape === null || $shape['fully_migrated']) {
+                return;
+            }
+
+            self::runMigrationSteps($shape);
+        } finally {
+            self::releaseLock();
+        }
+    }
+
+    /**
+     * @param array{
+     *     column_exists: bool,
+     *     column_nullable: bool,
+     *     old_unique_index_exists: bool,
+     *     new_unique_index_exists: bool,
+     *     date_index_exists: bool,
+     *     fully_migrated: bool
+     * } $shape
+     */
+    private static function runMigrationSteps(array $shape): void
+    {
         if (!$shape['column_exists']) {
             QueryUtils::sqlStatementThrowException(
                 'ALTER TABLE `' . self::TABLE . '`
@@ -181,5 +234,32 @@ final class ReminderTableMigration
             'date_index_exists' => $dateIndex,
             'fully_migrated' => $fullyMigrated,
         ];
+    }
+
+    /**
+     * Acquire a MySQL session-level advisory lock.
+     *
+     * `GET_LOCK` returns 1 on success, 0 on timeout, NULL on error or
+     * when the connection's wait was killed. Treat anything other than
+     * 1 as "not acquired".
+     */
+    private static function acquireLock(): bool
+    {
+        $row = QueryUtils::fetchRecords(
+            'SELECT GET_LOCK(?, ?) AS got',
+            [self::LOCK_NAME, self::LOCK_TIMEOUT_SECONDS]
+        );
+        return (int) ($row[0]['got'] ?? 0) === 1;
+    }
+
+    /**
+     * Release the advisory lock acquired by acquireLock().
+     */
+    private static function releaseLock(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DO RELEASE_LOCK(?)',
+            [self::LOCK_NAME]
+        );
     }
 }

--- a/src/Module/Schema/ReminderTableMigration.php
+++ b/src/Module/Schema/ReminderTableMigration.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * In-place schema migration for `oce_sinch_appointment_reminders`.
+ *
+ * Earlier versions used UNIQUE KEY (pc_eid). That blocks all but the first
+ * occurrence of a recurring appointment from ever sending an SMS reminder.
+ * The new key is (pc_eid, occurrence_date). Module installers run table.sql
+ * on install only, so existing tenants need an in-place upgrade.
+ *
+ * The migration is invoked from two places:
+ *
+ * 1. `ModuleManagerListener::enable()` — covers fresh installs and explicit
+ *    re-enables after an upgrade.
+ * 2. `AppointmentReminderService::run()` — covers the case where a tenant
+ *    upgrades the module code without disabling/re-enabling the module.
+ *    Without this safety net, `loadSentOccurrences()` would hard-fail
+ *    against the legacy column-less table.
+ *
+ * The end-state probe verifies the column exists, is NOT NULL, the new
+ * unique key is present, and the old unique key is gone. Each remediation
+ * step then runs only if its specific precondition is unmet, so a partially
+ * applied migration (e.g., enable was interrupted between ALTERs) finishes
+ * cleanly on the next call instead of short-circuiting on "column exists"
+ * and leaving the table in a half-migrated state.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Schema;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+final class ReminderTableMigration
+{
+    private const TABLE = 'oce_sinch_appointment_reminders';
+    private const COLUMN = 'occurrence_date';
+    private const OLD_UNIQUE_INDEX = 'unique_event_reminder';
+    private const NEW_UNIQUE_INDEX = 'unique_event_occurrence';
+    private const DATE_INDEX = 'idx_occurrence_date';
+
+    /**
+     * Bring the dedup table to the target shape.
+     *
+     * Idempotent and partial-migration safe. No-op once the table is fully
+     * migrated, or when the table doesn't exist yet (install hasn't run).
+     *
+     * @throws \Throwable on database failure
+     */
+    public static function ensureUpgraded(): void
+    {
+        $shape = self::probeShape();
+        if ($shape === null) {
+            // Table absent — install hasn't run; table.sql will create
+            // the new shape directly.
+            return;
+        }
+        if ($shape['fully_migrated']) {
+            return;
+        }
+
+        if (!$shape['column_exists']) {
+            QueryUtils::sqlStatementThrowException(
+                'ALTER TABLE `' . self::TABLE . '`
+                    ADD COLUMN `' . self::COLUMN . '` DATE NULL AFTER `pc_eid`'
+            );
+        }
+
+        // Backfill from the parent event date for any rows still missing
+        // the column value. Safe to run unconditionally — if everything is
+        // already populated the UPDATE matches zero rows.
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `' . self::TABLE . '` r
+             INNER JOIN `openemr_postcalendar_events` e ON e.pc_eid = r.pc_eid
+             SET r.`' . self::COLUMN . '` = e.pc_eventDate
+             WHERE r.`' . self::COLUMN . '` IS NULL'
+        );
+
+        // Drop any rows the join above could not backfill — they reference
+        // events that no longer exist, so dedup state is moot.
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `' . self::TABLE . '` WHERE `' . self::COLUMN . '` IS NULL'
+        );
+
+        // MODIFY runs when the column was already nullable, OR when this
+        // call just added it (ADD COLUMN above creates it as NULL so the
+        // backfill UPDATE can populate existing rows before the NOT NULL
+        // constraint locks in).
+        if ($shape['column_nullable'] || !$shape['column_exists']) {
+            QueryUtils::sqlStatementThrowException(
+                'ALTER TABLE `' . self::TABLE . '`
+                    MODIFY `' . self::COLUMN . '` DATE NOT NULL'
+            );
+        }
+
+        if ($shape['old_unique_index_exists']) {
+            QueryUtils::sqlStatementThrowException(
+                'ALTER TABLE `' . self::TABLE . '` DROP INDEX `' . self::OLD_UNIQUE_INDEX . '`'
+            );
+        }
+
+        if (!$shape['new_unique_index_exists']) {
+            QueryUtils::sqlStatementThrowException(
+                'ALTER TABLE `' . self::TABLE . '`
+                    ADD UNIQUE KEY `' . self::NEW_UNIQUE_INDEX . '` (`pc_eid`, `' . self::COLUMN . '`)'
+            );
+        }
+
+        if (!$shape['date_index_exists']) {
+            QueryUtils::sqlStatementThrowException(
+                'ALTER TABLE `' . self::TABLE . '`
+                    ADD INDEX `' . self::DATE_INDEX . '` (`' . self::COLUMN . '`)'
+            );
+        }
+    }
+
+    /**
+     * Inspect the current table shape.
+     *
+     * @return array{
+     *     column_exists: bool,
+     *     column_nullable: bool,
+     *     old_unique_index_exists: bool,
+     *     new_unique_index_exists: bool,
+     *     date_index_exists: bool,
+     *     fully_migrated: bool
+     * }|null  null when the table doesn't exist
+     */
+    private static function probeShape(): ?array
+    {
+        $tables = QueryUtils::fetchRecords(
+            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            [self::TABLE]
+        );
+        if (count($tables) === 0) {
+            return null;
+        }
+
+        $columns = QueryUtils::fetchRecords(
+            'SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ?
+               AND COLUMN_NAME = ?',
+            [self::TABLE, self::COLUMN]
+        );
+        $columnExists = count($columns) > 0;
+        $columnNullable = $columnExists
+            && (string) ($columns[0]['IS_NULLABLE'] ?? '') === 'YES';
+
+        $indexRows = QueryUtils::fetchRecords(
+            'SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            [self::TABLE]
+        );
+        $indexNames = array_map(
+            static fn(array $row): string => (string) ($row['INDEX_NAME'] ?? ''),
+            $indexRows
+        );
+        $oldUnique = in_array(self::OLD_UNIQUE_INDEX, $indexNames, true);
+        $newUnique = in_array(self::NEW_UNIQUE_INDEX, $indexNames, true);
+        $dateIndex = in_array(self::DATE_INDEX, $indexNames, true);
+
+        $fullyMigrated = $columnExists
+            && !$columnNullable
+            && !$oldUnique
+            && $newUnique
+            && $dateIndex;
+
+        return [
+            'column_exists' => $columnExists,
+            'column_nullable' => $columnNullable,
+            'old_unique_index_exists' => $oldUnique,
+            'new_unique_index_exists' => $newUnique,
+            'date_index_exists' => $dateIndex,
+            'fully_migrated' => $fullyMigrated,
+        ];
+    }
+}

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -32,7 +32,8 @@ class AppointmentReminderService
     public function __construct(
         private readonly GlobalConfig $config,
         private readonly TemplateService $templateService,
-        private readonly MessageService $messageService
+        private readonly MessageService $messageService,
+        private readonly UpcomingAppointmentFinder $finder
     ) {
         $this->logger = new SystemLogger();
     }
@@ -62,17 +63,29 @@ class AppointmentReminderService
             return $results;
         }
 
-        $appointments = $this->getUpcomingAppointments($hours);
+        $now = new \DateTimeImmutable();
+        $appointments = $this->finder->findUpcoming($hours, $now);
         if ($appointments === []) {
             $this->logger->debug('No upcoming appointments found within notification window');
             return $results;
         }
+
+        $sentKeys = $this->loadSentOccurrences(
+            $now->format('Y-m-d'),
+            $now->modify(sprintf('+%d hours', $hours))->format('Y-m-d')
+        );
 
         $templateKey = $this->templateService->getAppointmentReminderTemplateKey();
 
         foreach ($appointments as $appointment) {
             $pcEid = (int) $appointment['pc_eid'];
             $patientId = (int) $appointment['pc_pid'];
+            $occurrenceDate = (string) $appointment['pc_eventDate'];
+
+            if (isset($sentKeys[$pcEid . '|' . $occurrenceDate])) {
+                // Already reminded for this specific occurrence — quiet skip.
+                continue;
+            }
 
             $rawPhone = $appointment['phone_cell'] ?? '';
             if ($rawPhone === '') {
@@ -131,7 +144,7 @@ class AppointmentReminderService
                     $message,
                     new MessageOptions(templateKey: $templateKey, skipConsentCheck: true)
                 );
-                $this->recordReminderSent($pcEid, $patientId, $templateKey);
+                $this->recordReminderSent($pcEid, $patientId, $occurrenceDate, $templateKey);
                 $results['sent']++;
             } catch (\Throwable $e) {
                 $results['failed']++;
@@ -154,44 +167,51 @@ class AppointmentReminderService
     }
 
     /**
-     * Query upcoming appointments within the notification window
+     * Bulk-load already-sent reminder keys for the active window.
      *
-     * Find events from openemr_postcalendar_events where the appointment
-     * datetime is between now and now + $hours hours, and the event is
-     * not cancelled (pc_apptstatus != 'x').
+     * Returned map keys are `"{pc_eid}|{occurrence_date}"`; values are
+     * irrelevant (presence is the signal). One round trip replaces a
+     * per-occurrence SELECT in the eligibility loop.
      *
-     * @return array<int, array<string, mixed>>
+     * @return array<string, true>
      */
-    private function getUpcomingAppointments(int $hours): array
+    private function loadSentOccurrences(string $fromDate, string $toDate): array
     {
-        $sql = "SELECT e.pc_eid, e.pc_pid, e.pc_eventDate, e.pc_startTime,
-                       p.phone_cell, p.hipaa_allowsms
-                FROM openemr_postcalendar_events e
-                JOIN patient_data p ON e.pc_pid = p.pid
-                LEFT JOIN oce_sinch_appointment_reminders r ON e.pc_eid = r.pc_eid
-                WHERE CONCAT(e.pc_eventDate, ' ', e.pc_startTime) > NOW()
-                  AND CONCAT(e.pc_eventDate, ' ', e.pc_startTime) <= DATE_ADD(NOW(), INTERVAL ? HOUR)
-                  AND e.pc_apptstatus != 'x'
-                  AND e.pc_pid > 0
-                  AND r.id IS NULL
-                ORDER BY e.pc_eventDate, e.pc_startTime";
+        $sql = "SELECT pc_eid, occurrence_date
+                FROM oce_sinch_appointment_reminders
+                WHERE occurrence_date BETWEEN ? AND ?";
+        $rows = QueryUtils::fetchRecords($sql, [$fromDate, $toDate]);
 
-        return QueryUtils::fetchRecords($sql, [$hours]);
+        $map = [];
+        foreach ($rows as $row) {
+            $key = (string) ($row['pc_eid'] ?? '') . '|' . (string) ($row['occurrence_date'] ?? '');
+            $map[$key] = true;
+        }
+        return $map;
     }
 
     /**
-     * Record that a reminder was sent for this event
+     * Record that a reminder was sent for a specific occurrence
      *
      * Use INSERT IGNORE to handle race conditions where concurrent cron runs
-     * pass the LEFT JOIN check and both attempt to insert. The UNIQUE KEY on
-     * pc_eid ensures only one succeeds; the other is silently ignored.
+     * both pass the dedup check and attempt to insert. The UNIQUE KEY on
+     * (pc_eid, occurrence_date) ensures only one succeeds; the other is
+     * silently ignored. Recurring appointments share `pc_eid` across their
+     * occurrences, so `occurrence_date` is what distinguishes them.
      */
-    private function recordReminderSent(int $pcEid, int $patientId, string $templateKey): void
-    {
+    private function recordReminderSent(
+        int $pcEid,
+        int $patientId,
+        string $occurrenceDate,
+        string $templateKey
+    ): void {
         $sql = "INSERT IGNORE INTO oce_sinch_appointment_reminders
-                    (pc_eid, patient_id, sent_at, template_key)
-                VALUES (?, ?, NOW(), ?)";
-        QueryUtils::sqlStatementThrowException($sql, [$pcEid, $patientId, $templateKey]);
+                    (pc_eid, occurrence_date, patient_id, sent_at, template_key)
+                VALUES (?, ?, ?, NOW(), ?)";
+        QueryUtils::sqlStatementThrowException(
+            $sql,
+            [$pcEid, $occurrenceDate, $patientId, $templateKey]
+        );
     }
 
     /**

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -21,6 +21,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 use OpenCoreEMR\Modules\SinchConversations\ConsentBlock;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+use OpenCoreEMR\Modules\SinchConversations\Schema\ReminderTableMigration;
 use OpenCoreEMR\Modules\SinchConversations\SkipReason;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -54,6 +55,11 @@ class AppointmentReminderService
             'failed' => 0,
             'errors' => [],
         ];
+
+        // Safety net for tenants who upgrade the module code without
+        // disabling/re-enabling the module. enable() also calls this; both
+        // paths short-circuit once the table is fully migrated.
+        ReminderTableMigration::ensureUpgraded();
 
         $this->purgeExpiredReminders();
 

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -45,10 +45,14 @@ class AppointmentReminderService
      * Find upcoming appointments within the notification window, skip patients
      * who are ineligible or already reminded, and send reminders for the rest.
      *
+     * @param \DateTimeImmutable|null $now Wall-clock for the run. Tests pass
+     *     a fixed instant; production callers (background_service_entry)
+     *     leave null and get the current time.
      * @return array{sent: int, skipped: int, failed: int, errors: list<string>}
      */
-    public function run(): array
+    public function run(?\DateTimeImmutable $now = null): array
     {
+        $now ??= new \DateTimeImmutable();
         $results = [
             'sent' => 0,
             'skipped' => 0,
@@ -58,8 +62,20 @@ class AppointmentReminderService
 
         // Safety net for tenants who upgrade the module code without
         // disabling/re-enabling the module. enable() also calls this; both
-        // paths short-circuit once the table is fully migrated.
-        ReminderTableMigration::ensureUpgraded();
+        // paths short-circuit once the table is fully migrated. We catch
+        // here so a lock-timeout or DDL error doesn't crash the cron
+        // runner — the next tick will retry. background_service_entry has
+        // no try/catch around run(), so this is the failure boundary.
+        try {
+            ReminderTableMigration::ensureUpgraded();
+        } catch (\Throwable $e) {
+            $results['failed']++;
+            $results['errors'][] = 'schema migration failed: ' . $e->getMessage();
+            $this->logger->error('Appointment reminder schema migration failed', [
+                'exception' => ExceptionContext::fromThrowable($e),
+            ]);
+            return $results;
+        }
 
         $this->purgeExpiredReminders();
 
@@ -69,7 +85,6 @@ class AppointmentReminderService
             return $results;
         }
 
-        $now = new \DateTimeImmutable();
         $appointments = $this->finder->findUpcoming($hours, $now);
         if ($appointments === []) {
             $this->logger->debug('No upcoming appointments found within notification window');

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -60,6 +60,12 @@ class AppointmentReminderService
             'errors' => [],
         ];
 
+        // Purge first: it only references `sent_at`, which exists in
+        // both the old and new schemas, so it doesn't depend on the
+        // migration succeeding. Running it first means a tenant blocked
+        // on a failing migration still gets stale-row cleanup.
+        $this->purgeExpiredReminders();
+
         // Safety net for tenants who upgrade the module code without
         // disabling/re-enabling the module. enable() also calls this; both
         // paths short-circuit once the table is fully migrated. We catch
@@ -76,8 +82,6 @@ class AppointmentReminderService
             ]);
             return $results;
         }
-
-        $this->purgeExpiredReminders();
 
         $hours = $this->config->getSmsNotificationHours();
         if ($hours <= 0) {
@@ -99,17 +103,20 @@ class AppointmentReminderService
         $templateKey = $this->templateService->getAppointmentReminderTemplateKey();
 
         foreach ($appointments as $appointment) {
-            $pcEid = (int) $appointment['pc_eid'];
-            $patientId = (int) $appointment['pc_pid'];
-            $occurrenceDate = (string) $appointment['pc_eventDate'];
+            // UpcomingAppointmentFinder declares the row shape with typed
+            // fields; PHPStan enforces it on every implementation, so no
+            // narrowing is needed here.
+            $pcEid = $appointment['pc_eid'];
+            $patientId = $appointment['pc_pid'];
+            $occurrenceDate = $appointment['pc_eventDate'];
 
-            if (isset($sentKeys[$pcEid . '|' . $occurrenceDate])) {
+            if (isset($sentKeys[self::dedupKey($pcEid, $occurrenceDate)])) {
                 // Already reminded for this specific occurrence — quiet skip.
                 continue;
             }
 
-            $rawPhone = $appointment['phone_cell'] ?? '';
-            if ($rawPhone === '') {
+            $rawPhone = $appointment['phone_cell'];
+            if ($rawPhone === null || $rawPhone === '') {
                 $this->logSkip($pcEid, $patientId, SkipReason::MissingPhone);
                 $results['skipped']++;
                 continue;
@@ -124,7 +131,7 @@ class AppointmentReminderService
                 continue;
             }
 
-            $hipaaAllowSms = (string) ($appointment['hipaa_allowsms'] ?? '');
+            $hipaaAllowSms = $appointment['hipaa_allowsms'] ?? '';
             if ($hipaaAllowSms !== 'YES') {
                 $this->logSkip($pcEid, $patientId, SkipReason::HipaaDisallowsSms, [
                     'hipaa_allowsms' => $hipaaAllowSms === '' ? 'unset' : $hipaaAllowSms,
@@ -171,7 +178,7 @@ class AppointmentReminderService
                 // a finder that returns the same occurrence twice) is
                 // skipped instead of double-sent. The DB INSERT IGNORE
                 // dedups the log row, not the SMS delivery.
-                $sentKeys[$pcEid . '|' . $occurrenceDate] = true;
+                $sentKeys[self::dedupKey($pcEid, $occurrenceDate)] = true;
                 $results['sent']++;
             } catch (\Throwable $e) {
                 $results['failed']++;
@@ -215,10 +222,45 @@ class AppointmentReminderService
 
         $map = [];
         foreach ($rows as $row) {
-            $key = (string) ($row['pc_eid'] ?? '') . '|' . (string) ($row['occurrence_date'] ?? '');
-            $map[$key] = true;
+            // Schema guarantees both columns are non-null; a row that
+            // disagrees is a real bug — drop it and log instead of
+            // silently coercing it into a misshapen dedup key.
+            $pcEidRaw = $row['pc_eid'] ?? null;
+            $pcEid = is_int($pcEidRaw)
+                ? $pcEidRaw
+                : (is_string($pcEidRaw)
+                    ? filter_var($pcEidRaw, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]])
+                    : false);
+            if (!is_int($pcEid)) {
+                $this->logger->warning(
+                    'Skipping dedup row: pc_eid is not a positive integer',
+                    ['raw_pc_eid_type' => get_debug_type($pcEidRaw)]
+                );
+                continue;
+            }
+            $occurrenceDate = $row['occurrence_date'] ?? null;
+            if (!is_string($occurrenceDate) || $occurrenceDate === '') {
+                $this->logger->warning(
+                    'Skipping dedup row: occurrence_date is not a non-empty string',
+                    ['raw_occurrence_date_type' => get_debug_type($occurrenceDate)]
+                );
+                continue;
+            }
+            $map[self::dedupKey($pcEid, $occurrenceDate)] = true;
         }
         return $map;
+    }
+
+    /**
+     * Build the in-memory dedup map key for a single occurrence.
+     *
+     * Centralised so the format can change without touching three call
+     * sites (loadSentOccurrences, the eligibility check, the in-loop
+     * mark after a successful send).
+     */
+    private static function dedupKey(int $pcEid, string $occurrenceDate): string
+    {
+        return $pcEid . '|' . $occurrenceDate;
     }
 
     /**
@@ -313,16 +355,21 @@ class AppointmentReminderService
     }
 
     /**
-     * Build template variables for an appointment
+     * Build template variables for an appointment.
      *
-     * @param array<string, mixed> $appointment
+     * @param array{
+     *     pc_eid: int,
+     *     pc_pid: int,
+     *     pc_eventDate: string,
+     *     pc_startTime: string,
+     *     phone_cell: ?string,
+     *     hipaa_allowsms: ?string
+     * } $appointment
      * @return array<string, string>
      */
     private function buildTemplateVariables(array $appointment): array
     {
-        $date = (string) ($appointment['pc_eventDate'] ?? '');
-        $time = (string) ($appointment['pc_startTime'] ?? '');
-        $rawDatetime = $date . ' ' . $time;
+        $rawDatetime = $appointment['pc_eventDate'] . ' ' . $appointment['pc_startTime'];
 
         try {
             $dt = new \DateTimeImmutable($rawDatetime);

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -176,8 +176,12 @@ class AppointmentReminderService
      * Bulk-load already-sent reminder keys for the active window.
      *
      * Returned map keys are `"{pc_eid}|{occurrence_date}"`; values are
-     * irrelevant (presence is the signal). One round trip replaces a
-     * per-occurrence SELECT in the eligibility loop.
+     * irrelevant (presence is the signal). One round trip up front
+     * supplies the dedup state for every appointment in the window —
+     * cheaper than a per-occurrence SELECT and necessary because the
+     * old `LEFT JOIN ... r.id IS NULL` filter no longer fits now that
+     * the dedup key is `(pc_eid, occurrence_date)` and the appointment
+     * source has moved out of SQL into the finder.
      *
      * @return array<string, true>
      */
@@ -197,13 +201,22 @@ class AppointmentReminderService
     }
 
     /**
-     * Record that a reminder was sent for a specific occurrence
+     * Record that a reminder was sent for a specific occurrence.
      *
-     * Use INSERT IGNORE to handle race conditions where concurrent cron runs
-     * both pass the dedup check and attempt to insert. The UNIQUE KEY on
-     * (pc_eid, occurrence_date) ensures only one succeeds; the other is
-     * silently ignored. Recurring appointments share `pc_eid` across their
-     * occurrences, so `occurrence_date` is what distinguishes them.
+     * The UNIQUE KEY on `(pc_eid, occurrence_date)` exists so re-runs of
+     * the cron — same process, next tick — never insert a second log row
+     * for an occurrence already sent. It does NOT make the
+     * send-then-record sequence atomic: if two processes ever raced past
+     * the bulk dedup check at the top of run(), both would send before
+     * either reached this insert. The actual concurrency guard for that
+     * scenario lives in OpenEMR's `background_services.running` flag,
+     * which serializes cron invocations of this service.
+     *
+     * INSERT IGNORE keeps the call idempotent under that re-run pattern
+     * (and tolerates a pessimistic re-record from any future retry path)
+     * by silently dropping a duplicate-key collision instead of throwing.
+     * Recurring appointments share `pc_eid` across their occurrences, so
+     * `occurrence_date` is what distinguishes them.
      */
     private function recordReminderSent(
         int $pcEid,

--- a/src/Module/Service/AppointmentReminderService.php
+++ b/src/Module/Service/AppointmentReminderService.php
@@ -166,6 +166,12 @@ class AppointmentReminderService
                     new MessageOptions(templateKey: $templateKey, skipConsentCheck: true)
                 );
                 $this->recordReminderSent($pcEid, $patientId, $occurrenceDate, $templateKey);
+                // Mark the in-memory dedup map too, so a duplicate
+                // (pc_eid, occurrence_date) later in this same run (e.g.
+                // a finder that returns the same occurrence twice) is
+                // skipped instead of double-sent. The DB INSERT IGNORE
+                // dedups the log row, not the SMS delivery.
+                $sentKeys[$pcEid . '|' . $occurrenceDate] = true;
                 $results['sent']++;
             } catch (\Throwable $e) {
                 $results['failed']++;

--- a/src/Module/Service/CoreAppointmentFinder.php
+++ b/src/Module/Service/CoreAppointmentFinder.php
@@ -36,8 +36,9 @@ class CoreAppointmentFinder implements UpcomingAppointmentFinder
         require_once $fileroot . '/library/appointments.inc.php';
 
         $windowEnd = $now->modify(sprintf('+%d hours', $windowHours));
-        // fetchAllEvents filters by date (Y-m-d), so widen one extra day
-        // to be safe — we re-check the precise time bound in PHP below.
+        // fetchAllEvents filters by date (Y-m-d) inclusive on both ends,
+        // so a window that crosses midnight already pulls in the trailing
+        // calendar day. We re-check the precise time bound in PHP below.
         $fromDate = $now->format('Y-m-d');
         $toDate = $windowEnd->format('Y-m-d');
 

--- a/src/Module/Service/CoreAppointmentFinder.php
+++ b/src/Module/Service/CoreAppointmentFinder.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Service;
 
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Core\OEGlobalsBag;
 
 class CoreAppointmentFinder implements UpcomingAppointmentFinder
@@ -28,8 +29,14 @@ class CoreAppointmentFinder implements UpcomingAppointmentFinder
      */
     public function findUpcoming(int $windowHours, \DateTimeImmutable $now): array
     {
-        $fileroot = (string) (OEGlobalsBag::getInstance()->get('fileroot') ?? '');
+        $fileroot = OEGlobalsBag::getInstance()->getString('fileroot');
         if ($fileroot === '') {
+            // No way to require library/appointments.inc.php — surface
+            // the misconfiguration loudly so a clinic seeing zero
+            // reminders can find the cause instead of silently shipping.
+            (new SystemLogger())->error(
+                'CoreAppointmentFinder: $GLOBALS[fileroot] is empty; cannot load core appointment helpers'
+            );
             return [];
         }
 
@@ -42,33 +49,53 @@ class CoreAppointmentFinder implements UpcomingAppointmentFinder
         $fromDate = $now->format('Y-m-d');
         $toDate = $windowEnd->format('Y-m-d');
 
-        /** @var array<int, array<string, mixed>>|false $events */
         $events = \fetchAllEvents($fromDate, $toDate);
         if (!is_array($events)) {
             return [];
         }
 
+        $logger = new SystemLogger();
         $occurrences = [];
         foreach ($events as $event) {
-            $pcPid = (int) ($event['pc_pid'] ?? 0);
-            if ($pcPid <= 0) {
+            if (!is_array($event)) {
                 continue;
             }
 
-            $apptStatus = (string) ($event['pc_apptstatus'] ?? '');
-            if ($apptStatus === 'x') {
+            // Required fields. The OpenEMR mysqli driver returns numeric
+            // columns as native ints when configured, but historically as
+            // numeric strings — accept both for the integer columns,
+            // reject anything else.
+            $pcPid = self::asPositiveInt($event['pc_pid'] ?? null);
+            if ($pcPid === null) {
+                continue;
+            }
+            $pcEid = self::asPositiveInt($event['pc_eid'] ?? null);
+            if ($pcEid === null) {
                 continue;
             }
 
-            $eventDate = (string) ($event['pc_eventDate'] ?? '');
-            $startTime = (string) ($event['pc_startTime'] ?? '');
-            if ($eventDate === '' || $startTime === '') {
+            $apptStatus = $event['pc_apptstatus'] ?? null;
+            if (is_string($apptStatus) && $apptStatus === 'x') {
+                continue;
+            }
+
+            $eventDate = $event['pc_eventDate'] ?? null;
+            $startTime = $event['pc_startTime'] ?? null;
+            if (
+                !is_string($eventDate) || !is_string($startTime)
+                || $eventDate === '' || $startTime === ''
+            ) {
                 continue;
             }
 
             try {
                 $apptDt = new \DateTimeImmutable($eventDate . ' ' . $startTime);
             } catch (\Throwable) {
+                $logger->warning('Skipping event with unparseable datetime', [
+                    'pc_eid' => $pcEid,
+                    'pc_eventDate' => $eventDate,
+                    'pc_startTime' => $startTime,
+                ]);
                 continue;
             }
 
@@ -76,16 +103,41 @@ class CoreAppointmentFinder implements UpcomingAppointmentFinder
                 continue;
             }
 
+            // Optional fields — surface as null when absent or non-string;
+            // downstream eligibility checks handle that explicitly.
+            $phoneCell = $event['phone_cell'] ?? null;
+            $hipaaAllowSms = $event['hipaa_allowsms'] ?? null;
+
             $occurrences[] = [
-                'pc_eid' => (int) ($event['pc_eid'] ?? 0),
+                'pc_eid' => $pcEid,
                 'pc_pid' => $pcPid,
                 'pc_eventDate' => $eventDate,
                 'pc_startTime' => $startTime,
-                'phone_cell' => isset($event['phone_cell']) ? (string) $event['phone_cell'] : null,
-                'hipaa_allowsms' => isset($event['hipaa_allowsms']) ? (string) $event['hipaa_allowsms'] : null,
+                'phone_cell' => is_string($phoneCell) ? $phoneCell : null,
+                'hipaa_allowsms' => is_string($hipaaAllowSms) ? $hipaaAllowSms : null,
             ];
         }
 
         return $occurrences;
+    }
+
+    /**
+     * Narrow a value into a positive int, accepting both native ints and
+     * numeric strings (the historical mysqli return shape). Returns null
+     * for anything else, including zero/negative values that wouldn't be
+     * a valid event/patient id.
+     */
+    private static function asPositiveInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+        if (is_string($value)) {
+            $parsed = filter_var($value, FILTER_VALIDATE_INT, [
+                'options' => ['min_range' => 1],
+            ]);
+            return is_int($parsed) ? $parsed : null;
+        }
+        return null;
     }
 }

--- a/src/Module/Service/CoreAppointmentFinder.php
+++ b/src/Module/Service/CoreAppointmentFinder.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Default UpcomingAppointmentFinder backed by core OpenEMR
+ *
+ * Wraps `library/appointments.inc.php::fetchAllEvents()`, which expands
+ * `pc_recurrtype` / `pc_recurrspec` into per-occurrence rows. Production
+ * uses this; unit tests inject a stub instead so they don't have to load
+ * the procedural library or wire up the kernel event dispatcher.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Service;
+
+use OpenEMR\Core\OEGlobalsBag;
+
+class CoreAppointmentFinder implements UpcomingAppointmentFinder
+{
+    /**
+     * @inheritDoc
+     */
+    public function findUpcoming(int $windowHours, \DateTimeImmutable $now): array
+    {
+        $fileroot = (string) (OEGlobalsBag::getInstance()->get('fileroot') ?? '');
+        if ($fileroot === '') {
+            return [];
+        }
+
+        require_once $fileroot . '/library/appointments.inc.php';
+
+        $windowEnd = $now->modify(sprintf('+%d hours', $windowHours));
+        // fetchAllEvents filters by date (Y-m-d), so widen one extra day
+        // to be safe — we re-check the precise time bound in PHP below.
+        $fromDate = $now->format('Y-m-d');
+        $toDate = $windowEnd->format('Y-m-d');
+
+        /** @var array<int, array<string, mixed>>|false $events */
+        $events = \fetchAllEvents($fromDate, $toDate);
+        if (!is_array($events)) {
+            return [];
+        }
+
+        $occurrences = [];
+        foreach ($events as $event) {
+            $pcPid = (int) ($event['pc_pid'] ?? 0);
+            if ($pcPid <= 0) {
+                continue;
+            }
+
+            $apptStatus = (string) ($event['pc_apptstatus'] ?? '');
+            if ($apptStatus === 'x') {
+                continue;
+            }
+
+            $eventDate = (string) ($event['pc_eventDate'] ?? '');
+            $startTime = (string) ($event['pc_startTime'] ?? '');
+            if ($eventDate === '' || $startTime === '') {
+                continue;
+            }
+
+            try {
+                $apptDt = new \DateTimeImmutable($eventDate . ' ' . $startTime);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if ($apptDt <= $now || $apptDt > $windowEnd) {
+                continue;
+            }
+
+            $occurrences[] = [
+                'pc_eid' => (int) ($event['pc_eid'] ?? 0),
+                'pc_pid' => $pcPid,
+                'pc_eventDate' => $eventDate,
+                'pc_startTime' => $startTime,
+                'phone_cell' => isset($event['phone_cell']) ? (string) $event['phone_cell'] : null,
+                'hipaa_allowsms' => isset($event['hipaa_allowsms']) ? (string) $event['hipaa_allowsms'] : null,
+            ];
+        }
+
+        return $occurrences;
+    }
+}

--- a/src/Module/Service/UpcomingAppointmentFinder.php
+++ b/src/Module/Service/UpcomingAppointmentFinder.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Upcoming Appointment Finder
+ *
+ * Locate calendar occurrences (one-shot or recurring) whose start time
+ * falls within a window after `now`. Implementations expand recurring
+ * events into one record per occurrence.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Service;
+
+interface UpcomingAppointmentFinder
+{
+    /**
+     * Return appointment occurrences whose start datetime is in
+     * `($now, $now + $windowHours]`.
+     *
+     * Recurring events MUST be expanded to one returned record per
+     * occurrence; the same `pc_eid` may appear multiple times with
+     * different `pc_eventDate` values.
+     *
+     * @return list<array{
+     *     pc_eid: int,
+     *     pc_pid: int,
+     *     pc_eventDate: string,
+     *     pc_startTime: string,
+     *     phone_cell: ?string,
+     *     hipaa_allowsms: ?string
+     * }>
+     */
+    public function findUpcoming(int $windowHours, \DateTimeImmutable $now): array;
+}

--- a/table.sql
+++ b/table.sql
@@ -158,17 +158,21 @@ CREATE TABLE IF NOT EXISTS `oce_sinch_services` (
     INDEX `idx_is_default` (`is_default`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Table to track sent appointment reminders (prevent duplicates)
+-- Table to track sent appointment reminders (prevent duplicates).
+-- Recurring appointments share `pc_eid` across their occurrences, so the
+-- dedup key is (pc_eid, occurrence_date) rather than pc_eid alone.
 CREATE TABLE IF NOT EXISTS `oce_sinch_appointment_reminders` (
   `id` INT(11) PRIMARY KEY AUTO_INCREMENT NOT NULL,
   `pc_eid` INT(11) NOT NULL COMMENT 'Calendar event ID from openemr_postcalendar_events',
+  `occurrence_date` DATE NOT NULL COMMENT 'Specific occurrence date (recurring appts share pc_eid across occurrences)',
   `patient_id` BIGINT(20) NOT NULL COMMENT 'Patient ID',
   `sent_at` DATETIME NOT NULL COMMENT 'When the reminder was sent',
   `template_key` VARCHAR(100) NOT NULL COMMENT 'Template used for this reminder',
   `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'When this record was created',
-  UNIQUE KEY `unique_event_reminder` (`pc_eid`),
+  UNIQUE KEY `unique_event_occurrence` (`pc_eid`, `occurrence_date`),
   INDEX `idx_patient_id` (`patient_id`),
-  INDEX `idx_sent_at` (`sent_at`)
+  INDEX `idx_sent_at` (`sent_at`),
+  INDEX `idx_occurrence_date` (`occurrence_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Webhook nonce tracking for replay protection.

--- a/tests/Mocks/MockQueryUtils.php
+++ b/tests/Mocks/MockQueryUtils.php
@@ -49,8 +49,14 @@ class QueryUtils
     {
         self::$queries[] = ['sql' => $sql, 'binds' => $binds];
 
-        // Return mock results if set
         $key = self::generateKey($sql, $binds);
+
+        // Drain queued sequential results first (parity with querySingleRow),
+        // so tests can simulate state changes between successive calls.
+        if (!empty(self::$mockResultQueue[$key])) {
+            return array_shift(self::$mockResultQueue[$key]);
+        }
+
         return self::$mockResults[$key] ?? [];
     }
 

--- a/tests/Mocks/StubAppointmentFinder.php
+++ b/tests/Mocks/StubAppointmentFinder.php
@@ -37,7 +37,26 @@ class StubAppointmentFinder implements UpcomingAppointmentFinder
 
     public function findUpcoming(int $windowHours, \DateTimeImmutable $now): array
     {
-        return $this->occurrences;
+        // Honour the interface contract — only return occurrences whose
+        // start datetime falls in `($now, $now + $windowHours]`. A real
+        // implementation must filter; the stub does too so tests can't
+        // accidentally pass occurrences that the production code would
+        // never see.
+        $end = $now->modify(sprintf('+%d hours', $windowHours));
+        $filtered = [];
+        foreach ($this->occurrences as $occ) {
+            try {
+                $apptDt = new \DateTimeImmutable(
+                    $occ['pc_eventDate'] . ' ' . $occ['pc_startTime']
+                );
+            } catch (\Throwable) {
+                continue;
+            }
+            if ($apptDt > $now && $apptDt <= $end) {
+                $filtered[] = $occ;
+            }
+        }
+        return $filtered;
     }
 
     /**

--- a/tests/Mocks/StubAppointmentFinder.php
+++ b/tests/Mocks/StubAppointmentFinder.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Stub UpcomingAppointmentFinder for tests
+ *
+ * Returns a preset list of occurrences. Lets reminder-service tests
+ * skip the SQL-mock rigging that the old in-line query required.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Mocks;
+
+use OpenCoreEMR\Modules\SinchConversations\Service\UpcomingAppointmentFinder;
+
+class StubAppointmentFinder implements UpcomingAppointmentFinder
+{
+    /**
+     * @param list<array{
+     *     pc_eid: int,
+     *     pc_pid: int,
+     *     pc_eventDate: string,
+     *     pc_startTime: string,
+     *     phone_cell: ?string,
+     *     hipaa_allowsms: ?string
+     * }> $occurrences
+     */
+    public function __construct(private array $occurrences = [])
+    {
+    }
+
+    public function findUpcoming(int $windowHours, \DateTimeImmutable $now): array
+    {
+        return $this->occurrences;
+    }
+
+    /**
+     * @param list<array{
+     *     pc_eid: int,
+     *     pc_pid: int,
+     *     pc_eventDate: string,
+     *     pc_startTime: string,
+     *     phone_cell: ?string,
+     *     hipaa_allowsms: ?string
+     * }> $occurrences
+     */
+    public function setOccurrences(array $occurrences): void
+    {
+        $this->occurrences = $occurrences;
+    }
+}

--- a/tests/Unit/ModuleManagerListenerTest.php
+++ b/tests/Unit/ModuleManagerListenerTest.php
@@ -155,8 +155,13 @@ class ModuleManagerListenerTest extends TestCase
         // migration should return cleanly (not throw) since the schema
         // is now at the target shape.
         QueryUtils::setMockResult(
+            'SELECT DATABASE() AS db',
+            [],
+            [['db' => 'test_tenant_db']]
+        );
+        QueryUtils::setMockResult(
             'SELECT GET_LOCK(?, ?) AS got',
-            ['oce_sinch_reminder_migration', 30],
+            ['oce_sinch_reminder_migration:test_tenant_db', 30],
             [['got' => 0]]
         );
         // First probe: legacy shape (forces the lock acquisition attempt).
@@ -264,9 +269,17 @@ class ModuleManagerListenerTest extends TestCase
         array $indexes,
         bool $lockAcquired = true
     ): void {
+        // The lock name is per-tenant: '<prefix>:<DATABASE()>'.
+        // Mock the DATABASE() probe and key the GET_LOCK mock to the
+        // resulting concatenated name.
+        QueryUtils::setMockResult(
+            'SELECT DATABASE() AS db',
+            [],
+            [['db' => 'test_tenant_db']]
+        );
         QueryUtils::setMockResult(
             'SELECT GET_LOCK(?, ?) AS got',
-            ['oce_sinch_reminder_migration', 30],
+            ['oce_sinch_reminder_migration:test_tenant_db', 30],
             [['got' => $lockAcquired ? 1 : 0]]
         );
 

--- a/tests/Unit/ModuleManagerListenerTest.php
+++ b/tests/Unit/ModuleManagerListenerTest.php
@@ -148,6 +148,75 @@ class ModuleManagerListenerTest extends TestCase
         );
     }
 
+    public function testEnableConvergesWhenAnotherProcessFinishedMigrationFirst(): void
+    {
+        // Simulate: lock contention — we couldn't acquire the lock — but
+        // by the time we re-probe the holder has already finished. The
+        // migration should return cleanly (not throw) since the schema
+        // is now at the target shape.
+        QueryUtils::setMockResult(
+            'SELECT GET_LOCK(?, ?) AS got',
+            ['oce_sinch_reminder_migration', 30],
+            [['got' => 0]]
+        );
+        // First probe: legacy shape (forces the lock acquisition attempt).
+        // Second probe (after lock fails): fully migrated.
+        QueryUtils::setMockResult(
+            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders'],
+            [['TABLE_NAME' => 'oce_sinch_appointment_reminders']]
+        );
+        QueryUtils::queueMockResult(
+            'SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ?
+               AND COLUMN_NAME = ?',
+            ['oce_sinch_appointment_reminders', 'occurrence_date'],
+            [] // first probe: column missing
+        );
+        QueryUtils::queueMockResult(
+            'SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ?
+               AND COLUMN_NAME = ?',
+            ['oce_sinch_appointment_reminders', 'occurrence_date'],
+            [['IS_NULLABLE' => 'NO']] // second probe: column NOT NULL
+        );
+        QueryUtils::queueMockResult(
+            'SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders'],
+            [['INDEX_NAME' => 'unique_event_reminder']] // first probe: legacy
+        );
+        QueryUtils::queueMockResult(
+            'SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders'],
+            [
+                ['INDEX_NAME' => 'unique_event_occurrence'],
+                ['INDEX_NAME' => 'idx_occurrence_date'],
+            ] // second probe: fully migrated
+        );
+
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $result = $listener->moduleManagerAction('enable', 1, 'Success');
+
+        $this->assertSame('Success', $result);
+
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(
+            0,
+            array_filter($queries, static fn(array $q): bool => str_starts_with(ltrim($q['sql']), 'ALTER TABLE')),
+            'No ALTERs should run when another process finished the migration'
+        );
+        $this->assertCount(
+            0,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'RELEASE_LOCK')),
+            'RELEASE_LOCK only runs when GET_LOCK succeeded'
+        );
+    }
+
     public function testEnableFinishesMigrationWhenPartiallyApplied(): void
     {
         // Partial-migration scenario: column was added (still nullable) and
@@ -189,8 +258,18 @@ class ModuleManagerListenerTest extends TestCase
      * @param bool|null $columnIsNullable null = column does not exist
      * @param list<string> $indexes
      */
-    private function mockMigrationShape(bool $tableExists, ?bool $columnIsNullable, array $indexes): void
-    {
+    private function mockMigrationShape(
+        bool $tableExists,
+        ?bool $columnIsNullable,
+        array $indexes,
+        bool $lockAcquired = true
+    ): void {
+        QueryUtils::setMockResult(
+            'SELECT GET_LOCK(?, ?) AS got',
+            ['oce_sinch_reminder_migration', 30],
+            [['got' => $lockAcquired ? 1 : 0]]
+        );
+
         QueryUtils::setMockResult(
             'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',

--- a/tests/Unit/ModuleManagerListenerTest.php
+++ b/tests/Unit/ModuleManagerListenerTest.php
@@ -68,16 +68,78 @@ class ModuleManagerListenerTest extends TestCase
         $this->assertSame('Success', $result);
 
         $queries = QueryUtils::getQueries();
-        $this->assertCount(2, $queries);
+        // upsert + 2 INFORMATION_SCHEMA probes (column + table; both empty
+        // so migration short-circuits as a no-op for fresh installs) + activate
+        $this->assertCount(4, $queries);
 
-        // First: upsert to ensure the row exists
         $this->assertStringContainsString('INSERT INTO `background_services`', $queries[0]['sql']);
         $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $queries[0]['sql']);
 
-        // Second: activate
-        $this->assertStringContainsString('UPDATE `background_services` SET `active` = ?', $queries[1]['sql']);
-        $this->assertSame(1, $queries[1]['binds'][0]);
-        $this->assertSame('oce_sinch_reminders', $queries[1]['binds'][1]);
+        $this->assertStringContainsString('INFORMATION_SCHEMA.COLUMNS', $queries[1]['sql']);
+        $this->assertSame(['oce_sinch_appointment_reminders', 'occurrence_date'], $queries[1]['binds']);
+
+        $this->assertStringContainsString('INFORMATION_SCHEMA.TABLES', $queries[2]['sql']);
+        $this->assertSame(['oce_sinch_appointment_reminders'], $queries[2]['binds']);
+
+        $this->assertStringContainsString('UPDATE `background_services` SET `active` = ?', $queries[3]['sql']);
+        $this->assertSame(1, $queries[3]['binds'][0]);
+        $this->assertSame('oce_sinch_reminders', $queries[3]['binds'][1]);
+    }
+
+    public function testEnableSkipsMigrationWhenOccurrenceDateColumnAlreadyExists(): void
+    {
+        QueryUtils::setMockResult(
+            'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ?
+               AND COLUMN_NAME = ?',
+            ['oce_sinch_appointment_reminders', 'occurrence_date'],
+            [['COLUMN_NAME' => 'occurrence_date']]
+        );
+
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $listener->moduleManagerAction('enable', 1, 'Success');
+
+        $queries = QueryUtils::getQueries();
+        // upsert + column probe (returned a row → short-circuit) + activate
+        $this->assertCount(3, $queries);
+        $this->assertStringContainsString('INFORMATION_SCHEMA.COLUMNS', $queries[1]['sql']);
+        $this->assertStringContainsString('UPDATE `background_services`', $queries[2]['sql']);
+    }
+
+    public function testEnableRunsMigrationWhenLegacyTableExists(): void
+    {
+        // Column missing, but table exists — old shape, must migrate.
+        QueryUtils::setMockResult(
+            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders'],
+            [['TABLE_NAME' => 'oce_sinch_appointment_reminders']]
+        );
+
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $listener->moduleManagerAction('enable', 1, 'Success');
+
+        $queries = QueryUtils::getQueries();
+        $alterColumnAdds = array_filter(
+            $queries,
+            static fn(array $q): bool => str_contains($q['sql'], 'ADD COLUMN `occurrence_date`')
+        );
+        $this->assertCount(1, $alterColumnAdds);
+
+        $backfills = array_filter(
+            $queries,
+            static fn(array $q): bool => str_contains($q['sql'], 'UPDATE `oce_sinch_appointment_reminders` r')
+                && str_contains($q['sql'], 'SET r.occurrence_date = e.pc_eventDate')
+        );
+        $this->assertCount(1, $backfills);
+
+        $finalize = array_filter(
+            $queries,
+            static fn(array $q): bool => str_contains($q['sql'], 'unique_event_occurrence')
+                && str_contains($q['sql'], 'DROP INDEX `unique_event_reminder`')
+        );
+        $this->assertCount(1, $finalize);
     }
 
     public function testDisableDeactivatesBackgroundService(): void

--- a/tests/Unit/ModuleManagerListenerTest.php
+++ b/tests/Unit/ModuleManagerListenerTest.php
@@ -68,81 +68,151 @@ class ModuleManagerListenerTest extends TestCase
         $this->assertSame('Success', $result);
 
         $queries = QueryUtils::getQueries();
-        // upsert + 2 INFORMATION_SCHEMA probes (column missing AND table
-        // missing — i.e. enable runs before install has created the table;
-        // migration short-circuits as a no-op) + activate.
-        // Fresh installs that did run table.sql will short-circuit after
-        // the COLUMNS probe (covered by testEnableSkipsMigrationWhenOccurrenceDateColumnAlreadyExists).
-        $this->assertCount(4, $queries);
+        // upsert + TABLES probe (returns empty — install hasn't created
+        // the table yet, so the migration short-circuits as a no-op) +
+        // activate. Fresh installs that ran table.sql first land in
+        // testEnableShortCircuitsWhenSchemaAlreadyAtTarget.
+        $this->assertCount(3, $queries);
 
         $this->assertStringContainsString('INSERT INTO `background_services`', $queries[0]['sql']);
         $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $queries[0]['sql']);
 
-        $this->assertStringContainsString('INFORMATION_SCHEMA.COLUMNS', $queries[1]['sql']);
-        $this->assertSame(['oce_sinch_appointment_reminders', 'occurrence_date'], $queries[1]['binds']);
+        $this->assertStringContainsString('INFORMATION_SCHEMA.TABLES', $queries[1]['sql']);
+        $this->assertSame(['oce_sinch_appointment_reminders'], $queries[1]['binds']);
 
-        $this->assertStringContainsString('INFORMATION_SCHEMA.TABLES', $queries[2]['sql']);
-        $this->assertSame(['oce_sinch_appointment_reminders'], $queries[2]['binds']);
-
-        $this->assertStringContainsString('UPDATE `background_services` SET `active` = ?', $queries[3]['sql']);
-        $this->assertSame(1, $queries[3]['binds'][0]);
-        $this->assertSame('oce_sinch_reminders', $queries[3]['binds'][1]);
+        $this->assertStringContainsString('UPDATE `background_services` SET `active` = ?', $queries[2]['sql']);
+        $this->assertSame(1, $queries[2]['binds'][0]);
+        $this->assertSame('oce_sinch_reminders', $queries[2]['binds'][1]);
     }
 
-    public function testEnableSkipsMigrationWhenOccurrenceDateColumnAlreadyExists(): void
+    public function testEnableShortCircuitsWhenSchemaAlreadyAtTarget(): void
     {
-        QueryUtils::setMockResult(
-            'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
-             WHERE TABLE_SCHEMA = DATABASE()
-               AND TABLE_NAME = ?
-               AND COLUMN_NAME = ?',
-            ['oce_sinch_appointment_reminders', 'occurrence_date'],
-            [['COLUMN_NAME' => 'occurrence_date']]
+        $this->mockMigrationShape(
+            tableExists: true,
+            columnIsNullable: false,
+            indexes: ['unique_event_occurrence', 'idx_occurrence_date', 'idx_patient_id', 'idx_sent_at']
         );
 
         $listener = \ModuleManagerListener::initListenerSelf();
         $listener->moduleManagerAction('enable', 1, 'Success');
 
         $queries = QueryUtils::getQueries();
-        // upsert + column probe (returned a row → short-circuit) + activate
-        $this->assertCount(3, $queries);
-        $this->assertStringContainsString('INFORMATION_SCHEMA.COLUMNS', $queries[1]['sql']);
-        $this->assertStringContainsString('UPDATE `background_services`', $queries[2]['sql']);
+        // upsert + 3 probes (TABLES, COLUMNS, STATISTICS) + activate. No ALTERs.
+        $this->assertCount(5, $queries);
+
+        $alterCount = count(array_filter(
+            $queries,
+            static fn(array $q): bool => str_starts_with(ltrim($q['sql']), 'ALTER TABLE')
+        ));
+        $this->assertSame(0, $alterCount, 'Already-migrated schema must not run ALTERs');
     }
 
     public function testEnableRunsMigrationWhenLegacyTableExists(): void
     {
-        // Column missing, but table exists — old shape, must migrate.
-        QueryUtils::setMockResult(
-            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
-             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
-            ['oce_sinch_appointment_reminders'],
-            [['TABLE_NAME' => 'oce_sinch_appointment_reminders']]
+        // Old shape: column missing, old unique index present, no new index.
+        $this->mockMigrationShape(
+            tableExists: true,
+            columnIsNullable: null, // column does not exist
+            indexes: ['unique_event_reminder', 'idx_patient_id', 'idx_sent_at']
         );
 
         $listener = \ModuleManagerListener::initListenerSelf();
         $listener->moduleManagerAction('enable', 1, 'Success');
 
         $queries = QueryUtils::getQueries();
-        $alterColumnAdds = array_filter(
-            $queries,
-            static fn(array $q): bool => str_contains($q['sql'], 'ADD COLUMN `occurrence_date`')
-        );
-        $this->assertCount(1, $alterColumnAdds);
 
-        $backfills = array_filter(
-            $queries,
-            static fn(array $q): bool => str_contains($q['sql'], 'UPDATE `oce_sinch_appointment_reminders` r')
-                && str_contains($q['sql'], 'SET r.occurrence_date = e.pc_eventDate')
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'ADD COLUMN `occurrence_date`'))
         );
-        $this->assertCount(1, $backfills);
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'UPDATE `oce_sinch_appointment_reminders` r')
+                && str_contains($q['sql'], 'SET r.`occurrence_date` = e.pc_eventDate'))
+        );
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'MODIFY `occurrence_date` DATE NOT NULL'))
+        );
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'DROP INDEX `unique_event_reminder`'))
+        );
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'ADD UNIQUE KEY `unique_event_occurrence`'))
+        );
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'ADD INDEX `idx_occurrence_date`'))
+        );
+    }
 
-        $finalize = array_filter(
-            $queries,
-            static fn(array $q): bool => str_contains($q['sql'], 'unique_event_occurrence')
-                && str_contains($q['sql'], 'DROP INDEX `unique_event_reminder`')
+    public function testEnableFinishesMigrationWhenPartiallyApplied(): void
+    {
+        // Partial-migration scenario: column was added (still nullable) and
+        // the old unique key is still present, but no new indexes exist
+        // (e.g., a previous enable was interrupted between ALTERs).
+        $this->mockMigrationShape(
+            tableExists: true,
+            columnIsNullable: true,
+            indexes: ['unique_event_reminder', 'idx_patient_id', 'idx_sent_at']
         );
-        $this->assertCount(1, $finalize);
+
+        $listener = \ModuleManagerListener::initListenerSelf();
+        $listener->moduleManagerAction('enable', 1, 'Success');
+
+        $queries = QueryUtils::getQueries();
+
+        // ADD COLUMN must NOT run a second time — column already exists.
+        $this->assertCount(
+            0,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'ADD COLUMN `occurrence_date`'))
+        );
+
+        // The remaining steps must finish the migration.
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'MODIFY `occurrence_date` DATE NOT NULL'))
+        );
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'DROP INDEX `unique_event_reminder`'))
+        );
+        $this->assertCount(
+            1,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'ADD UNIQUE KEY `unique_event_occurrence`'))
+        );
+    }
+
+    /**
+     * @param bool|null $columnIsNullable null = column does not exist
+     * @param list<string> $indexes
+     */
+    private function mockMigrationShape(bool $tableExists, ?bool $columnIsNullable, array $indexes): void
+    {
+        QueryUtils::setMockResult(
+            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders'],
+            $tableExists ? [['TABLE_NAME' => 'oce_sinch_appointment_reminders']] : []
+        );
+
+        QueryUtils::setMockResult(
+            'SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ?
+               AND COLUMN_NAME = ?',
+            ['oce_sinch_appointment_reminders', 'occurrence_date'],
+            $columnIsNullable === null ? [] : [['IS_NULLABLE' => $columnIsNullable ? 'YES' : 'NO']]
+        );
+
+        QueryUtils::setMockResult(
+            'SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders'],
+            array_map(static fn(string $name): array => ['INDEX_NAME' => $name], $indexes)
+        );
     }
 
     public function testDisableDeactivatesBackgroundService(): void

--- a/tests/Unit/ModuleManagerListenerTest.php
+++ b/tests/Unit/ModuleManagerListenerTest.php
@@ -68,8 +68,11 @@ class ModuleManagerListenerTest extends TestCase
         $this->assertSame('Success', $result);
 
         $queries = QueryUtils::getQueries();
-        // upsert + 2 INFORMATION_SCHEMA probes (column + table; both empty
-        // so migration short-circuits as a no-op for fresh installs) + activate
+        // upsert + 2 INFORMATION_SCHEMA probes (column missing AND table
+        // missing — i.e. enable runs before install has created the table;
+        // migration short-circuits as a no-op) + activate.
+        // Fresh installs that did run table.sql will short-circuit after
+        // the COLUMNS probe (covered by testEnableSkipsMigrationWhenOccurrenceDateColumnAlreadyExists).
         $this->assertCount(4, $queries);
 
         $this->assertStringContainsString('INSERT INTO `background_services`', $queries[0]['sql']);

--- a/tests/Unit/Schema/ReminderTableMigrationTest.php
+++ b/tests/Unit/Schema/ReminderTableMigrationTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Unit tests for ReminderTableMigration.
+ *
+ * Covers each branch of the probe + lock + step machinery directly,
+ * decoupled from ModuleManagerListener so the migration can be evolved
+ * without churning lifecycle tests.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Schema;
+
+use OpenCoreEMR\Modules\SinchConversations\Schema\ReminderTableMigration;
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\TestCase;
+
+class ReminderTableMigrationTest extends TestCase
+{
+    private const TABLE_PROBE_SQL = 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?';
+    private const COLUMN_PROBE_SQL = 'SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = ?
+               AND COLUMN_NAME = ?';
+    private const INDEX_PROBE_SQL = 'SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?';
+    private const DATABASE_PROBE_SQL = 'SELECT DATABASE() AS db';
+    private const GET_LOCK_SQL = 'SELECT GET_LOCK(?, ?) AS got';
+    private const TENANT_DB = 'test_tenant';
+    private const LOCK_NAME = 'oce_sinch_reminder_migration:test_tenant';
+
+    protected function setUp(): void
+    {
+        QueryUtils::clearQueries();
+        QueryUtils::clearMockResults();
+    }
+
+    public function testNoOpWhenTableDoesNotExist(): void
+    {
+        // Default mock is empty → TABLES probe returns []. Nothing else
+        // should be queried; the migration short-circuits.
+        ReminderTableMigration::ensureUpgraded();
+
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(1, $queries);
+        $this->assertStringContainsString('INFORMATION_SCHEMA.TABLES', $queries[0]['sql']);
+    }
+
+    public function testNoOpWhenSchemaAlreadyAtTarget(): void
+    {
+        $this->mockShape(
+            tableExists: true,
+            columnIsNullable: false,
+            indexes: ['unique_event_occurrence', 'idx_occurrence_date'],
+        );
+
+        ReminderTableMigration::ensureUpgraded();
+
+        $queries = QueryUtils::getQueries();
+        // Three probes (TABLES, COLUMNS, STATISTICS), no lock acquisition,
+        // no ALTERs. Fast-path return without taking the lock.
+        $this->assertCount(3, $queries);
+        $this->assertCount(
+            0,
+            array_filter($queries, static fn(array $q): bool => str_starts_with(ltrim($q['sql']), 'ALTER TABLE'))
+        );
+        $this->assertCount(
+            0,
+            array_filter($queries, static fn(array $q): bool => str_contains($q['sql'], 'GET_LOCK'))
+        );
+    }
+
+    public function testRunsAllStepsForLegacyTable(): void
+    {
+        $this->mockShape(
+            tableExists: true,
+            columnIsNullable: null,
+            indexes: ['unique_event_reminder'],
+        );
+
+        ReminderTableMigration::ensureUpgraded();
+
+        $sqls = array_column(QueryUtils::getQueries(), 'sql');
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'ADD COLUMN `occurrence_date`')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'SET r.`occurrence_date` = e.pc_eventDate')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'DELETE FROM `oce_sinch_appointment_reminders` WHERE `occurrence_date` IS NULL')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'MODIFY `occurrence_date` DATE NOT NULL')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'DROP INDEX `unique_event_reminder`')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'ADD UNIQUE KEY `unique_event_occurrence`')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'ADD INDEX `idx_occurrence_date`')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'RELEASE_LOCK')));
+    }
+
+    public function testSkipsAddColumnWhenColumnAlreadyExists(): void
+    {
+        // Partial migration: column was added (still nullable) and old
+        // unique index is still there. ADD COLUMN must NOT run again.
+        $this->mockShape(
+            tableExists: true,
+            columnIsNullable: true,
+            indexes: ['unique_event_reminder'],
+        );
+
+        ReminderTableMigration::ensureUpgraded();
+
+        $sqls = array_column(QueryUtils::getQueries(), 'sql');
+        $this->assertCount(0, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'ADD COLUMN `occurrence_date`')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'MODIFY `occurrence_date` DATE NOT NULL')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'DROP INDEX `unique_event_reminder`')));
+        $this->assertCount(1, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'ADD UNIQUE KEY `unique_event_occurrence`')));
+    }
+
+    public function testReturnsCleanWhenLockContentionAndAnotherFinishedFirst(): void
+    {
+        $this->mockShape(
+            tableExists: true,
+            columnIsNullable: null,
+            indexes: ['unique_event_reminder'],
+            lockAcquired: false,
+        );
+        // Re-probe after lock fails: holder finished while we waited.
+        QueryUtils::queueMockResult(
+            self::COLUMN_PROBE_SQL,
+            ['oce_sinch_appointment_reminders', 'occurrence_date'],
+            [['IS_NULLABLE' => 'NO']],
+        );
+        QueryUtils::queueMockResult(
+            self::INDEX_PROBE_SQL,
+            ['oce_sinch_appointment_reminders'],
+            [
+                ['INDEX_NAME' => 'unique_event_occurrence'],
+                ['INDEX_NAME' => 'idx_occurrence_date'],
+            ],
+        );
+
+        ReminderTableMigration::ensureUpgraded();
+
+        $sqls = array_column(QueryUtils::getQueries(), 'sql');
+        $this->assertCount(0, array_filter($sqls, static fn(string $s): bool => str_starts_with(ltrim($s), 'ALTER TABLE')));
+        $this->assertCount(0, array_filter($sqls, static fn(string $s): bool => str_contains($s, 'RELEASE_LOCK')));
+    }
+
+    public function testThrowsWhenLockContentionAndStillLegacy(): void
+    {
+        $this->mockShape(
+            tableExists: true,
+            columnIsNullable: null,
+            indexes: ['unique_event_reminder'],
+            lockAcquired: false,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not acquire migration advisory lock');
+
+        ReminderTableMigration::ensureUpgraded();
+    }
+
+    public function testThrowsWhenDatabaseProbeReturnsEmpty(): void
+    {
+        $this->mockShape(
+            tableExists: true,
+            columnIsNullable: null,
+            indexes: ['unique_event_reminder'],
+        );
+        // Override DATABASE() probe → empty.
+        QueryUtils::setMockResult(self::DATABASE_PROBE_SQL, [], [['db' => '']]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('SELECT DATABASE() returned no value');
+
+        ReminderTableMigration::ensureUpgraded();
+    }
+
+    public function testThrowsWhenIsNullableNotAString(): void
+    {
+        QueryUtils::setMockResult(
+            self::TABLE_PROBE_SQL,
+            ['oce_sinch_appointment_reminders'],
+            [['TABLE_NAME' => 'oce_sinch_appointment_reminders']],
+        );
+        QueryUtils::setMockResult(
+            self::COLUMN_PROBE_SQL,
+            ['oce_sinch_appointment_reminders', 'occurrence_date'],
+            [['IS_NULLABLE' => 0]], // intentionally wrong type
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('IS_NULLABLE was not a string');
+
+        ReminderTableMigration::ensureUpgraded();
+    }
+
+    public function testReleaseLockSwallowsErrorsToPreserveOriginalException(): void
+    {
+        // Migration steps fail (DDL throws). RELEASE_LOCK then also throws
+        // (driver glitch). The caller must see the *original* DDL error,
+        // not the release-lock secondary error.
+        $this->mockShape(
+            tableExists: true,
+            columnIsNullable: null,
+            indexes: ['unique_event_reminder'],
+        );
+        // First sqlStatementThrowException after the probe is the ADD COLUMN.
+        QueryUtils::setNextException(new \RuntimeException('ADD COLUMN failed: disk full'));
+
+        try {
+            ReminderTableMigration::ensureUpgraded();
+            $this->fail('Expected RuntimeException');
+        } catch (\Throwable $e) {
+            $this->assertSame('ADD COLUMN failed: disk full', $e->getMessage());
+        }
+    }
+
+    /**
+     * @param bool|null $columnIsNullable null = column does not exist
+     * @param list<string> $indexes
+     */
+    private function mockShape(
+        bool $tableExists,
+        ?bool $columnIsNullable,
+        array $indexes,
+        bool $lockAcquired = true,
+    ): void {
+        QueryUtils::setMockResult(
+            self::TABLE_PROBE_SQL,
+            ['oce_sinch_appointment_reminders'],
+            $tableExists ? [['TABLE_NAME' => 'oce_sinch_appointment_reminders']] : [],
+        );
+        QueryUtils::setMockResult(
+            self::COLUMN_PROBE_SQL,
+            ['oce_sinch_appointment_reminders', 'occurrence_date'],
+            $columnIsNullable === null ? [] : [['IS_NULLABLE' => $columnIsNullable ? 'YES' : 'NO']],
+        );
+        QueryUtils::setMockResult(
+            self::INDEX_PROBE_SQL,
+            ['oce_sinch_appointment_reminders'],
+            array_map(static fn(string $name): array => ['INDEX_NAME' => $name], $indexes),
+        );
+        QueryUtils::setMockResult(
+            self::DATABASE_PROBE_SQL,
+            [],
+            [['db' => self::TENANT_DB]],
+        );
+        QueryUtils::setMockResult(
+            self::GET_LOCK_SQL,
+            [self::LOCK_NAME, 30],
+            [['got' => $lockAcquired ? 1 : 0]],
+        );
+    }
+}

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -629,7 +629,12 @@ class AppointmentReminderServiceTest extends TestCase
 
     public function testRunSkipsRecurringOccurrenceAlreadySent(): void
     {
-        $now = new \DateTimeImmutable();
+        // Pin $now so the dedup-load bind values match between test setup
+        // and service execution. Without this, run()'s internal `new
+        // DateTimeImmutable()` could land on the next calendar day if
+        // the test crosses midnight, leaving the mocked SELECT unmatched
+        // and causing the dedup skip to silently no-op.
+        $now = new \DateTimeImmutable('2026-05-15 12:00:00');
         $day1 = $now->modify('+1 day')->format('Y-m-d');
         $day2 = $now->modify('+2 days')->format('Y-m-d');
         $day3 = $now->modify('+3 days')->format('Y-m-d');
@@ -658,7 +663,7 @@ class AppointmentReminderServiceTest extends TestCase
             ->method('sendToPatient')
             ->willReturn(['id' => 'msg-dedup']);
 
-        $results = $this->service->run();
+        $results = $this->service->run($now);
 
         $this->assertSame(2, $results['sent']);
         $this->assertSame(0, $results['skipped'], 'Already-sent occurrences are quiet skips, not eligibility skips');
@@ -705,6 +710,41 @@ class AppointmentReminderServiceTest extends TestCase
         $this->assertSame($occurrenceDate, $inserts[0]['binds'][1]);
         $this->assertSame(72, $inserts[0]['binds'][2]);
         $this->assertSame('appointment_reminder_no_portal', $inserts[0]['binds'][3]);
+    }
+
+    // --- migration failure ---
+
+    public function testRunReturnsFailedResultWhenMigrationThrows(): void
+    {
+        // Force ensureUpgraded() to throw: legacy table exists (forces
+        // lock acquisition), no GET_LOCK mock → lock attempt returns
+        // [] → got=0 → false → re-probe still legacy → RuntimeException.
+        QueryUtils::setMockResult(
+            'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            ['oce_sinch_appointment_reminders'],
+            [['TABLE_NAME' => 'oce_sinch_appointment_reminders']]
+        );
+
+        // Service should not crash the cron runner — caller has no catch.
+        $results = $this->service->run();
+
+        $this->assertSame(1, $results['failed']);
+        $this->assertSame(0, $results['sent']);
+        $this->assertCount(1, $results['errors']);
+        $this->assertStringContainsString('schema migration failed', $results['errors'][0]);
+
+        // Migration is the failure boundary — purge / appointment-finder
+        // / sender must not have run.
+        $queries = QueryUtils::getQueries();
+        $this->assertCount(
+            0,
+            array_filter(
+                $queries,
+                static fn(array $q): bool => str_contains($q['sql'], 'DELETE FROM oce_sinch_appointment_reminders')
+            ),
+            'Purge must not run when the migration fails'
+        );
     }
 
     // --- cleanup ---

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -20,6 +20,7 @@ use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
 use OpenCoreEMR\Modules\SinchConversations\Service\TemplateService;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\StubAppointmentFinder;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -31,6 +32,7 @@ class AppointmentReminderServiceTest extends TestCase
     private GlobalConfig $config;
     private TemplateService&MockObject $templateService;
     private MessageService&MockObject $messageService;
+    private StubAppointmentFinder $finder;
     private AppointmentReminderService $service;
 
     protected function setUp(): void
@@ -47,11 +49,13 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->templateService = $this->createMock(TemplateService::class);
         $this->messageService = $this->createMock(MessageService::class);
+        $this->finder = new StubAppointmentFinder();
 
         $this->service = new AppointmentReminderService(
             $this->config,
             $this->templateService,
-            $this->messageService
+            $this->messageService,
+            $this->finder
         );
     }
 
@@ -65,7 +69,8 @@ class AppointmentReminderServiceTest extends TestCase
         $service = new AppointmentReminderService(
             $config,
             $this->templateService,
-            $this->messageService
+            $this->messageService,
+            new StubAppointmentFinder()
         );
 
         $results = $service->run();
@@ -481,7 +486,8 @@ class AppointmentReminderServiceTest extends TestCase
         $service = new AppointmentReminderService(
             $config,
             $this->templateService,
-            $this->messageService
+            $this->messageService,
+            $this->finder
         );
 
         $this->mockUpcomingAppointments([
@@ -571,6 +577,123 @@ class AppointmentReminderServiceTest extends TestCase
         $this->assertSame(0, $results['skipped']);
     }
 
+    // --- recurring appointments ---
+
+    public function testRunSendsOneReminderPerOccurrenceForRecurringAppointment(): void
+    {
+        // Same pc_eid, three different occurrence dates — what fetchAllEvents
+        // produces for a daily-recurring appointment.
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(900, 70, '2026-04-01', '09:00:00', '+15557770001', 'YES'),
+            $this->makeAppointment(900, 70, '2026-04-02', '09:00:00', '+15557770001', 'YES'),
+            $this->makeAppointment(900, 70, '2026-04-03', '09:00:00', '+15557770001', 'YES'),
+        ]);
+        $this->mockActiveConsent(70, '+15557770001');
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+        $this->templateService->method('render')
+            ->willReturn('Reminder.');
+        $this->messageService->expects($this->exactly(3))
+            ->method('sendToPatient')
+            ->willReturn(['id' => 'msg-recur']);
+
+        $results = $this->service->run();
+
+        $this->assertSame(3, $results['sent']);
+        $this->assertSame(0, $results['skipped']);
+
+        $inserts = array_values(array_filter(
+            QueryUtils::getQueries(),
+            static fn(array $q): bool => str_contains(
+                $q['sql'],
+                'INSERT IGNORE INTO oce_sinch_appointment_reminders'
+            )
+        ));
+        $this->assertCount(3, $inserts, 'Expected one INSERT per occurrence');
+
+        $occurrenceDates = array_map(
+            static fn(array $q): string => (string) $q['binds'][1],
+            $inserts
+        );
+        sort($occurrenceDates);
+        $this->assertSame(['2026-04-01', '2026-04-02', '2026-04-03'], $occurrenceDates);
+    }
+
+    public function testRunSkipsRecurringOccurrenceAlreadySent(): void
+    {
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(901, 71, '2026-04-01', '10:00:00', '+15557770002', 'YES'),
+            $this->makeAppointment(901, 71, '2026-04-02', '10:00:00', '+15557770002', 'YES'),
+            $this->makeAppointment(901, 71, '2026-04-03', '10:00:00', '+15557770002', 'YES'),
+        ]);
+        $this->mockActiveConsent(71, '+15557770002');
+
+        // Pre-seed the dedup table: April 2 has already been sent.
+        QueryUtils::setMockResult(
+            "SELECT pc_eid, occurrence_date
+                FROM oce_sinch_appointment_reminders
+                WHERE occurrence_date BETWEEN ? AND ?",
+            [(new \DateTimeImmutable())->format('Y-m-d'), (new \DateTimeImmutable())->modify('+24 hours')->format('Y-m-d')],
+            [['pc_eid' => 901, 'occurrence_date' => '2026-04-02']]
+        );
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+        $this->templateService->method('render')
+            ->willReturn('Reminder.');
+        $this->messageService->expects($this->exactly(2))
+            ->method('sendToPatient')
+            ->willReturn(['id' => 'msg-dedup']);
+
+        $results = $this->service->run();
+
+        $this->assertSame(2, $results['sent']);
+        $this->assertSame(0, $results['skipped'], 'Already-sent occurrences are quiet skips, not eligibility skips');
+
+        $inserts = array_values(array_filter(
+            QueryUtils::getQueries(),
+            static fn(array $q): bool => str_contains(
+                $q['sql'],
+                'INSERT IGNORE INTO oce_sinch_appointment_reminders'
+            )
+        ));
+        $occurrenceDates = array_map(
+            static fn(array $q): string => (string) $q['binds'][1],
+            $inserts
+        );
+        sort($occurrenceDates);
+        $this->assertSame(['2026-04-01', '2026-04-03'], $occurrenceDates);
+    }
+
+    public function testRecordedReminderBindsIncludeOccurrenceDate(): void
+    {
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(902, 72, '2026-04-15', '09:00:00', '+15557770003', 'YES'),
+        ]);
+        $this->mockActiveConsent(72, '+15557770003');
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+        $this->templateService->method('render')->willReturn('Reminder.');
+        $this->messageService->method('sendToPatient')->willReturn(['id' => 'msg-bind']);
+
+        $this->service->run();
+
+        $inserts = array_values(array_filter(
+            QueryUtils::getQueries(),
+            static fn(array $q): bool => str_contains(
+                $q['sql'],
+                'INSERT IGNORE INTO oce_sinch_appointment_reminders'
+            )
+        ));
+        $this->assertCount(1, $inserts);
+        $this->assertSame(902, $inserts[0]['binds'][0]);
+        $this->assertSame('2026-04-15', $inserts[0]['binds'][1]);
+        $this->assertSame(72, $inserts[0]['binds'][2]);
+        $this->assertSame('appointment_reminder_no_portal', $inserts[0]['binds'][3]);
+    }
+
     // --- cleanup ---
 
     public function testRunPurgesExpiredReminders(): void
@@ -591,25 +714,21 @@ class AppointmentReminderServiceTest extends TestCase
     // --- Helpers ---
 
     /**
-     * @param array<int, array<string, mixed>> $appointments
+     * @param list<array{
+     *     pc_eid: int,
+     *     pc_pid: int,
+     *     pc_eventDate: string,
+     *     pc_startTime: string,
+     *     phone_cell: ?string,
+     *     hipaa_allowsms: ?string
+     * }> $appointments
      */
     private function mockUpcomingAppointments(array $appointments): void
     {
-        QueryUtils::setMockResult(
-            "SELECT e.pc_eid, e.pc_pid, e.pc_eventDate, e.pc_startTime,
-                       p.phone_cell, p.hipaa_allowsms
-                FROM openemr_postcalendar_events e
-                JOIN patient_data p ON e.pc_pid = p.pid
-                LEFT JOIN oce_sinch_appointment_reminders r ON e.pc_eid = r.pc_eid
-                WHERE CONCAT(e.pc_eventDate, ' ', e.pc_startTime) > NOW()
-                  AND CONCAT(e.pc_eventDate, ' ', e.pc_startTime) <= DATE_ADD(NOW(), INTERVAL ? HOUR)
-                  AND e.pc_apptstatus != 'x'
-                  AND e.pc_pid > 0
-                  AND r.id IS NULL
-                ORDER BY e.pc_eventDate, e.pc_startTime",
-            [24],
-            $appointments
-        );
+        // Mutate the existing finder in place so any AppointmentReminderService
+        // already constructed with a reference to it (e.g. tests that build a
+        // local service with a custom config) sees the new occurrences.
+        $this->finder->setOccurrences($appointments);
     }
 
     /**

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -581,12 +581,19 @@ class AppointmentReminderServiceTest extends TestCase
 
     public function testRunSendsOneReminderPerOccurrenceForRecurringAppointment(): void
     {
-        // Same pc_eid, three different occurrence dates — what fetchAllEvents
-        // produces for a daily-recurring appointment.
+        // Use dates relative to "now" so the occurrences mirror what a real
+        // CoreAppointmentFinder would return for a daily-recurring appointment
+        // within the active reminder window. The stub doesn't enforce the
+        // window contract — this is for readability and contract-fidelity.
+        $now = new \DateTimeImmutable();
+        $day1 = $now->modify('+1 day')->format('Y-m-d');
+        $day2 = $now->modify('+2 days')->format('Y-m-d');
+        $day3 = $now->modify('+3 days')->format('Y-m-d');
+
         $this->mockUpcomingAppointments([
-            $this->makeAppointment(900, 70, '2026-04-01', '09:00:00', '+15557770001', 'YES'),
-            $this->makeAppointment(900, 70, '2026-04-02', '09:00:00', '+15557770001', 'YES'),
-            $this->makeAppointment(900, 70, '2026-04-03', '09:00:00', '+15557770001', 'YES'),
+            $this->makeAppointment(900, 70, $day1, '09:00:00', '+15557770001', 'YES'),
+            $this->makeAppointment(900, 70, $day2, '09:00:00', '+15557770001', 'YES'),
+            $this->makeAppointment(900, 70, $day3, '09:00:00', '+15557770001', 'YES'),
         ]);
         $this->mockActiveConsent(70, '+15557770001');
 
@@ -617,25 +624,30 @@ class AppointmentReminderServiceTest extends TestCase
             $inserts
         );
         sort($occurrenceDates);
-        $this->assertSame(['2026-04-01', '2026-04-02', '2026-04-03'], $occurrenceDates);
+        $this->assertSame([$day1, $day2, $day3], $occurrenceDates);
     }
 
     public function testRunSkipsRecurringOccurrenceAlreadySent(): void
     {
+        $now = new \DateTimeImmutable();
+        $day1 = $now->modify('+1 day')->format('Y-m-d');
+        $day2 = $now->modify('+2 days')->format('Y-m-d');
+        $day3 = $now->modify('+3 days')->format('Y-m-d');
+
         $this->mockUpcomingAppointments([
-            $this->makeAppointment(901, 71, '2026-04-01', '10:00:00', '+15557770002', 'YES'),
-            $this->makeAppointment(901, 71, '2026-04-02', '10:00:00', '+15557770002', 'YES'),
-            $this->makeAppointment(901, 71, '2026-04-03', '10:00:00', '+15557770002', 'YES'),
+            $this->makeAppointment(901, 71, $day1, '10:00:00', '+15557770002', 'YES'),
+            $this->makeAppointment(901, 71, $day2, '10:00:00', '+15557770002', 'YES'),
+            $this->makeAppointment(901, 71, $day3, '10:00:00', '+15557770002', 'YES'),
         ]);
         $this->mockActiveConsent(71, '+15557770002');
 
-        // Pre-seed the dedup table: April 2 has already been sent.
+        // Pre-seed the dedup table: middle day has already been sent.
         QueryUtils::setMockResult(
             "SELECT pc_eid, occurrence_date
                 FROM oce_sinch_appointment_reminders
                 WHERE occurrence_date BETWEEN ? AND ?",
-            [(new \DateTimeImmutable())->format('Y-m-d'), (new \DateTimeImmutable())->modify('+24 hours')->format('Y-m-d')],
-            [['pc_eid' => 901, 'occurrence_date' => '2026-04-02']]
+            [$now->format('Y-m-d'), $now->modify('+24 hours')->format('Y-m-d')],
+            [['pc_eid' => 901, 'occurrence_date' => $day2]]
         );
 
         $this->templateService->method('getAppointmentReminderTemplateKey')
@@ -663,13 +675,14 @@ class AppointmentReminderServiceTest extends TestCase
             $inserts
         );
         sort($occurrenceDates);
-        $this->assertSame(['2026-04-01', '2026-04-03'], $occurrenceDates);
+        $this->assertSame([$day1, $day3], $occurrenceDates);
     }
 
     public function testRecordedReminderBindsIncludeOccurrenceDate(): void
     {
+        $occurrenceDate = (new \DateTimeImmutable())->modify('+1 day')->format('Y-m-d');
         $this->mockUpcomingAppointments([
-            $this->makeAppointment(902, 72, '2026-04-15', '09:00:00', '+15557770003', 'YES'),
+            $this->makeAppointment(902, 72, $occurrenceDate, '09:00:00', '+15557770003', 'YES'),
         ]);
         $this->mockActiveConsent(72, '+15557770003');
 
@@ -689,7 +702,7 @@ class AppointmentReminderServiceTest extends TestCase
         ));
         $this->assertCount(1, $inserts);
         $this->assertSame(902, $inserts[0]['binds'][0]);
-        $this->assertSame('2026-04-15', $inserts[0]['binds'][1]);
+        $this->assertSame($occurrenceDate, $inserts[0]['binds'][1]);
         $this->assertSame(72, $inserts[0]['binds'][2]);
         $this->assertSame('appointment_reminder_no_portal', $inserts[0]['binds'][3]);
     }

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -34,6 +34,12 @@ class AppointmentReminderServiceTest extends TestCase
     private MessageService&MockObject $messageService;
     private StubAppointmentFinder $finder;
     private AppointmentReminderService $service;
+    /**
+     * Fixed test clock — pinned just before the dates the eligibility
+     * test fixtures use, so a 24-hour window covers them all and the
+     * stub finder's window-contract enforcement doesn't filter them out.
+     */
+    private \DateTimeImmutable $now;
 
     protected function setUp(): void
     {
@@ -41,8 +47,11 @@ class AppointmentReminderServiceTest extends TestCase
         QueryUtils::clearMockResults();
         SystemLogger::clearLogs();
 
+        // 96h window covers the 4-day span of the recurring-appointment
+        // fixtures (now + 3 days) so the stub finder's window enforcement
+        // doesn't filter them out.
         $this->config = new GlobalConfig(new MockGlobalsAccessor([
-            'SMS_NOTIFICATION_HOUR' => 24,
+            'SMS_NOTIFICATION_HOUR' => 96,
             GlobalConfig::CONFIG_OPTION_CLINIC_NAME => 'Test Clinic',
             GlobalConfig::CONFIG_OPTION_CLINIC_PHONE => '+15551234567',
         ]), new MockConfigFactory());
@@ -50,6 +59,7 @@ class AppointmentReminderServiceTest extends TestCase
         $this->templateService = $this->createMock(TemplateService::class);
         $this->messageService = $this->createMock(MessageService::class);
         $this->finder = new StubAppointmentFinder();
+        $this->now = new \DateTimeImmutable('2026-03-31 12:00:00');
 
         $this->service = new AppointmentReminderService(
             $this->config,
@@ -73,7 +83,7 @@ class AppointmentReminderServiceTest extends TestCase
             new StubAppointmentFinder()
         );
 
-        $results = $service->run();
+        $results = $service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(0, $results['skipped']);
@@ -99,7 +109,7 @@ class AppointmentReminderServiceTest extends TestCase
     {
         $this->mockUpcomingAppointments([]);
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(0, $results['skipped']);
@@ -124,7 +134,7 @@ class AppointmentReminderServiceTest extends TestCase
             ->with(42, '+15559999999', 'Your appointment is coming up.', $this->anything())
             ->willReturn(['id' => 'msg-reminder-1']);
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['sent']);
         $this->assertSame(0, $results['skipped']);
@@ -162,7 +172,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
@@ -197,7 +207,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
@@ -232,7 +242,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
@@ -263,7 +273,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->once())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['sent']);
         $this->assertSame(0, $results['skipped']);
@@ -283,7 +293,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
@@ -302,7 +312,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['skipped']);
         $this->assertSkipLogged(103, 45, 'hipaa_disallows_sms', ['hipaa_allowsms' => 'unset']);
@@ -322,7 +332,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(0, $results['skipped']);
@@ -342,7 +352,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['skipped']);
@@ -362,7 +372,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['skipped']);
         $this->assertSkipLogged(120, 55, 'unparseable_phone', ['phone_last4' => '']);
@@ -379,7 +389,7 @@ class AppointmentReminderServiceTest extends TestCase
         $this->templateService->method('getAppointmentReminderTemplateKey')
             ->willReturn('appointment_reminder_no_portal');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['skipped']);
         $this->assertSkipLogged(121, 56, 'unparseable_phone', ['phone_last4' => '1234']);
@@ -402,7 +412,7 @@ class AppointmentReminderServiceTest extends TestCase
         $this->messageService->method('sendToPatient')
             ->willThrowException(new ValidationException('API error'));
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['failed']);
@@ -426,7 +436,7 @@ class AppointmentReminderServiceTest extends TestCase
 
         $this->messageService->expects($this->never())->method('sendToPatient');
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(0, $results['sent']);
         $this->assertSame(1, $results['failed']);
@@ -466,7 +476,7 @@ class AppointmentReminderServiceTest extends TestCase
         $this->messageService->method('sendToPatient')
             ->willReturn(['id' => 'msg-ok']);
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(2, $results['sent']);
         $this->assertSame(1, $results['skipped']);
@@ -514,7 +524,7 @@ class AppointmentReminderServiceTest extends TestCase
         $this->messageService->method('sendToPatient')
             ->willReturn(['id' => 'msg-portal']);
 
-        $results = $service->run();
+        $results = $service->run($this->now);
 
         $this->assertSame(1, $results['sent']);
     }
@@ -545,7 +555,7 @@ class AppointmentReminderServiceTest extends TestCase
         $this->messageService->method('sendToPatient')
             ->willReturn(['id' => 'msg-fmt']);
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['sent']);
     }
@@ -571,7 +581,7 @@ class AppointmentReminderServiceTest extends TestCase
             ->with(80, '+15102551233', 'Reminder for raw phone.', $this->anything())
             ->willReturn(['id' => 'msg-raw-phone']);
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['sent']);
         $this->assertSame(0, $results['skipped']);
@@ -581,14 +591,12 @@ class AppointmentReminderServiceTest extends TestCase
 
     public function testRunSendsOneReminderPerOccurrenceForRecurringAppointment(): void
     {
-        // Use dates relative to "now" so the occurrences mirror what a real
-        // CoreAppointmentFinder would return for a daily-recurring appointment
-        // within the active reminder window. The stub doesn't enforce the
-        // window contract — this is for readability and contract-fidelity.
-        $now = new \DateTimeImmutable();
-        $day1 = $now->modify('+1 day')->format('Y-m-d');
-        $day2 = $now->modify('+2 days')->format('Y-m-d');
-        $day3 = $now->modify('+3 days')->format('Y-m-d');
+        // Use dates relative to the fixture clock so the occurrences look
+        // like what a real CoreAppointmentFinder would return for a
+        // daily-recurring appointment within the active reminder window.
+        $day1 = $this->now->modify('+1 day')->format('Y-m-d');
+        $day2 = $this->now->modify('+2 days')->format('Y-m-d');
+        $day3 = $this->now->modify('+3 days')->format('Y-m-d');
 
         $this->mockUpcomingAppointments([
             $this->makeAppointment(900, 70, $day1, '09:00:00', '+15557770001', 'YES'),
@@ -605,7 +613,7 @@ class AppointmentReminderServiceTest extends TestCase
             ->method('sendToPatient')
             ->willReturn(['id' => 'msg-recur']);
 
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(3, $results['sent']);
         $this->assertSame(0, $results['skipped']);
@@ -629,15 +637,9 @@ class AppointmentReminderServiceTest extends TestCase
 
     public function testRunSkipsRecurringOccurrenceAlreadySent(): void
     {
-        // Pin $now so the dedup-load bind values match between test setup
-        // and service execution. Without this, run()'s internal `new
-        // DateTimeImmutable()` could land on the next calendar day if
-        // the test crosses midnight, leaving the mocked SELECT unmatched
-        // and causing the dedup skip to silently no-op.
-        $now = new \DateTimeImmutable('2026-05-15 12:00:00');
-        $day1 = $now->modify('+1 day')->format('Y-m-d');
-        $day2 = $now->modify('+2 days')->format('Y-m-d');
-        $day3 = $now->modify('+3 days')->format('Y-m-d');
+        $day1 = $this->now->modify('+1 day')->format('Y-m-d');
+        $day2 = $this->now->modify('+2 days')->format('Y-m-d');
+        $day3 = $this->now->modify('+3 days')->format('Y-m-d');
 
         $this->mockUpcomingAppointments([
             $this->makeAppointment(901, 71, $day1, '10:00:00', '+15557770002', 'YES'),
@@ -647,11 +649,16 @@ class AppointmentReminderServiceTest extends TestCase
         $this->mockActiveConsent(71, '+15557770002');
 
         // Pre-seed the dedup table: middle day has already been sent.
+        // Bind range mirrors the service's internal computation:
+        // [now Y-m-d, (now + SMS_NOTIFICATION_HOUR) Y-m-d].
         QueryUtils::setMockResult(
             "SELECT pc_eid, occurrence_date
                 FROM oce_sinch_appointment_reminders
                 WHERE occurrence_date BETWEEN ? AND ?",
-            [$now->format('Y-m-d'), $now->modify('+24 hours')->format('Y-m-d')],
+            [
+                $this->now->format('Y-m-d'),
+                $this->now->modify('+96 hours')->format('Y-m-d'),
+            ],
             [['pc_eid' => 901, 'occurrence_date' => $day2]]
         );
 
@@ -663,7 +670,7 @@ class AppointmentReminderServiceTest extends TestCase
             ->method('sendToPatient')
             ->willReturn(['id' => 'msg-dedup']);
 
-        $results = $this->service->run($now);
+        $results = $this->service->run($this->now);
 
         $this->assertSame(2, $results['sent']);
         $this->assertSame(0, $results['skipped'], 'Already-sent occurrences are quiet skips, not eligibility skips');
@@ -685,7 +692,7 @@ class AppointmentReminderServiceTest extends TestCase
 
     public function testRecordedReminderBindsIncludeOccurrenceDate(): void
     {
-        $occurrenceDate = (new \DateTimeImmutable())->modify('+1 day')->format('Y-m-d');
+        $occurrenceDate = $this->now->modify('+1 day')->format('Y-m-d');
         $this->mockUpcomingAppointments([
             $this->makeAppointment(902, 72, $occurrenceDate, '09:00:00', '+15557770003', 'YES'),
         ]);
@@ -696,7 +703,7 @@ class AppointmentReminderServiceTest extends TestCase
         $this->templateService->method('render')->willReturn('Reminder.');
         $this->messageService->method('sendToPatient')->willReturn(['id' => 'msg-bind']);
 
-        $this->service->run();
+        $this->service->run($this->now);
 
         $inserts = array_values(array_filter(
             QueryUtils::getQueries(),
@@ -718,8 +725,7 @@ class AppointmentReminderServiceTest extends TestCase
         // Without in-loop dedup, both would send because the bulk-loaded
         // sentKeys map is empty and the DB INSERT IGNORE only dedups the
         // log row after both sends complete.
-        $now = new \DateTimeImmutable('2026-05-15 12:00:00');
-        $day = $now->modify('+1 day')->format('Y-m-d');
+        $day = $this->now->modify('+1 day')->format('Y-m-d');
         $this->mockUpcomingAppointments([
             $this->makeAppointment(950, 80, $day, '09:00:00', '+15557770100', 'YES'),
             $this->makeAppointment(950, 80, $day, '09:00:00', '+15557770100', 'YES'),
@@ -733,10 +739,28 @@ class AppointmentReminderServiceTest extends TestCase
             ->method('sendToPatient')
             ->willReturn(['id' => 'msg-dup']);
 
-        $results = $this->service->run($now);
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['sent']);
         $this->assertSame(0, $results['skipped'], 'In-loop dedup is a quiet skip, not an eligibility skip');
+    }
+
+    // --- stub honours the finder contract ---
+
+    public function testStubAppointmentFinderFiltersOccurrencesOutsideWindow(): void
+    {
+        // Three occurrences: one before now (out), one inside window, one
+        // after windowEnd (out). The stub should return only the middle.
+        $now = new \DateTimeImmutable('2026-03-31 12:00:00');
+        $beforeNow = $this->makeAppointment(801, 81, '2026-03-30', '12:00:00');
+        $inWindow = $this->makeAppointment(802, 82, '2026-04-01', '06:00:00');
+        $afterEnd = $this->makeAppointment(803, 83, '2026-04-05', '12:00:00');
+        $stub = new StubAppointmentFinder([$beforeNow, $inWindow, $afterEnd]);
+
+        $occurrences = $stub->findUpcoming(96, $now);
+
+        $this->assertCount(1, $occurrences);
+        $this->assertSame(802, $occurrences[0]['pc_eid']);
     }
 
     // --- migration failure ---
@@ -754,23 +778,25 @@ class AppointmentReminderServiceTest extends TestCase
         );
 
         // Service should not crash the cron runner — caller has no catch.
-        $results = $this->service->run();
+        $results = $this->service->run($this->now);
 
         $this->assertSame(1, $results['failed']);
         $this->assertSame(0, $results['sent']);
         $this->assertCount(1, $results['errors']);
         $this->assertStringContainsString('schema migration failed', $results['errors'][0]);
 
-        // Migration is the failure boundary — purge / appointment-finder
-        // / sender must not have run.
+        // Purge runs before migration (it only references sent_at, which
+        // exists in both schemas, so it's not gated by migration success).
+        // The finder and sender, on the other hand, must not have run —
+        // migration failure is the boundary that cuts the eligibility loop.
         $queries = QueryUtils::getQueries();
         $this->assertCount(
             0,
             array_filter(
                 $queries,
-                static fn(array $q): bool => str_contains($q['sql'], 'DELETE FROM oce_sinch_appointment_reminders')
+                static fn(array $q): bool => str_contains($q['sql'], 'INSERT IGNORE INTO oce_sinch_appointment_reminders')
             ),
-            'Purge must not run when the migration fails'
+            'No reminder INSERTs after migration failure'
         );
     }
 
@@ -780,7 +806,7 @@ class AppointmentReminderServiceTest extends TestCase
     {
         $this->mockUpcomingAppointments([]);
 
-        $this->service->run();
+        $this->service->run($this->now);
 
         $queries = QueryUtils::getQueries();
         $deleteQueries = array_filter(

--- a/tests/Unit/Service/AppointmentReminderServiceTest.php
+++ b/tests/Unit/Service/AppointmentReminderServiceTest.php
@@ -712,6 +712,33 @@ class AppointmentReminderServiceTest extends TestCase
         $this->assertSame('appointment_reminder_no_portal', $inserts[0]['binds'][3]);
     }
 
+    public function testRunDedupesDuplicateOccurrencesWithinSingleRun(): void
+    {
+        // Finder returns the same (pc_eid, pc_eventDate) twice in one run.
+        // Without in-loop dedup, both would send because the bulk-loaded
+        // sentKeys map is empty and the DB INSERT IGNORE only dedups the
+        // log row after both sends complete.
+        $now = new \DateTimeImmutable('2026-05-15 12:00:00');
+        $day = $now->modify('+1 day')->format('Y-m-d');
+        $this->mockUpcomingAppointments([
+            $this->makeAppointment(950, 80, $day, '09:00:00', '+15557770100', 'YES'),
+            $this->makeAppointment(950, 80, $day, '09:00:00', '+15557770100', 'YES'),
+        ]);
+        $this->mockActiveConsent(80, '+15557770100');
+
+        $this->templateService->method('getAppointmentReminderTemplateKey')
+            ->willReturn('appointment_reminder_no_portal');
+        $this->templateService->method('render')->willReturn('Reminder.');
+        $this->messageService->expects($this->once())
+            ->method('sendToPatient')
+            ->willReturn(['id' => 'msg-dup']);
+
+        $results = $this->service->run($now);
+
+        $this->assertSame(1, $results['sent']);
+        $this->assertSame(0, $results['skipped'], 'In-loop dedup is a quiet skip, not an eligibility skip');
+    }
+
     // --- migration failure ---
 
     public function testRunReturnsFailedResultWhenMigrationThrows(): void


### PR DESCRIPTION
## Summary

Recurring appointments never received SMS reminders. Verified live on `canary-clinic.stg`: two test patients with daily-repeating appointments got the email reminders but never the texts.

**Root cause.** `AppointmentReminderService::getUpcomingAppointments()` ran a hand-written query that compared `pc_eventDate > NOW()` directly. OpenEMR stores a recurring appointment as a single row whose `pc_eventDate` is the **original** (first) occurrence; later occurrences are not separate rows. Once the original date drifted into the past — which happens on day 2 of any "repeats daily" appointment — the predicate stopped matching and no occurrence ever fired. Email reminders worked because core's notification pipeline goes through `library/appointments.inc.php::fetchAllEvents()`, which expands `pc_recurrtype` / `pc_recurrspec` into per-occurrence rows. The Sinch module reimplemented the query and dropped recurrence handling.

A second related defect: the dedup table `oce_sinch_appointment_reminders` keyed on `pc_eid` alone, so even if recurrence had been expanded, the first sent reminder would have blocked every subsequent occurrence of the same recurring event.

## Approach

- New `UpcomingAppointmentFinder` interface; default `CoreAppointmentFinder` wraps `\fetchAllEvents()` so the production path uses core's authoritative recurrence-expansion code (no duplicated logic, no drift).
- `StubAppointmentFinder` in tests; service stays unit-testable without the procedural function or a kernel event dispatcher.
- Dedup table migrates from `UNIQUE (pc_eid)` to `UNIQUE (pc_eid, occurrence_date)`. `ModuleManagerListener::enable()` runs an idempotent in-place migration (INFORMATION_SCHEMA probe → ALTER + backfill from `openemr_postcalendar_events.pc_eventDate` → swap unique key) so existing tenants on the old shape upgrade on next enable. Fresh installs get the new shape directly from `table.sql`.
- The reminder service bulk-loads already-sent `(pc_eid, occurrence_date)` pairs for the active window in one query and filters in PHP, replacing the old `LEFT JOIN ... r.id IS NULL` predicate.

## Test plan

- [x] `task check` — pre-commit, PHPCS, PHPStan, Rector, composer-require-checker all green
- [x] `composer phpunit` — 523 tests, 1344 assertions; new coverage:
  - `testRunSendsOneReminderPerOccurrenceForRecurringAppointment` — three occurrences, three sends, three distinct INSERT binds
  - `testRunSkipsRecurringOccurrenceAlreadySent` — one of three pre-seeded as already sent, expect two new sends
  - `testRecordedReminderBindsIncludeOccurrenceDate` — verifies the new column is in the INSERT
  - `testEnableSkipsMigrationWhenOccurrenceDateColumnAlreadyExists`
  - `testEnableRunsMigrationWhenLegacyTableExists`
- [ ] Local docker end-to-end: install module on a fresh DB, create a daily-recurring appointment with mobile + `Allow SMS = YES`, set `SMS_NOTIFICATION_HOUR = 24`, run the background service, verify one SMS lands and a re-run does not double-send
- [ ] After merge → release → image rollout: verify on `canary-clinic.stg` that today's next occurrence of each test patient's daily appointment produces exactly one SMS