### PR TITLE
fix(reminders): read pid from fetchAppointments rows, not pc_pid

### DIFF
--- a/src/Module/Service/CoreAppointmentFinder.php
+++ b/src/Module/Service/CoreAppointmentFinder.php
@@ -74,7 +74,13 @@ class CoreAppointmentFinder implements UpcomingAppointmentFinder
             // columns as native ints when configured, but historically as
             // numeric strings — accept both for the integer columns,
             // reject anything else.
-            $pcPid = self::asPositiveInt($event['pc_pid'] ?? null);
+            //
+            // The patient id column is `pid` in the row returned by
+            // fetchAppointments — it comes from the `patient_data p` LEFT
+            // JOIN's SELECT (`p.pid`). The events table column is
+            // `e.pc_pid` but the SELECT list does not expose it, so reading
+            // `pc_pid` from the row drops every event silently. See #145.
+            $pcPid = self::asPositiveInt($event['pid'] ?? null);
             if ($pcPid === null) {
                 continue;
             }

--- a/tests/Integration/AppointmentReminderCronTest.php
+++ b/tests/Integration/AppointmentReminderCronTest.php
@@ -49,6 +49,10 @@ final class AppointmentReminderCronTest extends IntegrationTestCase
         // The reminder template needs a clinic_name variable, and the
         // module-enabled gate reads its own toggle from globals.
         $GLOBALS['oce_sinch_conversations_enabled'] = '1';
+        // GlobalConfig::getClinicName() reads this; without it the
+        // template's required-variable check fails. Locally a populated
+        // .env supplies it; CI never does, so set it explicitly.
+        $GLOBALS['oce_sinch_conversations_clinic_name'] = 'Integration Test Clinic';
     }
 
     public function testOneOffAppointmentInWindowSendsOneReminder(): void

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -49,6 +49,12 @@ abstract class IntegrationTestCase extends TestCase
         $this->purgeModuleRowsForFixturePatients();
         $this->appointments->removeFixtures();
         $this->patients->removeFixtures();
+
+        // The reminder template lives in oce_sinch_message_templates and
+        // is normally populated by TemplateSyncService against Sinch.
+        // Tests can't reach Sinch, so seed the no-portal variant directly.
+        // Idempotent (UNIQUE template_key + INSERT IGNORE).
+        $this->seedAppointmentReminderTemplate();
     }
 
     protected function tearDown(): void
@@ -130,5 +136,20 @@ abstract class IntegrationTestCase extends TestCase
             "DELETE FROM oce_sinch_patient_consent WHERE patient_id IN ({$placeholders})",
             $ids
         );
+    }
+
+    private function seedAppointmentReminderTemplate(): void
+    {
+        $sql = "INSERT IGNORE INTO oce_sinch_message_templates
+                    (template_key, template_name, category, communication_type,
+                     body, required_variables, compliance_confidence,
+                     sinch_approved, active)
+                VALUES (?, ?, 'appointments', 'individual', ?, ?, 100, TRUE, TRUE)";
+        QueryUtils::sqlStatementThrowException($sql, [
+            'appointment_reminder_no_portal',
+            'Appointment reminder (no portal)',
+            '{{ clinic_name }}: Reminder of your appointment {{ appt_time }}. {{ opt_out }}',
+            '["clinic_name","appt_time","opt_out"]',
+        ]);
     }
 }

