### PR TITLE
fix(reminders): call fetchAppointments, not fetchAllEvents

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -47,7 +47,7 @@
     "attr",
     "text",
     "date",
-    "fetchAllEvents",
+    "fetchAppointments",
     "random_bytes"
   ],
   "php-core-extensions": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -48,7 +48,7 @@ parameters:
                 - src/Module/Console/Command/AbstractModuleCommand.php
 
         # OpenEMR global functions not available for static analysis
-        - '#Function (xl|xlt|xla|xlj|text|attr|fetchAllEvents) not found#'
+        - '#Function (xl|xlt|xla|xlj|text|attr|fetchAppointments) not found#'
 
         # Never-read properties are intentional (event handlers, etc.)
         - '#Property .+ is never read, only written#'

--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -368,7 +368,7 @@ class Bootstrap
     /**
      * Get Upcoming Appointment Finder
      *
-     * Production wraps core OpenEMR's recurrence-aware fetchAllEvents().
+     * Production wraps core OpenEMR's recurrence-aware fetchAppointments().
      */
     public function getUpcomingAppointmentFinder(): Service\UpcomingAppointmentFinder
     {

--- a/src/Module/Service/CoreAppointmentFinder.php
+++ b/src/Module/Service/CoreAppointmentFinder.php
@@ -3,10 +3,15 @@
 /**
  * Default UpcomingAppointmentFinder backed by core OpenEMR
  *
- * Wraps `library/appointments.inc.php::fetchAllEvents()`, which expands
- * `pc_recurrtype` / `pc_recurrspec` into per-occurrence rows. Production
+ * Wraps `library/appointments.inc.php::fetchAppointments()`, which
+ * expands `pc_recurrtype` / `pc_recurrspec` into per-occurrence rows and
+ * scopes results to patient appointments (`e.pc_pid != ''`). Production
  * uses this; unit tests inject a stub instead so they don't have to load
  * the procedural library or wire up the kernel event dispatcher.
+ *
+ * Why not fetchAllEvents: it returns provider availability blocks
+ * alongside patient appointments, so reminders fanned out to events with
+ * no patient attached. See #143.
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
@@ -43,13 +48,14 @@ class CoreAppointmentFinder implements UpcomingAppointmentFinder
         require_once $fileroot . '/library/appointments.inc.php';
 
         $windowEnd = $now->modify(sprintf('+%d hours', $windowHours));
-        // fetchAllEvents filters by date (Y-m-d) inclusive on both ends,
-        // so a window that crosses midnight already pulls in the trailing
-        // calendar day. We re-check the precise time bound in PHP below.
+        // fetchAppointments filters by date (Y-m-d) inclusive on both
+        // ends, so a window that crosses midnight already pulls in the
+        // trailing calendar day. We re-check the precise time bound in
+        // PHP below.
         $fromDate = $now->format('Y-m-d');
         $toDate = $windowEnd->format('Y-m-d');
 
-        $events = \fetchAllEvents($fromDate, $toDate);
+        $events = \fetchAppointments($fromDate, $toDate);
         if (!is_array($events)) {
             return [];
         }


### PR DESCRIPTION
## Summary

`CoreAppointmentFinder` wrapped core OpenEMR's `fetchAllEvents()`, which returns provider-availability blocks alongside patient appointments. The reminder service then either fanned out to events with no patient attached (silently dropped at the eligibility check) or — on tenants where category filtering happened to exclude the patient rows — produced zero reminders entirely. This is the bug field reports surfaced as "reminders silently went to zero on every tenant."

This PR swaps to `fetchAppointments()`, which scopes the underlying query to `e.pc_pid != ''` and applies the same recurring-event expansion the same way. Date-range semantics are unchanged, so the surrounding window logic stays put. Updated the phpstan ignore pattern and composer-require-checker symbol whitelist to the new function name.

Resolves #143.

## Important: this fix alone does NOT make the integration suite go green

The integration harness (#146 / #147) is still red on `main` because of #145 (`CoreAppointmentFinder` reads `$event['pc_pid']`, but `fetchAppointments` returns the patient column as `pid`, not `pc_pid`). Locally with this PR applied:

```
Tests: 5, Assertions: 5, Failures: 4, Skipped: 1.
```

— the same 4-fail/1-skip pattern as on main, with the failures still in the form `sent: 0`. The shape doesn't change because every event row reaching `CoreAppointmentFinder` still gets dropped at the `pc_pid` narrowing step. **Both #143 and #145 must land before any reminder actually gets sent.**

The integration suite will go green only after #145 also merges. That's expected and consistent with how the harness was designed: each fix removes one of the failure modes the suite exposes.

## Test plan

- [x] `composer phpunit` passes (547 unit tests, no regression).
- [x] `composer phpcs`, `composer phpstan`, `composer require-checker` clean.
- [x] `task test:integration` reports `Failures: 4, Skipped: 1` (same shape as `main`; failure mode unchanged because #145 still drops every row).
- [ ] CI integration job remains red until #145 also lands. That's expected.

Refs #145, #146, #147.