### PR TITLE
test(reminders): add end-to-end integration harness for appointment reminder cron

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,11 +42,8 @@ jobs:
     - name: Wait for OpenEMR install to settle
       run: |
         for i in {1..60}; do
-          if docker compose exec -T openemr test -f /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php; then
-            grep -q "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php 2>/dev/null \
-              && break
-            docker compose exec -T openemr grep -q "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php \
-              && break
+          if docker compose exec -T openemr grep -q "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php; then
+            break
           fi
           sleep 5
         done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,12 +41,19 @@ jobs:
 
     - name: Wait for OpenEMR install to settle
       run: |
+        ready=false
         for i in {1..60}; do
           if docker compose exec -T openemr grep -qF "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php; then
+            ready=true
             break
           fi
           sleep 5
         done
+        if [ "$ready" != "true" ]; then
+          echo "::error::OpenEMR did not finish installing within 5 minutes"
+          docker compose logs openemr
+          exit 1
+        fi
 
     - name: Register and enable module
       run: task module:install-enable

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Wait for OpenEMR install to settle
       run: |
         for i in {1..60}; do
-          if docker compose exec -T openemr grep -q "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php; then
+          if docker compose exec -T openemr grep -qF "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php; then
             break
           fi
           sleep 5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,8 +34,15 @@ jobs:
     - name: Install OpenEMR source under tools/openemr
       run: composer install --working-dir=tools/openemr --no-progress --no-interaction --prefer-dist
 
+    - name: Install OpenEMR's own runtime dependencies
+      # The openemr/openemr:flex image bind-mounts tools/openemr/vendor/openemr/openemr
+      # over /var/www/.../openemr. Without this step the bind mount has no vendor/
+      # of its own, login.php fails on the require_once(autoload.php) and the
+      # health check never goes green.
+      run: composer install --working-dir=tools/openemr/vendor/openemr/openemr --no-dev --no-progress --no-interaction --prefer-dist
+
     - name: Bring up dev stack
-      run: docker compose up -d --wait
+      run: docker compose up -d --wait --wait-timeout 600
       env:
         COMPOSE_HTTP_TIMEOUT: '300'
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,62 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  integration:
+    name: End-to-end integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+        coverage: none
+
+    - name: Install Task
+      uses: arduino/setup-task@v2
+      with:
+        version: 3.x
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install module composer deps
+      run: composer install --no-progress --no-interaction --prefer-dist
+
+    - name: Install OpenEMR source under tools/openemr
+      run: composer install --working-dir=tools/openemr --no-progress --no-interaction --prefer-dist
+
+    - name: Bring up dev stack
+      run: docker compose up -d --wait
+      env:
+        COMPOSE_HTTP_TIMEOUT: '300'
+
+    - name: Wait for OpenEMR install to settle
+      run: |
+        for i in {1..60}; do
+          if docker compose exec -T openemr test -f /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php; then
+            grep -q "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php 2>/dev/null \
+              && break
+            docker compose exec -T openemr grep -q "config = 1" /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php \
+              && break
+          fi
+          sleep 5
+        done
+
+    - name: Register and enable module
+      run: task module:install-enable
+
+    - name: Run integration suite
+      run: task test:integration
+
+    - name: Dump openemr logs on failure
+      if: failure()
+      run: docker compose logs openemr

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ compose.override.yml
 
 # PHPUnit
 .phpunit.cache/
+.phpunit.integration.cache/
 htmlcov/
 coverage-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,9 @@ task dev:start
 # Run all code quality checks
 task check
 
+# Run end-to-end integration tests (requires dev stack + module enabled)
+task test:integration
+
 # Clean up module tables
 task module:cleanup
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -257,6 +257,12 @@ tasks:
     - composer phpunit-coverage
     - echo "✅ Coverage report generated in htmlcov/"
 
+  test:integration:
+    desc: Run end-to-end integration tests (boots real OpenEMR + DB inside container)
+    cmds:
+    - docker compose up -d --wait
+    - docker compose exec -T openemr php {{.MODULE_PATH}}/vendor/bin/phpunit -c {{.MODULE_PATH}}/phpunit.integration.xml
+
   # === Development Helpers ===
   # Composer dependency management tasks (infrastructure, not code quality)
 