--- a/tests/Unit/Service/CoreAppointmentFinderTest.php
+++ b/tests/Unit/Service/CoreAppointmentFinderTest.php
@@ -71,8 +71,8 @@ class CoreAppointmentFinderTest extends TestCase
     {
         $now = new \DateTimeImmutable('2026-05-13 09:00:00');
         $GLOBALS['__test_fetch_appointments_return'] = [
-            $this->event(pcEid: 65, pcPid: 5, date: '2026-05-13', time: '14:00:00', phone: '+15102551233', sms: 'YES'),
-            $this->event(pcEid: 70, pcPid: 14, date: '2026-05-13', time: '11:00:00', phone: '+14123704170', sms: 'YES'),
+            $this->event(pcEid: 65, patientId: 5, date: '2026-05-13', time: '14:00:00', phone: '+15102551233', sms: 'YES'),
+            $this->event(pcEid: 70, patientId: 14, date: '2026-05-13', time: '11:00:00', phone: '+14123704170', sms: 'YES'),
         ];
 
         $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
@@ -90,24 +90,26 @@ class CoreAppointmentFinderTest extends TestCase
      * Defence in depth against the 1.2.0 bug. If fetchAppointments ever
      * starts returning rows without a patient (a core change, a future
      * caller passing custom WHERE clauses, etc.), the finder's positive-int
-     * pc_pid guard must drop them rather than emit a malformed occurrence.
-     * The throwing fetchAllEvents fixture catches the wrong-function half
-     * of the original bug; this test catches the wrong-shape half.
+     * patient-id guard must drop them rather than emit a malformed
+     * occurrence. The throwing fetchAllEvents fixture catches the
+     * wrong-function half of the original bug; this test catches the
+     * wrong-shape half.
      */
     public function testRejectsRowsWithoutPatientId(): void
     {
         $now = new \DateTimeImmutable('2026-05-13 09:00:00');
         $GLOBALS['__test_fetch_appointments_return'] = [
             // Patient appointment — should appear.
-            $this->event(pcEid: 65, pcPid: 5, date: '2026-05-13', time: '14:00:00'),
+            $this->event(pcEid: 65, patientId: 5, date: '2026-05-13', time: '14:00:00'),
             // Availability-style row matching the OpenEMR mysqli return
-            // shape: pc_pid is the empty string, not null. The asPositiveInt
+            // shape: pid is the empty string, not null, when the
+            // patient_data LEFT JOIN finds no match. The asPositiveInt
             // guard must drop both shapes — the empty string slipping
             // through would mean fetchAppointments-shaped rows where the
             // patient JOIN didn't match are emitted as malformed
             // occurrences. Cover both to keep that exit closed.
-            $this->event(pcEid: 7, pcPid: '', date: '2026-05-13', time: '10:00:00'),
-            $this->event(pcEid: 8, pcPid: null, date: '2026-05-13', time: '10:30:00'),
+            $this->event(pcEid: 7, patientId: '', date: '2026-05-13', time: '10:00:00'),
+            $this->event(pcEid: 8, patientId: null, date: '2026-05-13', time: '10:30:00'),
         ];
 
         $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
@@ -121,11 +123,11 @@ class CoreAppointmentFinderTest extends TestCase
         $now = new \DateTimeImmutable('2026-05-13 09:00:00');
         $GLOBALS['__test_fetch_appointments_return'] = [
             // Already past at $now — drop.
-            $this->event(pcEid: 1, pcPid: 5, date: '2026-05-13', time: '08:00:00'),
+            $this->event(pcEid: 1, patientId: 5, date: '2026-05-13', time: '08:00:00'),
             // Inside window.
-            $this->event(pcEid: 2, pcPid: 5, date: '2026-05-13', time: '14:00:00'),
+            $this->event(pcEid: 2, patientId: 5, date: '2026-05-13', time: '14:00:00'),
             // Beyond +10h boundary (19:01 > 19:00).
-            $this->event(pcEid: 3, pcPid: 5, date: '2026-05-13', time: '19:01:00'),
+            $this->event(pcEid: 3, patientId: 5, date: '2026-05-13', time: '19:01:00'),
         ];
 
         $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
@@ -138,8 +140,8 @@ class CoreAppointmentFinderTest extends TestCase
     {
         $now = new \DateTimeImmutable('2026-05-13 09:00:00');
         $GLOBALS['__test_fetch_appointments_return'] = [
-            $this->event(pcEid: 1, pcPid: 5, date: '2026-05-13', time: '14:00:00', status: 'x'),
-            $this->event(pcEid: 2, pcPid: 5, date: '2026-05-13', time: '15:00:00', status: '-'),
+            $this->event(pcEid: 1, patientId: 5, date: '2026-05-13', time: '14:00:00', status: 'x'),
+            $this->event(pcEid: 2, patientId: 5, date: '2026-05-13', time: '15:00:00', status: '-'),
         ];
 
         $result = (new CoreAppointmentFinder())->findUpcoming(10, $now);
@@ -159,17 +161,18 @@ class CoreAppointmentFinderTest extends TestCase
     }
 
     /**
-     * @param int|string|null $pcPid Mirrors the production seam: the row
+     * @param int|string|null $patientId Mirrors the production seam: the row
      *     comes back from fetchAppointments via OpenEMR's mysqli driver,
      *     which historically returns numeric columns as numeric strings
      *     and produces an empty string when the patient_data LEFT JOIN
      *     finds no match. Tests pass each variant to exercise the
-     *     finder's asPositiveInt guard.
+     *     finder's asPositiveInt guard. The key is `pid` (from `p.pid`
+     *     in the SELECT) — not `pc_pid`. See #145.
      * @return array<string, mixed>
      */
     private function event(
         int $pcEid,
-        int|string|null $pcPid,
+        int|string|null $patientId,
         string $date,
         string $time,
         ?string $phone = null,
@@ -178,7 +181,7 @@ class CoreAppointmentFinderTest extends TestCase
     ): array {
         return [
             'pc_eid' => $pcEid,
-            'pc_pid' => $pcPid,
+            'pid' => $patientId,
             'pc_eventDate' => $date,
             'pc_startTime' => $time,
             'pc_apptstatus' => $status,


### PR DESCRIPTION
## Summary

`CoreAppointmentFinder` narrowed each row using `\$event['pc_pid']`, but core's `fetchEvents()` SELECT does not expose `e.pc_pid` — the patient id column in the row is `pid`, joined in from `patient_data p`. Reading `pc_pid` always returned null, `asPositiveInt(null)` returned null, and every event was dropped silently.

This is the second of the two bugs that produced "reminders silently went to zero on every tenant" (the first was #143, already merged). With both bugs fixed, the cron actually delivers reminders end-to-end.

Resolves #145.

## Changes

- **`src/Module/Service/CoreAppointmentFinder.php`** — read `\$event['pid']` instead of `\$event['pc_pid']`. The output shape returned by `findUpcoming()` still emits `pc_pid` because that's the contract on the `UpcomingAppointmentFinder` interface and what `AppointmentReminderService` consumes — unchanged on purpose. Added a code comment explaining the column-name distinction so the next reader doesn't fall into the same trap.
- **`tests/Unit/Service/CoreAppointmentFinderTest.php`** — the `event()` helper used `pc_pid` as the input key, mirroring the bug. Renamed the parameter from `pcPid` to `patientId` and changed the row key to `pid`. Updated the docblock to call out the column name.
- **`tests/Integration/IntegrationTestCase.php`** — added `seedAppointmentReminderTemplate()` to `setUp()`. The integration environment has no Sinch sync, so without seeding the `appointment_reminder_no_portal` row the suite would fail on "Template not found" even with the finder bug fixed. This is a test-environment shortcoming (the production sync path lives in `TemplateSyncService`), not a production bug.

## Test plan

- [x] `composer phpunit` — 553 tests, 1444 assertions, no failures (no regression on the unit suite, including the existing CoreAppointmentFinder unit tests added in #143 which now exercise the corrected fixture shape).
- [x] `composer phpcs`, `composer phpstan`, `composer require-checker` clean.
- [x] `task test:integration` against this PR locally:
      ```
      OK (5 tests, 18 assertions)
      ```
      All five reminder scenarios green for the first time. The integration job on `main` will go green when this lands.

Refs #143, #146, #147.