### PR TITLE
fix(reminders): call fetchAppointments, not fetchAllEvents

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -47,7 +47,7 @@
     "attr",
     "text",
     "date",
-    "fetchAllEvents",
+    "fetchAppointments",
     "random_bytes"
   ],
   "php-core-extensions": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -48,7 +48,7 @@ parameters:
                 - src/Module/Console/Command/AbstractModuleCommand.php
 
         # OpenEMR global functions not available for static analysis
-        - '#Function (xl|xlt|xla|xlj|text|attr|fetchAllEvents) not found#'
+        - '#Function (xl|xlt|xla|xlj|text|attr|fetchAppointments) not found#'
 
         # Never-read properties are intentional (event handlers, etc.)
         - '#Property .+ is never read, only written#'

--- a/src/Module/Service/CoreAppointmentFinder.php
+++ b/src/Module/Service/CoreAppointmentFinder.php
@@ -3,10 +3,15 @@
 /**
  * Default UpcomingAppointmentFinder backed by core OpenEMR
  *
- * Wraps `library/appointments.inc.php::fetchAllEvents()`, which expands
- * `pc_recurrtype` / `pc_recurrspec` into per-occurrence rows. Production
- * uses this; unit tests inject a stub instead so they don't have to load
- * the procedural library or wire up the kernel event dispatcher.
+ * Wraps `library/appointments.inc.php::fetchAppointments()`, which (via
+ * the shared `fetchEvents()` helper) expands `pc_recurrtype` /
+ * `pc_recurrspec` into per-occurrence rows AND filters to events with a
+ * patient (`pc_pid != ''`). The sibling `fetchAllEvents()` returns
+ * provider-availability blocks ("In Office" / "Out Of Office" calendar
+ * events with no patient) and is used only by `getAvailableSlots()` —
+ * not what we want here. Production uses this; unit tests inject a stub
+ * instead so they don't have to load the procedural library or wire up
+ * the kernel event dispatcher.
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
@@ -43,13 +48,17 @@ class CoreAppointmentFinder implements UpcomingAppointmentFinder
         require_once $fileroot . '/library/appointments.inc.php';
 
         $windowEnd = $now->modify(sprintf('+%d hours', $windowHours));
-        // fetchAllEvents filters by date (Y-m-d) inclusive on both ends,
+        // fetchAppointments filters by date (Y-m-d) inclusive on both ends,
         // so a window that crosses midnight already pulls in the trailing
         // calendar day. We re-check the precise time bound in PHP below.
         $fromDate = $now->format('Y-m-d');
         $toDate = $windowEnd->format('Y-m-d');
 
-        $events = \fetchAllEvents($fromDate, $toDate);
+        // All optional args default to null/false, which makes
+        // fetchAppointments return every patient appointment in the
+        // window across all providers/facilities. The pc_pid != '' guard
+        // lives inside fetchAppointments itself.
+        $events = \fetchAppointments($fromDate, $toDate);
         if (!is_array($events)) {
             return [];
         }

--- a/tests/Unit/Service/CoreAppointmentFinderTest.php
+++ b/tests/Unit/Service/CoreAppointmentFinderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Service;
+
+use OpenCoreEMR\Modules\SinchConversations\Service\CoreAppointmentFinder;
+use OpenEMR\Core\OEGlobalsBag;
+use PHPUnit\Framework\TestCase;
+
+class CoreAppointmentFinderTest extends TestCase
+{
+    private const FIXTURE_ROOT = __DIR__ . '/../../fixtures/CoreAppointmentFinder';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OEGlobalsBag::reset();
+        $GLOBALS['fileroot'] = self::FIXTURE_ROOT;
+        $GLOBALS['__test_fetch_appointments_calls'] = [];
+        $GLOBALS['__test_fetch_appointments_return'] = [];
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['fileroot'],
+            $GLOBALS['__test_fetch_appointments_calls'],
+            $GLOBALS['__test_fetch_appointments_return'],
+        );
+        OEGlobalsBag::reset();
+        parent::tearDown();
+    }
+
+    public function testCallsFetchAppointmentsWithDateWindowBounds(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-13 09:00:00');
+
+        (new CoreAppointmentFinder())->findUpcoming(10, $now);
+
+        $this->assertCount(1, $GLOBALS['__test_fetch_appointments_calls']);
+        $this->assertSame(
+            ['from_date' => '2026-05-13', 'to_date' => '2026-05-13'],
+            $GLOBALS['__test_fetch_appointments_calls'][0],
+        );
+    }
+
+    public function testReturnsPatientOccurrencesInsideWindow(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-13 09:00:00');
+        $GLOBALS['__test_fetch_appointments_return'] = [
+            $this->event(pcEid: 65, pcPid: 5, date: '2026-05-13', time: '14:00:00', phone: '+15102551233', sms: 'YES'),
+            $this->event(pcEid: 70, pcPid: 14, date: '2026-05-13', time: '11:00:00', phone: '+14123704170', sms: 'YES'),
+        ];
+
+        $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
+
+        $this->assertCount(2, $result);
+        $this->assertSame(65, $result[0]['pc_eid']);
+        $this->assertSame(5, $result[0]['pc_pid']);
+        $this->assertSame('14:00:00', $result[0]['pc_startTime']);
+        $this->assertSame('+15102551233', $result[0]['phone_cell']);
+        $this->assertSame('YES', $result[0]['hipaa_allowsms']);
+        $this->assertSame(14, $result[1]['pc_pid']);
+    }
+
+    /**
+     * Regression guard for the 1.2.0 → 1.2.x bug where the finder called
+     * fetchAllEvents (which returns availability blocks with no patient).
+     * The fixture's fetchAllEvents throws; this test confirms findUpcoming
+     * doesn't trigger it even when the row shape includes nullable patient
+     * fields.
+     */
+    public function testRejectsRowsWithoutPatientId(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-13 09:00:00');
+        $GLOBALS['__test_fetch_appointments_return'] = [
+            // Patient appointment — should appear.
+            $this->event(pcEid: 65, pcPid: 5, date: '2026-05-13', time: '14:00:00'),
+            // Availability-style row that snuck through somehow (pc_pid empty).
+            // The finder's positive-int guard must drop it without error.
+            $this->event(pcEid: 7, pcPid: null, date: '2026-05-13', time: '10:00:00'),
+        ];
+
+        $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(5, $result[0]['pc_pid']);
+    }
+
+    public function testFiltersOutOccurrencesOutsideTheTimeWindow(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-13 09:00:00');
+        $GLOBALS['__test_fetch_appointments_return'] = [
+            // Already past at $now — drop.
+            $this->event(pcEid: 1, pcPid: 5, date: '2026-05-13', time: '08:00:00'),
+            // Inside window.
+            $this->event(pcEid: 2, pcPid: 5, date: '2026-05-13', time: '14:00:00'),
+            // Beyond +10h boundary (19:01 > 19:00).
+            $this->event(pcEid: 3, pcPid: 5, date: '2026-05-13', time: '19:01:00'),
+        ];
+
+        $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(2, $result[0]['pc_eid']);
+    }
+
+    public function testSkipsCancelledAppointments(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-13 09:00:00');
+        $GLOBALS['__test_fetch_appointments_return'] = [
+            $this->event(pcEid: 1, pcPid: 5, date: '2026-05-13', time: '14:00:00', status: 'x'),
+            $this->event(pcEid: 2, pcPid: 5, date: '2026-05-13', time: '15:00:00', status: '-'),
+        ];
+
+        $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(2, $result[0]['pc_eid']);
+    }
+
+    public function testReturnsEmptyWhenFilerootMissing(): void
+    {
+        unset($GLOBALS['fileroot']);
+
+        $result = (new CoreAppointmentFinder())->findUpcoming(10, new \DateTimeImmutable());
+
+        $this->assertSame([], $result);
+        $this->assertSame([], $GLOBALS['__test_fetch_appointments_calls']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function event(
+        int $pcEid,
+        ?int $pcPid,
+        string $date,
+        string $time,
+        ?string $phone = null,
+        ?string $sms = null,
+        string $status = '-',
+    ): array {
+        return [
+            'pc_eid' => $pcEid,
+            'pc_pid' => $pcPid,
+            'pc_eventDate' => $date,
+            'pc_startTime' => $time,
+            'pc_apptstatus' => $status,
+            'phone_cell' => $phone,
+            'hipaa_allowsms' => $sms,
+        ];
+    }
+}

--- a/tests/Unit/Service/CoreAppointmentFinderTest.php
+++ b/tests/Unit/Service/CoreAppointmentFinderTest.php
@@ -100,9 +100,14 @@ class CoreAppointmentFinderTest extends TestCase
         $GLOBALS['__test_fetch_appointments_return'] = [
             // Patient appointment — should appear.
             $this->event(pcEid: 65, pcPid: 5, date: '2026-05-13', time: '14:00:00'),
-            // Availability-style row that snuck through somehow (pc_pid empty).
-            // The finder's positive-int guard must drop it without error.
-            $this->event(pcEid: 7, pcPid: null, date: '2026-05-13', time: '10:00:00'),
+            // Availability-style row matching the OpenEMR mysqli return
+            // shape: pc_pid is the empty string, not null. The asPositiveInt
+            // guard must drop both shapes — the empty string slipping
+            // through would mean fetchAppointments-shaped rows where the
+            // patient JOIN didn't match are emitted as malformed
+            // occurrences. Cover both to keep that exit closed.
+            $this->event(pcEid: 7, pcPid: '', date: '2026-05-13', time: '10:00:00'),
+            $this->event(pcEid: 8, pcPid: null, date: '2026-05-13', time: '10:30:00'),
         ];
 
         $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
@@ -154,11 +159,17 @@ class CoreAppointmentFinderTest extends TestCase
     }
 
     /**
+     * @param int|string|null $pcPid Mirrors the production seam: the row
+     *     comes back from fetchAppointments via OpenEMR's mysqli driver,
+     *     which historically returns numeric columns as numeric strings
+     *     and produces an empty string when the patient_data LEFT JOIN
+     *     finds no match. Tests pass each variant to exercise the
+     *     finder's asPositiveInt guard.
      * @return array<string, mixed>
      */
     private function event(
         int $pcEid,
-        ?int $pcPid,
+        int|string|null $pcPid,
         string $date,
         string $time,
         ?string $phone = null,

--- a/tests/Unit/Service/CoreAppointmentFinderTest.php
+++ b/tests/Unit/Service/CoreAppointmentFinderTest.php
@@ -16,6 +16,20 @@ use OpenCoreEMR\Modules\SinchConversations\Service\CoreAppointmentFinder;
 use OpenEMR\Core\OEGlobalsBag;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for CoreAppointmentFinder.
+ *
+ * The fixture at tests/fixtures/CoreAppointmentFinder/library/appointments.inc.php
+ * stubs out the two relevant globals from core OpenEMR's appointments library:
+ *
+ *  - fetchAppointments() — controllable via $GLOBALS, returns canned event rows
+ *  - fetchAllEvents()    — throws RuntimeException
+ *
+ * The throwing fetchAllEvents() stub is the file-wide regression guard for
+ * the 1.2.0 bug where the finder called the wrong core helper and silently
+ * dispatched zero reminders. If a future change re-wires that call, every
+ * test in this file fails loudly instead of the cron going quiet.
+ */
 class CoreAppointmentFinderTest extends TestCase
 {
     private const FIXTURE_ROOT = __DIR__ . '/../../fixtures/CoreAppointmentFinder';
@@ -73,11 +87,12 @@ class CoreAppointmentFinderTest extends TestCase
     }
 
     /**
-     * Regression guard for the 1.2.0 → 1.2.x bug where the finder called
-     * fetchAllEvents (which returns availability blocks with no patient).
-     * The fixture's fetchAllEvents throws; this test confirms findUpcoming
-     * doesn't trigger it even when the row shape includes nullable patient
-     * fields.
+     * Defence in depth against the 1.2.0 bug. If fetchAppointments ever
+     * starts returning rows without a patient (a core change, a future
+     * caller passing custom WHERE clauses, etc.), the finder's positive-int
+     * pc_pid guard must drop them rather than emit a malformed occurrence.
+     * The throwing fetchAllEvents fixture catches the wrong-function half
+     * of the original bug; this test catches the wrong-shape half.
      */
     public function testRejectsRowsWithoutPatientId(): void
     {

--- a/tests/fixtures/CoreAppointmentFinder/library/appointments.inc.php
+++ b/tests/fixtures/CoreAppointmentFinder/library/appointments.inc.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Test fixture standing in for OpenEMR's library/appointments.inc.php.
+ *
+ * Defined as global functions because that's the seam CoreAppointmentFinder
+ * uses (`require_once $fileroot . '/library/appointments.inc.php'` then
+ * `\fetchAppointments(...)`). The fixture lets a unit test:
+ *
+ *  - control what fetchAppointments returns by setting
+ *    $GLOBALS['__test_fetch_appointments_return'] (array of event rows)
+ *  - inspect what arguments fetchAppointments was called with via
+ *    $GLOBALS['__test_fetch_appointments_calls']
+ *  - catch any regression that calls fetchAllEvents instead — the stub
+ *    throws, which would surface as a test failure rather than a silent
+ *    "wrong calendar feed" the way it did in 1.2.0
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+if (!function_exists('fetchAppointments')) {
+    function fetchAppointments(
+        $from_date,
+        $to_date,
+        $patient_id = null,
+        $provider_id = null,
+        $facility_id = null,
+        $pc_appstatus = null,
+        $with_out_provider = null,
+        $with_out_facility = null,
+        $pc_catid = null,
+        $tracker_board = false,
+        $nextX = 0,
+        $group_id = null,
+        $patient_name = null
+    ) {
+        $GLOBALS['__test_fetch_appointments_calls'][] = [
+            'from_date' => $from_date,
+            'to_date' => $to_date,
+        ];
+        return $GLOBALS['__test_fetch_appointments_return'] ?? [];
+    }
+}
+
+if (!function_exists('fetchAllEvents')) {
+    function fetchAllEvents($from_date, $to_date, $provider_id = null, $facility_id = null)
+    {
+        // Regression guard. fetchAllEvents returns provider-availability
+        // blocks ("In Office" / "Out Of Office") with pc_pid empty — never
+        // patient appointments. CoreAppointmentFinder used this in 1.2.0
+        // and reminders silently stopped firing. Fail loudly if anyone
+        // wires it back up.
+        throw new \RuntimeException(
+            'CoreAppointmentFinder must call fetchAppointments(), not fetchAllEvents() — '
+            . 'fetchAllEvents returns provider-availability blocks, not patient appointments.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`CoreAppointmentFinder` was calling core's `fetchAllEvents()`, which returns provider-availability blocks ("In Office" / "Out Of Office" calendar events with `pc_pid` empty) — not patient appointments. It is called from exactly one place in core, `getAvailableSlots()`, where the result feeds open-slot calculation.

The recurrence-expansion fix shipped in #137 (1.2.0) wired this function expecting patient appointments and silently produced zero SMS sends on every tenant: the cron fired every five minutes, iterated availability blocks with no patient, and dropped them on the missing-`pc_pid` guard.

The fix is one line: swap to `fetchAppointments()`, which delegates to the same `fetchEvents()` recurrence-expander but adds `AND e.pc_pid != ''` to the WHERE clause. Confirmed by reading `library/appointments.inc.php::fetchEvents()` that the SELECT clause includes `p.phone_cell` and `p.hipaa_allowsms` via the `patient_data` JOIN, so the columns the finder consumes downstream are preserved.

## Why a regression test is in this PR

The test fixture defines two stub global functions: `fetchAppointments` (controllable via globals) and `fetchAllEvents` (throws). Any future change that re-wires the wrong function fails every test in the file instead of silently disabling reminders for every tenant. This is the test that should have existed alongside #137 — the unit tests there mocked `UpcomingAppointmentFinder` itself, so the production wiring went unexercised.

## Verification status

- Bug **reproduced** against canary-clinic.stg (1.2.0 deployed, image `deploy-oce-800-r28_build-main_b20260512151028`): two patients with weekday-recurring appointments produced zero expanded events for their pids in a 7-day window via `fetchAllEvents`, while the same call returned 35 availability blocks with no patient.
- Fix **verified by unit tests** (`CoreAppointmentFinderTest`, 6 tests / 17 assertions, 75% line coverage of `CoreAppointmentFinder`).
- Fix **not yet verified live** — pending re-deploy and observation of SMS dispatch on the next cron tick.

## Test plan

- [x] `task check` passes (PHPCS, PHPStan, Rector, composer-require-checker, CLI smoke)
- [x] New `CoreAppointmentFinderTest` passes
- [ ] Deploy to canary-clinic.stg and confirm SMS dispatch for the two recurring-appointment patients on the next cron tick

## Follow-up

The deeper gap that let this ship is the lack of an end-to-end integration test that creates a patient + recurring appointment via OpenEMR's actual save path and asserts the cron sends an SMS. The unit-level regression guard here closes the specific wrong-function variant; the integration harness would catch the next-shaped variant. Worth filing as a follow-up issue.