--- a/docs/development/integration-tests.md
+++ b/docs/development/integration-tests.md
@@ -1,0 +1,55 @@
+# Integration Tests
+
+A separate suite from `tests/Unit`. Boots OpenEMR's real autoloader and runs against the live MariaDB inside the dev container. Catches the "wrong core function called" / "fixture diverges from production schema" class of bug that pure-PHP unit tests cannot — the class of bug that produced #137 and #143.
+
+## Layout
+
+```
+tests/Integration/
+├── bootstrap.php                       # Loads /var/www/.../openemr/interface/globals.php
+├── IntegrationTestCase.php             # Base TestCase: helpers + tearDown cleanup
+├── AppointmentReminderCronTest.php     # Scenarios for oce_sinch_run_appointment_reminders()
+├── Fakes/
+│   ├── RecordingMessageService.php     # Records sendToPatient() calls instead of dispatching
+│   └── RecordingBootstrap.php          # Bootstrap subclass that returns the recorder
+└── Fixtures/
+    ├── PatientFixtureManager.php       # Inserts/cleans patient_data rows
+    └── AppointmentFixtureManager.php   # Inserts/cleans openemr_postcalendar_events rows
+```
+
+## Running locally
+
+Two prerequisites:
+
+1. `task dev:start` — bring up the stack.
+2. `task module:install-enable` — register and enable the module so `oce_sinch_*` tables exist (one-time).
+
+Then:
+
+```sh
+task test:integration
+```
+
+That runs `phpunit -c phpunit.integration.xml` *inside the openemr container* — the host has no PHP/DB connectivity to the running install.
+
+## Fixture conventions
+
+Every fixture row is tagged with the prefix `oce-sinch-test-fixture` (in `patient_data.pubpid` and `openemr_postcalendar_events.pc_title`). `tearDown` deletes by prefix on OpenEMR-owned tables and by `patient_id IN (fixture pids)` on module-owned tables. Result: tests can run repeatedly against the dev DB without polluting it; a parallel run of upstream's own tests (whose prefix is `test-fixture`) cannot remove our fixtures or vice versa.
+
+If a test crashes mid-run, leftover rows survive — but the next run's `setUp` re-runs the same scrub before inserting fresh fixtures, so the impact is limited to one run's worth of warning noise.
+
+## Adding a scenario
+
+1. Subclass `IntegrationTestCase`.
+2. Use `$this->patients->insert([...])` and `$this->appointments->insertOneShot(...)` / `insertDailyRecurring(...)`.
+3. Call `$this->runReminders($now)` and assert against `$this->recorder()->getSends()` and the returned counters.
+
+Don't reach for raw SQL or `sqlInsert` for OpenEMR-owned tables — extend the relevant fixture manager instead so cleanup keeps working.
+
+## Why no `drid`, no transactional wrapping
+
+`drid` (drop + reinstall) is a sledgehammer that breaks any concurrent dev session and adds minutes per run. Transactional wrapping looks tempting but breaks against OpenEMR's MyISAM tables and any code path that issues an implicit commit (DDL, certain `SET` statements). Prefix-tagged cleanup is the upstream OpenEMR convention (`tools/openemr/.../tests/Tests/Fixtures/BaseFixtureManager.php`) — we follow it for the same reasons they do.
+
+## CI
+
+The `integration-tests` job in `.github/workflows/integration-tests.yml` brings up the dev stack on every PR and runs the suite on a single PHP version (the unit-test matrix continues to cover all supported versions).

--- a/docs/development/integration-tests.md
+++ b/docs/development/integration-tests.md
@@ -2,6 +2,8 @@
 
 A separate suite from `tests/Unit`. Boots OpenEMR's real autoloader and runs against the live MariaDB inside the dev container. Catches the "wrong core function called" / "fixture diverges from production schema" class of bug that pure-PHP unit tests cannot — the class of bug that produced #137 and #143.
 
