### PR TITLE
test(reminders): make integration scenarios fail until #143 and #145 are fixed

### DIFF
--- a/tests/Integration/AppointmentReminderCronTest.php
+++ b/tests/Integration/AppointmentReminderCronTest.php
@@ -14,6 +14,13 @@
  * the seam between the module and that procedural library — the seam
  * where #137 and #143 lived.
  *
+ * Until #143 (fetchAllEvents vs fetchAppointments) and #145 (pc_pid vs
+ * pid) are fixed, every scenario except the cancelled-appointment one
+ * fails: every event is dropped at the finder, so the reminder service
+ * never calls sendToPatient. That red CI status IS the harness's value —
+ * the reminder cron is broken in production today and the suite makes
+ * that visible until the bugs are fixed.
+ *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
  * @author    Michael A. Smith <michael@opencoreemr.com>
@@ -42,15 +49,8 @@ final class AppointmentReminderCronTest extends IntegrationTestCase
         $GLOBALS['oce_sinch_conversations_enabled'] = '1';
     }
 
-    /**
-     * Skip until #145 (CoreAppointmentFinder reads non-existent `pc_pid`)
-     * is fixed. The harness exercise behind this assertion works — running
-     * it against a worktree with the #145 one-character fix produces a
-     * passing assert. See #145 for the bug detail.
-     */
     public function testOneOffAppointmentInWindowSendsOneReminder(): void
     {
-        $this->markTestIncomplete('Blocked on #145 (pc_pid vs pid in CoreAppointmentFinder)');
         $now = new \DateTimeImmutable('2026-06-01 09:00:00');
         $appointmentTime = $now->modify('+12 hours');
 
@@ -69,14 +69,14 @@ final class AppointmentReminderCronTest extends IntegrationTestCase
     }
 
     /**
-     * Defends against #137 (recurring-expansion bug) AND exposes #143
+     * Defends against #137 (recurring-expansion bug) and exposes #143
      * (CoreAppointmentFinder calling fetchAllEvents instead of
-     * fetchAppointments). Currently also blocked on #145; once both
-     * #143 and #145 land, this assertion runs.
+     * fetchAppointments). With a 48h window and a daily-recurring
+     * appointment whose first occurrence is 12h after $now, exactly two
+     * future occurrences fall inside the window.
      */
     public function testRecurringAppointmentExpandsToOneSendPerOccurrence(): void
     {
-        $this->markTestIncomplete('Blocked on #143 (fetchAllEvents vs fetchAppointments) and #145 (pc_pid vs pid)');
         $now = new \DateTimeImmutable('2026-06-01 09:00:00');
         $seriesStart = $now->modify('+12 hours');           // tonight
         $seriesEnd = $now->modify('+10 days');               // far future
@@ -103,14 +103,14 @@ final class AppointmentReminderCronTest extends IntegrationTestCase
     }
 
     /**
-     * This passes on main today only because EVERY appointment is dropped
-     * (#145), so an excluded one is indistinguishable from an included one.
-     * Once #145 lands the test becomes meaningful — until then it's a
-     * vacuous green and we mark it incomplete to be honest about that.
+     * This passes vacuously while #145 drops every appointment. Once #145
+     * is fixed it becomes the real cancelled-status assertion, and the
+     * @depends ensures it only runs when the basic-send path also works
+     * (so a green here actually means "we excluded this one", not "we
+     * dropped everything").
      */
     public function testCancelledAppointmentExcluded(): void
     {
-        $this->markTestIncomplete('Blocked on #145; assertion is vacuous until the finder returns rows');
         $now = new \DateTimeImmutable('2026-06-01 09:00:00');
         $pid = $this->patients->insert([
             'phone_cell' => '+15555553333',
@@ -127,7 +127,6 @@ final class AppointmentReminderCronTest extends IntegrationTestCase
 
     public function testHipaaAllowsmsNoSkipsSend(): void
     {
-        $this->markTestIncomplete('Blocked on #145 (pc_pid vs pid in CoreAppointmentFinder)');
         $now = new \DateTimeImmutable('2026-06-01 09:00:00');
         $pid = $this->patients->insert([
             'phone_cell' => '+15555554444',
@@ -144,7 +143,6 @@ final class AppointmentReminderCronTest extends IntegrationTestCase
 
     public function testDedupAcrossRuns(): void
     {
-        $this->markTestIncomplete('Blocked on #145 (pc_pid vs pid in CoreAppointmentFinder)');
         $now = new \DateTimeImmutable('2026-06-01 09:00:00');
         $pid = $this->patients->insert([
             'phone_cell' => '+15555555555',

--- a/tests/Integration/AppointmentReminderCronTest.php
+++ b/tests/Integration/AppointmentReminderCronTest.php
@@ -32,6 +32,8 @@ declare(strict_types=1);
 
 namespace OpenCoreEMR\Modules\SinchConversations\Tests\Integration;
 
+use PHPUnit\Framework\Attributes\Depends;
+
 final class AppointmentReminderCronTest extends IntegrationTestCase
 {
     private const WINDOW_HOURS = 48;
@@ -103,12 +105,13 @@ final class AppointmentReminderCronTest extends IntegrationTestCase
     }
 
     /**
-     * This passes vacuously while #145 drops every appointment. Once #145
-     * is fixed it becomes the real cancelled-status assertion, and the
-     * @depends ensures it only runs when the basic-send path also works
-     * (so a green here actually means "we excluded this one", not "we
-     * dropped everything").
+     * Depends on the basic-send path so a green here actually means "we
+     * excluded the cancelled one", not "the finder returned nothing".
+     * While #145 drops every event the basic-send test fails, this test
+     * is skipped, and the suite reports "4 fail + 1 skip" instead of "4
+     * fail + 1 vacuous green".
      */
+    #[Depends('testOneOffAppointmentInWindowSendsOneReminder')]
     public function testCancelledAppointmentExcluded(): void
     {
         $now = new \DateTimeImmutable('2026-06-01 09:00:00');


### PR DESCRIPTION
## Summary

Follow-up to #146. That PR marked every reminder scenario `markTestIncomplete()` referencing #143 and #145, which produces a green CI signal — exactly the failure mode the harness was supposed to prevent (\"the next variant of #137/#143 should fail visibly\"). The bugs are real and shipped to production; the suite should make that visible until they're fixed, not paper over it.

This PR removes every `markTestIncomplete` line.

## Expected CI behaviour

After this lands on main, the integration job is **red on main** until #143 and #145 are fixed:

- `testOneOffAppointmentInWindowSendsOneReminder` — fails (sent: 0, expected 1) [blocked on #145]
- `testRecurringAppointmentExpandsToOneSendPerOccurrence` — fails (sent: 0, expected 2) [blocked on #143 + #145]
- `testCancelledAppointmentExcluded` — passes vacuously (#145 drops everything; cancelled vs not is indistinguishable until the finder returns rows)
- `testHipaaAllowsmsNoSkipsSend` — fails (skipped: 0, expected 1) [blocked on #145]
- `testDedupAcrossRuns` — fails (sent: 0 on first run, expected 1) [blocked on #145]

Once #145 lands: 4 of 5 pass (recurring still fails, exposing #143 cleanly).
Once #143 also lands: all 5 pass (cancelled-status assertion stops being vacuous).

## Why this isn't \"the harness fixing the bugs\"

It still doesn't. Per directive on #146, this PR makes no production changes — `CoreAppointmentFinder` is untouched. The fixes belong in their own PRs (one per bug). This PR only flips the test status from \"silently incomplete\" to \"loudly failing,\" which is what the harness was always supposed to do.

## Test plan

- [ ] `composer phpunit` reports 547 unit tests passing (no regression).
- [ ] `composer phpcs` and `composer phpstan` clean.
- [ ] `task test:integration` reports 4 failures + 1 pass (the vacuous one) on a stack with main.
- [ ] CI integration-tests job goes red on this PR (the proof that the suite is now load-bearing).

Refs #143, #145, #146.