+**Fixture strategy (important):** patient and appointment rows are inserted directly into `patient_data` and `openemr_postcalendar_events` via `QueryUtils`, *not* through `PatientService::insert()` or any other public OpenEMR service. The fixture managers shape the rows to match what the real OpenEMR form handlers write (including `pc_recurrtype` / `pc_recurrspec` for recurring events, which `AppointmentService::insert()` itself does not populate), so core's procedural appointments library — `fetchAllEvents` / `fetchAppointments` — expands and returns them the same way it would in production. The "real OpenEMR" part of this suite is the *read* side of the seam (the procedural fetch + the actual reminder pipeline + the actual Bootstrap container), not the write side.
+
 ## Layout
 
 ```

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+PHPUnit configuration for the integration test suite.
+
+Unlike phpunit.xml, this configuration loads OpenEMR's real autoloader and
+globals (see tests/Integration/bootstrap.php) and runs against a live
+MariaDB. It must be invoked from inside the openemr container:
+
+    docker compose exec -T openemr \
+        php interface/modules/custom_modules/oce-module-sinch-conversations/vendor/bin/phpunit \
+        -c interface/modules/custom_modules/oce-module-sinch-conversations/phpunit.integration.xml
+
+The `task test:integration` target wraps this. Coverage is intentionally
+disabled — coverage reporting stays on the unit suite (phpunit.xml).
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/Integration/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.integration.cache"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         stderr="true"
+         beStrictAboutOutputDuringTests="false">
+    <testsuites>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Integration/AppointmentReminderCronTest.php
+++ b/tests/Integration/AppointmentReminderCronTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * End-to-end integration tests for the appointment reminder cron.
+ *
+ * Each test creates real patient + appointment rows via the actual OpenEMR
+ * data paths, then invokes oce_sinch_run_appointment_reminders()'s service
+ * graph (with MessageService swapped for a recording fake) and asserts on
+ * the captured sends. The unit suite covers the pure-PHP logic; this suite
+ * covers the seam between the module and core OpenEMR's procedural
+ * appointments library — the seam where #137 and #143 lived.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Integration;
+
+final class AppointmentReminderCronTest extends IntegrationTestCase
+{
+    private const WINDOW_HOURS = 48;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reminder service short-circuits when SMS_NOTIFICATION_HOUR is 0.
+        // OEGlobalsBag::get() falls back to $GLOBALS when a key isn't in
+        // the bag, so writing to $GLOBALS is the lowest-friction way to
+        // set this for the test.
+        $GLOBALS['SMS_NOTIFICATION_HOUR'] = self::WINDOW_HOURS;
+        // The reminder template needs a clinic_name variable, and the
+        // module-enabled gate reads its own toggle from globals.
+        $GLOBALS['oce_sinch_conversations_enabled'] = '1';
+    }
+
+    /**
+     * Skip until #145 (CoreAppointmentFinder reads non-existent `pc_pid`)
+     * is fixed. The harness exercise behind this assertion works — running
+     * it against a worktree with the #145 one-character fix produces a
+     * passing assert. See #145 for the bug detail.
+     */
+    public function testOneOffAppointmentInWindowSendsOneReminder(): void
+    {
+        $this->markTestIncomplete('Blocked on #145 (pc_pid vs pid in CoreAppointmentFinder)');
+        $now = new \DateTimeImmutable('2026-06-01 09:00:00');
+        $appointmentTime = $now->modify('+12 hours');
+
+        $pid = $this->patients->insert([
+            'phone_cell' => '+15555551234',
+            'hipaa_allowsms' => 'YES',
+        ]);
+        $this->appointments->insertOneShot($pid, $appointmentTime);
+
+        $result = $this->runReminders($now);
+
+        self::assertSame(1, $result['sent'], json_encode($result));
+        self::assertCount(1, $this->recorder()->getSends());
+        self::assertSame($pid, $this->recorder()->getSends()[0]['patientId']);
+        self::assertSame('+15555551234', $this->recorder()->getSends()[0]['phone']);
+    }
+
+    /**
+     * Defends against #137 (recurring-expansion bug) AND exposes #143
+     * (CoreAppointmentFinder calling fetchAllEvents instead of
+     * fetchAppointments). Currently also blocked on #145; once both
+     * #143 and #145 land, this assertion runs.
+     */
+    public function testRecurringAppointmentExpandsToOneSendPerOccurrence(): void
+    {
+        $this->markTestIncomplete('Blocked on #143 (fetchAllEvents vs fetchAppointments) and #145 (pc_pid vs pid)');
+        $now = new \DateTimeImmutable('2026-06-01 09:00:00');
+        $seriesStart = $now->modify('+12 hours');           // tonight
+        $seriesEnd = $now->modify('+10 days');               // far future
+
+        $pid = $this->patients->insert([
+            'phone_cell' => '+15555552222',
+            'hipaa_allowsms' => 'YES',
+        ]);
+        $this->appointments->insertDailyRecurring($pid, $seriesStart, $seriesEnd);
+
+        $result = $this->runReminders($now);
+
+        // 48h window starting at $now contains:
+        //   - $now+12h (tonight)
+        //   - $now+36h (tomorrow night)
+        // $now+60h is outside.
+        self::assertSame(2, $result['sent'], json_encode($result));
+        $sends = $this->recorder()->getSends();
+        self::assertCount(2, $sends);
+        foreach ($sends as $send) {
+            self::assertSame($pid, $send['patientId']);
+            self::assertSame('+15555552222', $send['phone']);
+        }
+    }
+
+    /**
+     * This passes on main today only because EVERY appointment is dropped
+     * (#145), so an excluded one is indistinguishable from an included one.
+     * Once #145 lands the test becomes meaningful — until then it's a
+     * vacuous green and we mark it incomplete to be honest about that.
+     */
+    public function testCancelledAppointmentExcluded(): void
+    {
+        $this->markTestIncomplete('Blocked on #145; assertion is vacuous until the finder returns rows');
+        $now = new \DateTimeImmutable('2026-06-01 09:00:00');
+        $pid = $this->patients->insert([
+            'phone_cell' => '+15555553333',
+            'hipaa_allowsms' => 'YES',
+        ]);
+        // 'x' is the cancelled-status code (CoreAppointmentFinder filters it).
+        $this->appointments->insertOneShot($pid, $now->modify('+6 hours'), apptStatus: 'x');
+
+        $result = $this->runReminders($now);
+
+        self::assertSame(0, $result['sent']);
+        self::assertCount(0, $this->recorder()->getSends());
+    }
+
+    public function testHipaaAllowsmsNoSkipsSend(): void
+    {
+        $this->markTestIncomplete('Blocked on #145 (pc_pid vs pid in CoreAppointmentFinder)');
+        $now = new \DateTimeImmutable('2026-06-01 09:00:00');
+        $pid = $this->patients->insert([
+            'phone_cell' => '+15555554444',
+            'hipaa_allowsms' => 'NO',
+        ]);
+        $this->appointments->insertOneShot($pid, $now->modify('+6 hours'));
+
+        $result = $this->runReminders($now);
+
+        self::assertSame(0, $result['sent']);
+        self::assertSame(1, $result['skipped']);
+        self::assertCount(0, $this->recorder()->getSends());
+    }
+
+    public function testDedupAcrossRuns(): void
+    {
+        $this->markTestIncomplete('Blocked on #145 (pc_pid vs pid in CoreAppointmentFinder)');
+        $now = new \DateTimeImmutable('2026-06-01 09:00:00');
+        $pid = $this->patients->insert([
+            'phone_cell' => '+15555555555',
+            'hipaa_allowsms' => 'YES',
+        ]);
+        $this->appointments->insertOneShot($pid, $now->modify('+6 hours'));
+
+        $first = $this->runReminders($now);
+        $second = $this->runReminders($now);
+
+        self::assertSame(1, $first['sent']);
+        self::assertSame(0, $second['sent']);
+        self::assertCount(1, $this->recorder()->getSends(), 'Recorder should see exactly one send across both runs');
+    }
+}

--- a/tests/Integration/AppointmentReminderCronTest.php
+++ b/tests/Integration/AppointmentReminderCronTest.php
@@ -3,12 +3,16 @@
 /**
  * End-to-end integration tests for the appointment reminder cron.
  *
- * Each test creates real patient + appointment rows via the actual OpenEMR
- * data paths, then invokes oce_sinch_run_appointment_reminders()'s service
+ * Each test inserts patient + appointment rows via the prefix-tagged
+ * fixture managers (direct SQL into patient_data /
+ * openemr_postcalendar_events), then invokes the real reminder service
  * graph (with MessageService swapped for a recording fake) and asserts on
- * the captured sends. The unit suite covers the pure-PHP logic; this suite
- * covers the seam between the module and core OpenEMR's procedural
- * appointments library — the seam where #137 and #143 lived.
+ * the captured sends. The fixture rows are deliberately shaped to match
+ * what the OpenEMR UI / form handlers write, so core's procedural
+ * appointments library expands and returns them the same way it would in
+ * production. The unit suite covers the pure-PHP logic; this suite covers
+ * the seam between the module and that procedural library — the seam
+ * where #137 and #143 lived.
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com

--- a/tests/Integration/Fakes/RecordingBootstrap.php
+++ b/tests/Integration/Fakes/RecordingBootstrap.php
@@ -42,14 +42,19 @@ class RecordingBootstrap extends Bootstrap
     }
 
     /**
-     * GlobalConfig is private on Bootstrap. We need a handle to construct
-     * the RecordingMessageService with the same config the real one uses.
-     * Reflection here keeps the production class API untouched.
+     * GlobalConfig is private on Bootstrap. Read it via a closure rebound
+     * to Bootstrap's scope — works on every supported PHP version and
+     * keeps the production class API untouched. Reflection's
+     * setAccessible() became a no-op in PHP 8.1, but a bound closure is
+     * the more portable, intent-revealing approach.
      */
     private function getGlobalConfigForTesting(): \OpenCoreEMR\Modules\SinchConversations\GlobalConfig
     {
-        $ref = new \ReflectionClass(Bootstrap::class);
-        $prop = $ref->getProperty('globalsConfig');
-        return $prop->getValue($this);
+        $reader = \Closure::bind(
+            fn(): \OpenCoreEMR\Modules\SinchConversations\GlobalConfig => $this->globalsConfig,
+            $this,
+            Bootstrap::class
+        );
+        return $reader();
     }
 }

--- a/tests/Integration/Fakes/RecordingBootstrap.php
+++ b/tests/Integration/Fakes/RecordingBootstrap.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Bootstrap subclass that returns a RecordingMessageService.
+ *
+ * Production Bootstrap::getMessageService() is a public method called once
+ * by getAppointmentReminderService(). Overriding it here is the entire
+ * test seam — no production-side change required.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fakes;
+
+use OpenCoreEMR\Modules\SinchConversations\Bootstrap;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
+
+class RecordingBootstrap extends Bootstrap
+{
+    private ?RecordingMessageService $recorder = null;
+
+    public function getMessageService(): MessageService
+    {
+        return $this->recorder ??= new RecordingMessageService(
+            $this->getGlobalConfigForTesting(),
+            $this->getConversationApiClient()
+        );
+    }
+
+    public function getRecorder(): RecordingMessageService
+    {
+        // Trigger lazy construction so callers can read sends after run().
+        $this->getMessageService();
+        \assert($this->recorder !== null);
+        return $this->recorder;
+    }
+
+    /**
+     * GlobalConfig is private on Bootstrap. We need a handle to construct
+     * the RecordingMessageService with the same config the real one uses.
+     * Reflection here keeps the production class API untouched.
+     */
+    private function getGlobalConfigForTesting(): \OpenCoreEMR\Modules\SinchConversations\GlobalConfig
+    {
+        $ref = new \ReflectionClass(Bootstrap::class);
+        $prop = $ref->getProperty('globalsConfig');
+        return $prop->getValue($this);
+    }
+}

--- a/tests/Integration/Fakes/RecordingMessageService.php
+++ b/tests/Integration/Fakes/RecordingMessageService.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Test fake that captures sendToPatient() calls instead of dispatching them.
+ *
+ * Substituted into Bootstrap by RecordingBootstrap so the real
+ * AppointmentReminderService runs through its actual code paths but never
+ * touches Sinch or writes to oce_sinch_messages. Each captured send is a
+ * tuple of (patientId, phone, message, options).
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fakes;
+
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageOptions;
+use OpenCoreEMR\Modules\SinchConversations\Service\MessageService;
+
+class RecordingMessageService extends MessageService
+{
+    /**
+     * @var list<array{patientId: int, phone: string, message: string, options: ?MessageOptions}>
+     */
+    private array $sends = [];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function sendToPatient(
+        int $patientId,
+        string $phoneNumber,
+        string $message,
+        ?MessageOptions $options = null
+    ): array {
+        $this->sends[] = [
+            'patientId' => $patientId,
+            'phone' => $phoneNumber,
+            'message' => $message,
+            'options' => $options,
+        ];
+
+        return ['id' => 'fake_msg_' . count($this->sends)];
+    }
+
+    /**
+     * @return list<array{patientId: int, phone: string, message: string, options: ?MessageOptions}>
+     */
+    public function getSends(): array
+    {
+        return $this->sends;
+    }
+}

--- a/tests/Integration/Fixtures/AppointmentFixtureManager.php
+++ b/tests/Integration/Fixtures/AppointmentFixtureManager.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Manages test appointment rows in openemr_postcalendar_events.
+ *
+ * Mirrors the upstream BaseFixtureManager pattern (every fixture row gets a
+ * known prefix in pc_title; cleanup deletes by prefix). Two reasons we
+ * write our own rather than reuse upstream's helpers:
+ *
+ *   - Upstream ships no AppointmentFixtureManager in tests/Tests/Fixtures.
+ *   - OpenEMR's AppointmentService::insert() does not write pc_recurrtype /
+ *     pc_recurrspec — those columns are only populated by the procedural
+ *     interface/main/calendar/add_edit_event.php form handler. To create a
+ *     recurring appointment we mirror the column shape that handler writes.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+class AppointmentFixtureManager
+{
+    public const TITLE_PREFIX = 'oce-sinch-test-fixture';
+
+    /**
+     * Insert a one-shot appointment.
+     *
+     * @return int pc_eid
+     */
+    public function insertOneShot(
+        int $pid,
+        \DateTimeImmutable $when,
+        int $durationMinutes = 30,
+        string $apptStatus = '-'
+    ): int {
+        return $this->insertEvent(
+            pid: $pid,
+            when: $when,
+            durationMinutes: $durationMinutes,
+            apptStatus: $apptStatus,
+            recurrType: 0,
+            recurrSpec: null,
+            endDate: '0000-00-00'
+        );
+    }
+
+    /**
+     * Insert a daily-recurring appointment.
+     *
+     * Writes the same column shape that interface/main/calendar/add_edit_event.php
+     * writes on form submit for daily recurrence: pc_recurrtype = 1,
+     * pc_recurrspec = serialize(['event_repeat_freq' => '1',
+     * 'event_repeat_freq_type' => '4', 'event_repeat_on_num' => '1',
+     * 'event_repeat_on_day' => '0', 'event_repeat_on_freq' => '0',
+     * 'exdate' => '']) — frequency type 4 = daily.
+     *
+     * @return int pc_eid (one row covers the whole series; core's
+     *     fetchAppointments expands it into per-occurrence rows)
+     */
+    public function insertDailyRecurring(
+        int $pid,
+        \DateTimeImmutable $start,
+        \DateTimeImmutable $end,
+        int $durationMinutes = 30,
+        string $apptStatus = '-'
+    ): int {
+        $recurrSpec = [
+            'event_repeat_freq' => '1',
+            'event_repeat_freq_type' => '4',
+            'event_repeat_on_num' => '1',
+            'event_repeat_on_day' => '0',
+            'event_repeat_on_freq' => '0',
+            'exdate' => '',
+        ];
+
+        return $this->insertEvent(
+            pid: $pid,
+            when: $start,
+            durationMinutes: $durationMinutes,
+            apptStatus: $apptStatus,
+            recurrType: 1,
+            recurrSpec: $recurrSpec,
+            endDate: $end->format('Y-m-d')
+        );
+    }
+
+    public function removeFixtures(): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM openemr_postcalendar_events WHERE pc_title LIKE ?",
+            [self::TITLE_PREFIX . '%']
+        );
+    }
+
+    /**
+     * @param array<string, string>|null $recurrSpec
+     */
+    private function insertEvent(
+        int $pid,
+        \DateTimeImmutable $when,
+        int $durationMinutes,
+        string $apptStatus,
+        int $recurrType,
+        ?array $recurrSpec,
+        string $endDate
+    ): int {
+        $startTime = $when->format('H:i:s');
+        $endTime = $when->modify("+{$durationMinutes} minutes")->format('H:i:s');
+        $durationSeconds = $durationMinutes * 60;
+        $title = self::TITLE_PREFIX . '-' . bin2hex(random_bytes(4));
+
+        $sql = "INSERT INTO openemr_postcalendar_events SET
+            pc_pid = ?,
+            pc_catid = 9,
+            pc_title = ?,
+            pc_duration = ?,
+            pc_hometext = '',
+            pc_eventDate = ?,
+            pc_endDate = ?,
+            pc_apptstatus = ?,
+            pc_startTime = ?,
+            pc_endTime = ?,
+            pc_facility = 0,
+            pc_billing_location = 0,
+            pc_informant = 1,
+            pc_eventstatus = 1,
+            pc_sharing = 1,
+            pc_aid = 1,
+            pc_recurrtype = ?,
+            pc_recurrspec = ?";
+
+        QueryUtils::sqlStatementThrowException($sql, [
+            $pid,
+            $title,
+            $durationSeconds,
+            $when->format('Y-m-d'),
+            $endDate,
+            $apptStatus,
+            $startTime,
+            $endTime,
+            $recurrType,
+            $recurrSpec === null ? '' : serialize($recurrSpec),
+        ]);
+
+        $row = QueryUtils::querySingleRow(
+            "SELECT pc_eid FROM openemr_postcalendar_events WHERE pc_title = ?",
+            [$title]
+        );
+        if (!is_array($row) || !isset($row['pc_eid'])) {
+            throw new \RuntimeException("Failed to read back inserted appointment {$title}");
+        }
+        return (int) $row['pc_eid'];
+    }
+}

--- a/tests/Integration/Fixtures/PatientFixtureManager.php
+++ b/tests/Integration/Fixtures/PatientFixtureManager.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Manages test patient rows in patient_data.
+ *
+ * Same prefix-tagged-cleanup convention as upstream BaseFixtureManager
+ * (tools/openemr/.../tests/Tests/Fixtures/BaseFixtureManager.php), but
+ * scoped to our module's prefix so a parallel run of upstream's own tests
+ * cannot remove our fixtures or vice versa.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Uuid\UuidRegistry;
+
+class PatientFixtureManager
+{
+    public const PUBPID_PREFIX = 'oce-sinch-test-fixture';
+
+    /**
+     * Insert a patient and return its pid.
+     *
+     * @param array<string, string|null> $overrides Column overrides. The
+     *     fixture defaults are minimal but valid; tests typically override
+     *     phone_cell and hipaa_allowsms to drive specific scenarios.
+     */
+    public function insert(array $overrides = []): int
+    {
+        $pubpid = self::PUBPID_PREFIX . '-' . bin2hex(random_bytes(4));
+        $defaults = [
+            'pubpid' => $pubpid,
+            'fname' => self::PUBPID_PREFIX,
+            'lname' => 'Patient-' . bin2hex(random_bytes(2)),
+            'DOB' => '1980-01-01',
+            'sex' => 'Female',
+            'phone_cell' => '+15555550000',
+            'hipaa_allowsms' => 'YES',
+        ];
+        $values = array_merge($defaults, $overrides);
+
+        $nextPid = $this->getNextPid();
+        $uuid = (new UuidRegistry(['table_name' => 'patient_data']))->createUuid();
+
+        $columns = array_merge($values, ['pid' => $nextPid, 'uuid' => $uuid]);
+        $setClauses = [];
+        $binds = [];
+        foreach ($columns as $col => $val) {
+            $setClauses[] = "`{$col}` = ?";
+            $binds[] = $val;
+        }
+        $sql = "INSERT INTO patient_data SET " . implode(', ', $setClauses);
+        QueryUtils::sqlStatementThrowException($sql, $binds);
+
+        return $nextPid;
+    }
+
+    public function removeFixtures(): void
+    {
+        $rows = QueryUtils::fetchRecords(
+            "SELECT `uuid` FROM patient_data WHERE pubpid LIKE ?",
+            [self::PUBPID_PREFIX . '%']
+        );
+        foreach ($rows as $row) {
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM uuid_registry WHERE table_name = 'patient_data' AND `uuid` = ?",
+                [$row['uuid']]
+            );
+        }
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM patient_data WHERE pubpid LIKE ?",
+            [self::PUBPID_PREFIX . '%']
+        );
+    }
+
+    private function getNextPid(): int
+    {
+        $row = QueryUtils::querySingleRow("SELECT IFNULL(MAX(pid), 0) + 1 AS next_pid FROM patient_data");
+        return (int) ($row['next_pid'] ?? 1);
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Base TestCase for the integration suite.
+ *
+ * Provides helpers that drive real OpenEMR code paths (PatientService /
+ * AppointmentFixtureManager, the actual cron entry function) and a tearDown
+ * that scrubs both OpenEMR-owned fixture rows (by prefix) and module-owned
+ * rows (by tracked id). The result: tests can run repeatedly against the
+ * dev database without leaking state.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Integration;
+
+use OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fakes\RecordingBootstrap;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fakes\RecordingMessageService;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fixtures\AppointmentFixtureManager;
+use OpenCoreEMR\Modules\SinchConversations\Tests\Integration\Fixtures\PatientFixtureManager;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Core\Kernel;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    protected PatientFixtureManager $patients;
+    protected AppointmentFixtureManager $appointments;
+    private ?RecordingBootstrap $bootstrap = null;
+
+    protected function setUp(): void
+    {
+        $this->patients = new PatientFixtureManager();
+        $this->appointments = new AppointmentFixtureManager();
+
+        // Scrub leftover module-owned rows from any prior interrupted run
+        // so a previous failure doesn't pollute this one. We can't track ids
+        // for rows we didn't insert, so we delete by patient prefix join.
+        $this->purgeModuleRowsForFixturePatients();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->purgeModuleRowsForFixturePatients();
+        $this->appointments->removeFixtures();
+        $this->patients->removeFixtures();
+    }
+
+    /**
+     * Run the appointment reminder service with MessageService swapped for
+     * the recording fake. Returns the result array from the service.
+     *
+     * @return array{sent: int, skipped: int, failed: int, errors: list<string>}
+     */
+    protected function runReminders(\DateTimeImmutable $now): array
+    {
+        $bootstrap = $this->getBootstrap();
+        return $bootstrap->getAppointmentReminderService()->run($now);
+    }
+
+    protected function recorder(): RecordingMessageService
+    {
+        return $this->getBootstrap()->getRecorder();
+    }
+
+    private function getBootstrap(): RecordingBootstrap
+    {
+        if ($this->bootstrap === null) {
+            $kernel = ($GLOBALS['kernel'] ?? null) instanceof Kernel
+                ? $GLOBALS['kernel']
+                : new Kernel();
+            $this->bootstrap = new RecordingBootstrap(
+                new EventDispatcher(),
+                $kernel
+            );
+        }
+        return $this->bootstrap;
+    }
+
+    /**
+     * Delete oce_sinch_* rows that reference our fixture patients.
+     *
+     * Module tables are FK-free so order is just hygiene. We scope by
+     * patient_id IN (fixture pids) so rows from real dev data are
+     * untouched.
+     */
+    private function purgeModuleRowsForFixturePatients(): void
+    {
+        $pids = QueryUtils::fetchRecords(
+            "SELECT pid FROM patient_data WHERE pubpid LIKE ?",
+            [PatientFixtureManager::PUBPID_PREFIX . '%']
+        );
+        if ($pids === []) {
+            return;
+        }
+        $placeholders = implode(',', array_fill(0, count($pids), '?'));
+        $ids = array_map(static fn(array $r): int => (int) $r['pid'], $pids);
+
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM oce_sinch_appointment_reminders WHERE patient_id IN ({$placeholders})",
+            $ids
+        );
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM oce_sinch_messages WHERE conversation_id IN (
+                SELECT conversation_id FROM oce_sinch_conversations WHERE patient_id IN ({$placeholders})
+            )",
+            $ids
+        );
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM oce_sinch_conversations WHERE patient_id IN ({$placeholders})",
+            $ids
+        );
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM oce_sinch_contacts WHERE patient_id IN ({$placeholders})",
+            $ids
+        );
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM oce_sinch_patient_consent WHERE patient_id IN ({$placeholders})",
+            $ids
+        );
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -3,11 +3,13 @@
 /**
  * Base TestCase for the integration suite.
  *
- * Provides helpers that drive real OpenEMR code paths (PatientService /
- * AppointmentFixtureManager, the actual cron entry function) and a tearDown
- * that scrubs both OpenEMR-owned fixture rows (by prefix) and module-owned
- * rows (by tracked id). The result: tests can run repeatedly against the
- * dev database without leaking state.
+ * Inserts patient/appointment fixture rows directly into patient_data and
+ * openemr_postcalendar_events via QueryUtils (the upstream BaseFixtureManager
+ * pattern), then exercises the real reminder pipeline — including core
+ * OpenEMR's procedural fetchAllEvents/fetchAppointments — against those
+ * rows. Both setUp and tearDown scrub OpenEMR-owned fixture rows by prefix
+ * and module-owned rows by tracked patient id, so a previous interrupted
+ * run cannot pollute this one.
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
@@ -40,10 +42,13 @@ abstract class IntegrationTestCase extends TestCase
         $this->patients = new PatientFixtureManager();
         $this->appointments = new AppointmentFixtureManager();
 
-        // Scrub leftover module-owned rows from any prior interrupted run
-        // so a previous failure doesn't pollute this one. We can't track ids
-        // for rows we didn't insert, so we delete by patient prefix join.
+        // A prior run may have crashed mid-test, leaving fixture rows on
+        // disk. Scrub everything before inserting fresh fixtures so this
+        // run is deterministic. Order matters: module rows reference
+        // patient ids, so they must go before the patients themselves.
         $this->purgeModuleRowsForFixturePatients();
+        $this->appointments->removeFixtures();
+        $this->patients->removeFixtures();
     }
 
     protected function tearDown(): void

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Integration test bootstrap.
+ *
+ * Loads OpenEMR's real autoloader and globals so tests run against a live
+ * MariaDB and exercise actual procedural library code (appointments.inc.php,
+ * etc.). Must run inside the openemr container — the host has no DB
+ * connectivity to the running install.
+ *
+ * Deliberately does NOT load tests/bootstrap.php's mocks: integration tests
+ * need the real OpenEMR\... classes, not the test doubles the unit suite uses.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+// The module's own composer autoloader (PHPUnit, our test classes, etc.).
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$openemrRoot = '/var/www/localhost/htdocs/openemr';
+if (!is_dir($openemrRoot)) {
+    fwrite(STDERR, "Integration tests must run inside the openemr container.\n"
+        . "Expected OpenEMR at {$openemrRoot} but the directory is missing.\n"
+        . "Run via: task test:integration\n");
+    exit(1);
+}
+
+// OpenEMR's session-bootstrapped globals. interface/globals.php starts a
+// session and pulls in the kernel, autoloader, and $GLOBALS state the
+// reminder pipeline reads (fileroot, OEGlobalsBag, etc.).
+$_SERVER['HTTP_HOST'] ??= 'localhost';
+$_SERVER['REQUEST_URI'] ??= '/';
+$ignoreAuth = true;
+require_once $openemrRoot . '/interface/globals.php';
+
+// Pre-flight: the module must be enabled at least once so its tables exist.
+// We don't auto-enable — that's a one-time manual step (or the CI job's
+// `task module:install-enable`). Conflating "test setup" with "module
+// install" hides real failures.
+$tableCheck = sqlQuery(
+    "SELECT COUNT(*) AS c FROM information_schema.tables "
+    . "WHERE table_schema = DATABASE() AND table_name = 'oce_sinch_appointment_reminders'"
+);
+if ((int) ($tableCheck['c'] ?? 0) === 0) {
+    fwrite(STDERR, "Module table oce_sinch_appointment_reminders is missing.\n"
+        . "Enable the module first:\n"
+        . "    task module:install-enable\n");
+    exit(1);
+}

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -25,10 +25,11 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 $openemrRoot = '/var/www/localhost/htdocs/openemr';
 if (!is_dir($openemrRoot)) {
-    fwrite(STDERR, "Integration tests must run inside the openemr container.\n"
-        . "Expected OpenEMR at {$openemrRoot} but the directory is missing.\n"
-        . "Run via: task test:integration\n");
-    exit(1);
+    throw new RuntimeException(
+        "Integration tests must run inside the openemr container."
+        . " Expected OpenEMR at {$openemrRoot} but the directory is missing."
+        . " Run via: task test:integration"
+    );
 }
 
 // OpenEMR's session-bootstrapped globals. interface/globals.php starts a
@@ -48,8 +49,8 @@ $tableCheck = sqlQuery(
     . "WHERE table_schema = DATABASE() AND table_name = 'oce_sinch_appointment_reminders'"
 );
 if ((int) ($tableCheck['c'] ?? 0) === 0) {
-    fwrite(STDERR, "Module table oce_sinch_appointment_reminders is missing.\n"
-        . "Enable the module first:\n"
-        . "    task module:install-enable\n");
-    exit(1);
+    throw new RuntimeException(
+        "Module table oce_sinch_appointment_reminders is missing."
+        . " Enable the module first: task module:install-enable"
+    );
 }


### PR DESCRIPTION
## Summary

Adds a `tests/Integration/` suite that boots OpenEMR's real autoloader and runs against the live MariaDB inside the dev container — the test layer that the unit suite cannot replace, because the bugs in #137 and #143 lived precisely at the seam where the unit tests stubbed core OpenEMR.

Closes #144 (harness only — does **not** fix #143). On first run the harness also surfaced #145, a previously-unknown bug where `CoreAppointmentFinder` reads `pc_pid` but `fetchAllEvents`/`fetchAppointments` return rows keyed `pid`. All five scenarios are `markTestIncomplete` pending #143 and #145; the PRs that fix those bugs flip them to active assertions.

**No production code changes** — the test seam was already public on `Bootstrap` (override `getMessageService()` in a test subclass).

## Approach

- **Fixture strategy:** prefix-tagged cleanup, mirroring upstream's `BaseFixtureManager` convention (`oce-sinch-test-fixture` prefix on `patient_data.pubpid` and `openemr_postcalendar_events.pc_title`). Module-owned tables are scrubbed by `patient_id IN (fixture pids)`. No `drid`, no transactional wrapping, no full DB resets — the dev DB stays usable and a parallel `task dev:start` workflow keeps working.
- **Test seam:** `RecordingBootstrap` extends `Bootstrap` and overrides `getMessageService()` to return a `RecordingMessageService` that captures `sendToPatient()` calls instead of dispatching to Sinch.
- **`task test:integration`** invokes `phpunit -c phpunit.integration.xml` inside the openemr container.
- **CI:** new `.github/workflows/integration-tests.yml` brings up the dev stack on every PR (single PHP version; the unit-test matrix continues to cover all supported versions).

## Why some assertions are vacuous today

`testCancelledAppointmentExcluded` is the only scenario that would pass on `main` if active — but it would pass *vacuously*, because #145 drops every appointment regardless of status. Marking it incomplete is more honest than letting it look like a real signal.

## Test plan

- [ ] `task test:integration` reports 5 incomplete (referencing #143 and #145).
- [ ] `composer phpunit` still reports 547 unit tests passing (no regression).
- [ ] `composer phpcs` and `composer phpstan` clean.
- [ ] After #145 lands locally, `task test:integration` shows 4 of 5 scenarios passing and the recurring-appointment scenario failing (the #143 repro).
- [ ] After both #143 and #145 land, all five scenarios pass.

Refs: #137, #143, #145.