### PR TITLE
fix(api): route Sinch API calls to the configured region, not always US

### DIFF
--- a/src/Module/Command/StandaloneConfig.php
+++ b/src/Module/Command/StandaloneConfig.php
@@ -54,11 +54,10 @@ class StandaloneConfig extends GlobalConfig
         return $this->config['region'] ?? 'us';
     }
 
-    public function getApiBaseUrl(): string
+    public function getSinchApiBaseUrl(): string
     {
         $region = $this->getSinchRegion();
         return match ($region) {
-            'us' => 'https://us.conversation.api.sinch.com',
             'eu' => 'https://eu.conversation.api.sinch.com',
             default => 'https://us.conversation.api.sinch.com',
         };

--- a/src/Module/Command/StandaloneConfig.php
+++ b/src/Module/Command/StandaloneConfig.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace OpenCoreEMR\Modules\SinchConversations\Command;
 
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 
 /**
  * Configuration adapter for CLI usage without OpenEMR globals
@@ -49,17 +50,13 @@ class StandaloneConfig extends GlobalConfig
         return $this->config['api_secret'] ?? '';
     }
 
-    public function getSinchRegion(): string
+    public function getSinchRegion(): Region
     {
-        return $this->config['region'] ?? 'us';
+        return Region::tryFrom($this->config['region'] ?? '') ?? Region::Us;
     }
 
     public function getSinchApiBaseUrl(): string
     {
-        $region = $this->getSinchRegion();
-        return match ($region) {
-            'eu' => 'https://eu.conversation.api.sinch.com',
-            default => 'https://us.conversation.api.sinch.com',
-        };
+        return $this->getSinchRegion()->conversationApiBaseUrl();
     }
 }

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -166,11 +166,12 @@ class SettingsController
             }
 
             // $hasApiTuple → $secretForValidation !== '' here (the guard
-            // above returned when an API tuple lacked a secret). Region is
-            // already validated by ConfigService::validateSettings before
-            // we reach this point, so tryFrom never returns null when
-            // $apiFieldChanged && $hasApiTuple — but check anyway and skip
-            // the API call if the region is unrecognised.
+            // above returned when an API tuple lacked a secret). Region
+            // hasn't been validated yet — that happens in
+            // ConfigService::saveSettings() further down — so check
+            // tryFrom and skip the API call if the form posted an
+            // unrecognised value (saveSettings will then reject it with a
+            // user-facing error).
             $region = Region::tryFrom($settings['region']);
             try {
                 if ($apiFieldChanged && $hasApiTuple && $region !== null) {

--- a/src/Module/Controller/SettingsController.php
+++ b/src/Module/Controller/SettingsController.php
@@ -21,6 +21,7 @@ use OpenCoreEMR\Modules\SinchConversations\Service\ConfigService;
 use OpenCoreEMR\Modules\SinchConversations\Service\TemplateSyncService;
 use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
@@ -76,7 +77,7 @@ class SettingsController
             'project_id' => $this->config->getSinchProjectId(),
             'app_id' => $this->config->getSinchAppId(),
             'api_key' => $this->config->getSinchApiKey(),
-            'region' => $this->config->getSinchRegion(),
+            'region' => $this->config->getSinchRegion()->value,
             'default_channel' => $this->config->getDefaultChannel(),
             'clinic_name' => $this->config->getClinicName(),
             'clinic_phone' => $this->config->getClinicPhone(),
@@ -147,7 +148,7 @@ class SettingsController
                 || $settings['project_id'] !== $this->config->getSinchProjectId()
                 || $settings['app_id'] !== $this->config->getSinchAppId()
                 || $settings['api_key'] !== $this->config->getSinchApiKey()
-                || $settings['region'] !== $this->config->getSinchRegion();
+                || $settings['region'] !== $this->config->getSinchRegion()->value;
             $hasApiTuple = $settings['project_id'] !== ''
                 && $settings['app_id'] !== ''
                 && $settings['api_key'] !== '';
@@ -165,17 +166,20 @@ class SettingsController
             }
 
             // $hasApiTuple → $secretForValidation !== '' here (the guard
-            // above returned when an API tuple lacked a secret).
-            $hasFullApiConfig = $hasApiTuple
-                && in_array($settings['region'], ConversationApiClient::SUPPORTED_REGIONS, true);
+            // above returned when an API tuple lacked a secret). Region is
+            // already validated by ConfigService::validateSettings before
+            // we reach this point, so tryFrom never returns null when
+            // $apiFieldChanged && $hasApiTuple — but check anyway and skip
+            // the API call if the region is unrecognised.
+            $region = Region::tryFrom($settings['region']);
             try {
-                if ($apiFieldChanged && $hasFullApiConfig) {
+                if ($apiFieldChanged && $hasApiTuple && $region !== null) {
                     $this->apiClient->validateCredentials(
                         $settings['project_id'],
                         $settings['app_id'],
                         $settings['api_key'],
                         $secretForValidation,
-                        $settings['region'],
+                        $region,
                     );
                 }
             } catch (ValidationException | ApiException $e) {

--- a/src/Module/GlobalConfig.php
+++ b/src/Module/GlobalConfig.php
@@ -16,6 +16,7 @@ namespace OpenCoreEMR\Modules\SinchConversations;
 
 use OpenCoreEMR\ModuleConfig\ConfigAccessorInterface;
 use OpenCoreEMR\ModuleConfig\ConfigFactory;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use OpenEMR\Common\Crypto\CryptoGen;
 use Symfony\Component\HttpFoundation\IpUtils;
 
@@ -105,14 +106,11 @@ class GlobalConfig
         return $this->getApiSecret();
     }
 
-    public function getRegion(): string
+    public function getSinchRegion(): Region
     {
-        return $this->configAccessor->getString(self::CONFIG_OPTION_REGION, 'us');
-    }
-
-    public function getSinchRegion(): string
-    {
-        return $this->getRegion();
+        return Region::tryFrom(
+            $this->configAccessor->getString(self::CONFIG_OPTION_REGION, '')
+        ) ?? Region::Us;
     }
 
     public function getDefaultChannel(): string
@@ -174,11 +172,7 @@ class GlobalConfig
      */
     public function getSinchApiBaseUrl(): string
     {
-        $region = $this->getRegion();
-        return match ($region) {
-            'eu' => 'https://eu.conversation.api.sinch.com',
-            default => 'https://us.conversation.api.sinch.com',
-        };
+        return $this->getSinchRegion()->conversationApiBaseUrl();
     }
 
     /**

--- a/src/Module/GlobalConfig.php
+++ b/src/Module/GlobalConfig.php
@@ -166,13 +166,16 @@ class GlobalConfig
     }
 
     /**
-     * Get the base URL for the Sinch Conversations API
+     * Get the base URL for the Sinch Conversations API.
+     *
+     * Name matches `OpenCoreEMR\Sinch\Conversation\Config\ConfigInterface`
+     * so clients that depend on the interface and clients that depend on
+     * the concrete `GlobalConfig` use the same vocabulary.
      */
-    public function getApiBaseUrl(): string
+    public function getSinchApiBaseUrl(): string
     {
         $region = $this->getRegion();
         return match ($region) {
-            'us' => 'https://us.conversation.api.sinch.com',
             'eu' => 'https://eu.conversation.api.sinch.com',
             default => 'https://us.conversation.api.sinch.com',
         };

--- a/src/Module/Service/ConfigService.php
+++ b/src/Module/Service/ConfigService.php
@@ -17,7 +17,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Service;
 use OpenCoreEMR\ModuleConfig\ConfigService as LibConfigService;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
-use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Logging\SystemLogger;
 
@@ -121,10 +121,10 @@ class ConfigService
         // Validate region
         if (isset($settings['region'])) {
             $region = (string)$settings['region'];
-            if (!in_array($region, ConversationApiClient::SUPPORTED_REGIONS, true)) {
+            if (Region::tryFrom($region) === null) {
                 throw new ValidationException(sprintf(
                     "Region must be one of: %s",
-                    implode(', ', ConversationApiClient::SUPPORTED_REGIONS),
+                    implode(', ', array_map(static fn(Region $r): string => $r->value, Region::cases())),
                 ));
             }
         }

--- a/src/Sinch/Conversation/Client/AppConfigurationClient.php
+++ b/src/Sinch/Conversation/Client/AppConfigurationClient.php
@@ -26,7 +26,6 @@ use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 
 class AppConfigurationClient
 {
-    private const BASE_URL = 'https://us.conversation.api.sinch.com';
     private const CONSENT_MAX_PAGES = 100;
     private readonly Client $httpClient;
     private ?string $cachedAccessToken = null;
@@ -34,7 +33,7 @@ class AppConfigurationClient
     public function __construct(private readonly ConfigInterface $config)
     {
         $this->httpClient = new Client([
-            'base_uri' => self::BASE_URL,
+            'base_uri' => $config->getSinchApiBaseUrl(),
             'timeout' => 30,
             'http_errors' => false,
         ]);

--- a/src/Sinch/Conversation/Client/AppConfigurationClient.php
+++ b/src/Sinch/Conversation/Client/AppConfigurationClient.php
@@ -60,7 +60,7 @@ class AppConfigurationClient
         }
 
         $authClient = new Client([
-            'base_uri' => "https://{$region}.auth.sinch.com",
+            'base_uri' => $region->authBaseUrl(),
             'timeout' => 30,
             'http_errors' => false,
         ]);

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -26,7 +26,6 @@ use OpenEMR\Common\Logging\SystemLogger;
 
 class ConversationApiClient
 {
-    private const BASE_URL = 'https://us.conversation.api.sinch.com';
     private const CONSENT_MAX_PAGES = 100;
 
     /** @var list<string> Sinch Conversations regions this client can talk to */
@@ -40,7 +39,7 @@ class ConversationApiClient
         ?Client $httpClient = null
     ) {
         $this->httpClient = $httpClient ?? new Client([
-            'base_uri' => self::BASE_URL,
+            'base_uri' => $config->getSinchApiBaseUrl(),
             'timeout' => 30,
             'http_errors' => false,
         ]);
@@ -517,9 +516,12 @@ class ConversationApiClient
 
         $accessToken = $this->requestOAuth2Token($region, $apiKey, $apiSecret);
 
-        // Build the regional URL explicitly. The shared httpClient is bound
-        // to a hardcoded US base_uri, so a relative path would always hit
-        // us.conversation.api.sinch.com regardless of $region.
+        // Build the URL with the SUPPLIED region, not the constructor's
+        // base_uri. The shared httpClient is bound to the *currently
+        // saved* config's region, but credential validation may be
+        // testing a region the operator is about to switch to. An
+        // absolute URL overrides Guzzle's base_uri so we always hit the
+        // region the operator is actually validating.
         $url = "https://{$region}.conversation.api.sinch.com/v1/projects/{$projectId}/apps/{$appId}";
 
         try {

--- a/src/Sinch/Conversation/Client/ConversationApiClient.php
+++ b/src/Sinch/Conversation/Client/ConversationApiClient.php
@@ -20,6 +20,7 @@ use OpenCoreEMR\Modules\SinchConversations\Common\ArrayPath;
 use OpenCoreEMR\Modules\SinchConversations\Common\Json;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Logging\ExceptionContext;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -28,8 +29,6 @@ class ConversationApiClient
 {
     private const CONSENT_MAX_PAGES = 100;
 
-    /** @var list<string> Sinch Conversations regions this client can talk to */
-    public const SUPPORTED_REGIONS = ['us', 'eu'];
     private readonly Client $httpClient;
     private readonly SystemLogger $logger;
     private ?string $cachedAccessToken = null;
@@ -496,7 +495,7 @@ class ConversationApiClient
         string $appId,
         string $apiKey,
         string $apiSecret,
-        string $region,
+        Region $region,
     ): void {
         if ($projectId === '') {
             throw new ValidationException('Project ID is required');
@@ -510,19 +509,16 @@ class ConversationApiClient
         if ($apiSecret === '') {
             throw new ValidationException('API Secret is required');
         }
-        if ($region === '') {
-            throw new ValidationException('Region is required');
-        }
 
         $accessToken = $this->requestOAuth2Token($region, $apiKey, $apiSecret);
 
-        // Build the URL with the SUPPLIED region, not the constructor's
+        // Build the URL from the SUPPLIED region, not the constructor's
         // base_uri. The shared httpClient is bound to the *currently
         // saved* config's region, but credential validation may be
         // testing a region the operator is about to switch to. An
         // absolute URL overrides Guzzle's base_uri so we always hit the
         // region the operator is actually validating.
-        $url = "https://{$region}.conversation.api.sinch.com/v1/projects/{$projectId}/apps/{$appId}";
+        $url = $region->conversationApiBaseUrl() . "/v1/projects/{$projectId}/apps/{$appId}";
 
         try {
             $response = $this->httpClient->get(
@@ -544,25 +540,17 @@ class ConversationApiClient
         $this->handleResponse($response);
     }
 
-    private function requestOAuth2Token(string $region, string $keyId, string $keySecret): string
+    private function requestOAuth2Token(Region $region, string $keyId, string $keySecret): string
     {
         if (empty($keyId) || empty($keySecret)) {
             throw new ApiException("API Key ID and Secret are required for OAuth2 authentication");
-        }
-
-        if (!in_array($region, self::SUPPORTED_REGIONS, true)) {
-            throw new ApiException(sprintf(
-                "Unsupported Sinch region '%s'; supported regions are: %s",
-                $region,
-                implode(', ', self::SUPPORTED_REGIONS),
-            ));
         }
 
         try {
             $this->logger->debug("Requesting OAuth2 token from Sinch");
 
             $response = $this->httpClient->post(
-                "https://{$region}.auth.sinch.com/oauth2/token",
+                $region->authBaseUrl() . '/oauth2/token',
                 [
                     'form_params' => [
                         'grant_type' => 'client_credentials',
@@ -625,7 +613,7 @@ class ConversationApiClient
 
             $response = $this->executeWithRetry(
                 fn(): \Psr\Http\Message\ResponseInterface => $this->httpClient->post(
-                    "https://{$region}.template.api.sinch.com/v2/projects/{$projectId}/templates",
+                    $region->templateApiBaseUrl() . "/v2/projects/{$projectId}/templates",
                     [
                         'headers' => [
                             'Content-Type' => 'application/json',
@@ -657,7 +645,7 @@ class ConversationApiClient
 
         try {
             $response = $this->httpClient->get(
-                "https://{$region}.template.api.sinch.com/v2/projects/{$projectId}/templates",
+                $region->templateApiBaseUrl() . "/v2/projects/{$projectId}/templates",
                 [
                     'headers' => [
                         'Content-Type' => 'application/json',

--- a/src/Sinch/Conversation/Config/ConfigInterface.php
+++ b/src/Sinch/Conversation/Config/ConfigInterface.php
@@ -25,4 +25,13 @@ interface ConfigInterface
     public function getSinchApiSecret(): string;
 
     public function getSinchRegion(): string;
+
+    /**
+     * Resolve the Conversations API base URL for the configured region.
+     *
+     * Implementations MUST return the regional host (e.g.
+     * `https://eu.conversation.api.sinch.com` for `eu`); clients use this
+     * for every API call so EU customers don't silently hit the US host.
+     */
+    public function getSinchApiBaseUrl(): string;
 }

--- a/src/Sinch/Conversation/Config/ConfigInterface.php
+++ b/src/Sinch/Conversation/Config/ConfigInterface.php
@@ -24,14 +24,14 @@ interface ConfigInterface
 
     public function getSinchApiSecret(): string;
 
-    public function getSinchRegion(): string;
+    public function getSinchRegion(): Region;
 
     /**
      * Resolve the Conversations API base URL for the configured region.
      *
-     * Implementations MUST return the regional host (e.g.
-     * `https://eu.conversation.api.sinch.com` for `eu`); clients use this
-     * for every API call so EU customers don't silently hit the US host.
+     * Implementations MUST return `$this->getSinchRegion()->conversationApiBaseUrl()`;
+     * the indirection exists so callers that already have a config don't
+     * need a second `Region` injection.
      */
     public function getSinchApiBaseUrl(): string;
 }

--- a/src/Sinch/Conversation/Config/Region.php
+++ b/src/Sinch/Conversation/Config/Region.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Sinch Conversations API region.
+ *
+ * Backed enum because the value is persisted in OpenEMR globals and sent
+ * to Sinch as a URL component. Adding a new region (e.g. `Au`) means
+ * adding a case here and getting PHPStan failures from every match
+ * statement that doesn't yet handle it — which is the point.
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com/
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Sinch\Conversation\Config;
+
+enum Region: string
+{
+    case Us = 'us';
+    case Eu = 'eu';
+
+    /**
+     * Conversations API base URL for this region (no trailing slash).
+     */
+    public function conversationApiBaseUrl(): string
+    {
+        return match ($this) {
+            self::Us => 'https://us.conversation.api.sinch.com',
+            self::Eu => 'https://eu.conversation.api.sinch.com',
+        };
+    }
+
+    /**
+     * OAuth2 token endpoint base URL for this region (no trailing slash).
+     *
+     * Used when exchanging an API key/secret pair for a short-lived
+     * bearer token via Sinch's central auth service.
+     */
+    public function authBaseUrl(): string
+    {
+        return match ($this) {
+            self::Us => 'https://us.auth.sinch.com',
+            self::Eu => 'https://eu.auth.sinch.com',
+        };
+    }
+
+    /**
+     * Template Management API base URL for this region (no trailing slash).
+     *
+     * Distinct host from the Conversations API; used by the
+     * template-sync paths (createTemplate, listTemplates).
+     */
+    public function templateApiBaseUrl(): string
+    {
+        return match ($this) {
+            self::Us => 'https://us.template.api.sinch.com',
+            self::Eu => 'https://eu.template.api.sinch.com',
+        };
+    }
+}

--- a/src/Sinch/Conversation/Config/StandaloneConfig.php
+++ b/src/Sinch/Conversation/Config/StandaloneConfig.php
@@ -43,17 +43,13 @@ class StandaloneConfig implements ConfigInterface
         return $this->config['api_secret'] ?? '';
     }
 
-    public function getSinchRegion(): string
+    public function getSinchRegion(): Region
     {
-        return $this->config['region'] ?? 'us';
+        return Region::tryFrom($this->config['region'] ?? '') ?? Region::Us;
     }
 
     public function getSinchApiBaseUrl(): string
     {
-        $region = $this->getSinchRegion();
-        return match ($region) {
-            'eu' => 'https://eu.conversation.api.sinch.com',
-            default => 'https://us.conversation.api.sinch.com',
-        };
+        return $this->getSinchRegion()->conversationApiBaseUrl();
     }
 }

--- a/src/Sinch/Conversation/Config/StandaloneConfig.php
+++ b/src/Sinch/Conversation/Config/StandaloneConfig.php
@@ -47,4 +47,13 @@ class StandaloneConfig implements ConfigInterface
     {
         return $this->config['region'] ?? 'us';
     }
+
+    public function getSinchApiBaseUrl(): string
+    {
+        $region = $this->getSinchRegion();
+        return match ($region) {
+            'eu' => 'https://eu.conversation.api.sinch.com',
+            default => 'https://us.conversation.api.sinch.com',
+        };
+    }
 }

--- a/tests/Unit/Client/ConversationApiClientTest.php
+++ b/tests/Unit/Client/ConversationApiClientTest.php
@@ -21,6 +21,7 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -45,7 +46,7 @@ class ConversationApiClientTest extends TestCase
         $this->mockConfig->method('getSinchAppId')->willReturn(self::APP_ID);
         $this->mockConfig->method('getSinchApiKey')->willReturn(self::API_KEY);
         $this->mockConfig->method('getSinchApiSecret')->willReturn(self::API_SECRET);
-        $this->mockConfig->method('getSinchRegion')->willReturn('us');
+        $this->mockConfig->method('getSinchRegion')->willReturn(Region::Us);
 
         $this->requestHistory = [];
     }
@@ -240,7 +241,7 @@ class ConversationApiClientTest extends TestCase
         $mockConfig->method('getSinchProjectId')->willReturn('');
         $mockConfig->method('getSinchApiKey')->willReturn(self::API_KEY);
         $mockConfig->method('getSinchApiSecret')->willReturn(self::API_SECRET);
-        $mockConfig->method('getSinchRegion')->willReturn('us');
+        $mockConfig->method('getSinchRegion')->willReturn(Region::Us);
 
         $client = $this->createClientWithConfig($mockConfig, []);
 
@@ -258,7 +259,7 @@ class ConversationApiClientTest extends TestCase
             new Response(200, [], '{"id": "test-app", "display_name": "Test App"}'),
         ]);
 
-        $client->validateCredentials('proj-x', 'app-x', 'key-x', 'secret-x', 'us');
+        $client->validateCredentials('proj-x', 'app-x', 'key-x', 'secret-x', Region::Us);
 
         $this->assertCount(2, $this->requestHistory);
         $this->assertStringContainsString(
@@ -286,7 +287,7 @@ class ConversationApiClientTest extends TestCase
 
         $this->expectException(ApiException::class);
         $this->expectExceptionMessage('Bad credentials');
-        $client->validateCredentials('proj-x', 'app-x', 'bad-key', 'bad-secret', 'us');
+        $client->validateCredentials('proj-x', 'app-x', 'bad-key', 'bad-secret', Region::Us);
     }
 
     public function testValidateCredentialsThrowsOnAppLookupFailure(): void
@@ -300,7 +301,7 @@ class ConversationApiClientTest extends TestCase
 
         $this->expectException(ApiException::class);
         $this->expectExceptionMessage('App not found');
-        $client->validateCredentials('proj-x', 'missing-app', 'key-x', 'secret-x', 'us');
+        $client->validateCredentials('proj-x', 'missing-app', 'key-x', 'secret-x', Region::Us);
     }
 
     public function testValidateCredentialsThrowsOnEmptyProjectId(): void
@@ -309,7 +310,7 @@ class ConversationApiClientTest extends TestCase
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Project ID is required');
-        $client->validateCredentials('', 'app-x', 'key-x', 'secret-x', 'us');
+        $client->validateCredentials('', 'app-x', 'key-x', 'secret-x', Region::Us);
     }
 
     public function testValidateCredentialsThrowsOnEmptyAppId(): void
@@ -318,7 +319,7 @@ class ConversationApiClientTest extends TestCase
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('App ID is required');
-        $client->validateCredentials('proj-x', '', 'key-x', 'secret-x', 'us');
+        $client->validateCredentials('proj-x', '', 'key-x', 'secret-x', Region::Us);
     }
 
     public function testValidateCredentialsThrowsOnEmptySecret(): void
@@ -327,7 +328,7 @@ class ConversationApiClientTest extends TestCase
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('API Secret is required');
-        $client->validateCredentials('proj-x', 'app-x', 'key-x', '', 'us');
+        $client->validateCredentials('proj-x', 'app-x', 'key-x', '', Region::Us);
     }
 
     // --- handleResponse error tests ---
@@ -481,7 +482,7 @@ class ConversationApiClientTest extends TestCase
         $mockConfig = $this->createMock(GlobalConfig::class);
         $mockConfig->method('getSinchApiKey')->willReturn('');
         $mockConfig->method('getSinchApiSecret')->willReturn('');
-        $mockConfig->method('getSinchRegion')->willReturn('us');
+        $mockConfig->method('getSinchRegion')->willReturn(Region::Us);
 
         $client = $this->createClientWithConfig($mockConfig, [], false);
 

--- a/tests/Unit/Config/RegionTest.php
+++ b/tests/Unit/Config/RegionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Config;
+
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
+use PHPUnit\Framework\TestCase;
+
+class RegionTest extends TestCase
+{
+    public function testUsConversationApiBaseUrl(): void
+    {
+        $this->assertSame('https://us.conversation.api.sinch.com', Region::Us->conversationApiBaseUrl());
+    }
+
+    public function testEuConversationApiBaseUrl(): void
+    {
+        $this->assertSame('https://eu.conversation.api.sinch.com', Region::Eu->conversationApiBaseUrl());
+    }
+
+    public function testUsAuthBaseUrl(): void
+    {
+        $this->assertSame('https://us.auth.sinch.com', Region::Us->authBaseUrl());
+    }
+
+    public function testEuAuthBaseUrl(): void
+    {
+        $this->assertSame('https://eu.auth.sinch.com', Region::Eu->authBaseUrl());
+    }
+
+    public function testUsTemplateApiBaseUrl(): void
+    {
+        $this->assertSame('https://us.template.api.sinch.com', Region::Us->templateApiBaseUrl());
+    }
+
+    public function testEuTemplateApiBaseUrl(): void
+    {
+        $this->assertSame('https://eu.template.api.sinch.com', Region::Eu->templateApiBaseUrl());
+    }
+
+    public function testCases(): void
+    {
+        // Ensure both supported regions are present and no extras have crept in
+        // — exhaustive `match` on Region in production code depends on this.
+        $this->assertSame([Region::Us, Region::Eu], Region::cases());
+    }
+}

--- a/tests/Unit/Config/StandaloneConfigTest.php
+++ b/tests/Unit/Config/StandaloneConfigTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit\Config;
+
+use OpenCoreEMR\Sinch\Conversation\Config\StandaloneConfig;
+use PHPUnit\Framework\TestCase;
+
+class StandaloneConfigTest extends TestCase
+{
+    public function testGetSinchApiBaseUrlDefaultsToUs(): void
+    {
+        $config = new StandaloneConfig([]);
+
+        $this->assertSame('https://us.conversation.api.sinch.com', $config->getSinchApiBaseUrl());
+    }
+
+    public function testGetSinchApiBaseUrlReturnsEuHostForEuRegion(): void
+    {
+        $config = new StandaloneConfig(['region' => 'eu']);
+
+        $this->assertSame('https://eu.conversation.api.sinch.com', $config->getSinchApiBaseUrl());
+    }
+
+    public function testGetSinchApiBaseUrlFallsBackToUsForUnknownRegion(): void
+    {
+        $config = new StandaloneConfig(['region' => 'asia']);
+
+        $this->assertSame('https://us.conversation.api.sinch.com', $config->getSinchApiBaseUrl());
+    }
+}

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -22,6 +22,7 @@ use OpenCoreEMR\Modules\SinchConversations\SessionAccessor;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
 use OpenCoreEMR\Sinch\Conversation\Client\ConversationApiClient;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use OpenCoreEMR\Sinch\Conversation\Exception\AccessDeniedException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ApiException;
 use OpenCoreEMR\Sinch\Conversation\Exception\ValidationException;
@@ -172,7 +173,7 @@ class SettingsControllerTest extends TestCase
 
         $this->apiClient->expects($this->once())
             ->method('validateCredentials')
-            ->with('new-proj', 'new-app', 'new-key', 'new-secret', 'eu');
+            ->with('new-proj', 'new-app', 'new-key', 'new-secret', Region::Eu);
         $this->configService->expects($this->once())->method('saveSettings');
         $this->session->expects($this->once())
             ->method('setFlash')
@@ -291,7 +292,7 @@ class SettingsControllerTest extends TestCase
         // (decoded value of base64('secret-1') from setUp).
         $this->apiClient->expects($this->once())
             ->method('validateCredentials')
-            ->with('proj-1', 'app-1', 'rotated-key', $this->anything(), 'us');
+            ->with('proj-1', 'app-1', 'rotated-key', $this->anything(), Region::Us);
         $this->configService->expects($this->once())->method('saveSettings');
 
         $this->controller->dispatch('save');

--- a/tests/Unit/GlobalConfigTest.php
+++ b/tests/Unit/GlobalConfigTest.php
@@ -182,12 +182,12 @@ class GlobalConfigTest extends TestCase
         $this->assertEquals('https://example.com/portal', $config->getPortalUrl());
     }
 
-    public function testGetApiBaseUrlUs(): void
+    public function testGetSinchApiBaseUrlUs(): void
     {
         $this->assertEquals('https://us.conversation.api.sinch.com', $this->config->getSinchApiBaseUrl());
     }
 
-    public function testGetApiBaseUrlEu(): void
+    public function testGetSinchApiBaseUrlEu(): void
     {
         $mockGlobals = new MockGlobalsAccessor([
             GlobalConfig::CONFIG_OPTION_REGION => 'eu',
@@ -197,7 +197,7 @@ class GlobalConfigTest extends TestCase
         $this->assertEquals('https://eu.conversation.api.sinch.com', $config->getSinchApiBaseUrl());
     }
 
-    public function testGetApiBaseUrlUnknownRegion(): void
+    public function testGetSinchApiBaseUrlUnknownRegion(): void
     {
         $mockGlobals = new MockGlobalsAccessor([
             GlobalConfig::CONFIG_OPTION_REGION => 'unknown',

--- a/tests/Unit/GlobalConfigTest.php
+++ b/tests/Unit/GlobalConfigTest.php
@@ -17,6 +17,7 @@ namespace OpenCoreEMR\Modules\SinchConversations\Tests\Unit;
 use OpenCoreEMR\Modules\SinchConversations\GlobalConfig;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockConfigFactory;
 use OpenCoreEMR\Modules\SinchConversations\Tests\Mocks\MockGlobalsAccessor;
+use OpenCoreEMR\Sinch\Conversation\Config\Region;
 use PHPUnit\Framework\TestCase;
 
 class GlobalConfigTest extends TestCase
@@ -104,22 +105,37 @@ class GlobalConfigTest extends TestCase
         $this->assertEquals('test-api-secret', $this->config->getSinchApiSecret());
     }
 
-    public function testGetRegion(): void
+    public function testGetSinchRegionFromConfig(): void
     {
-        $this->assertEquals('us', $this->config->getRegion());
+        $this->assertSame(Region::Us, $this->config->getSinchRegion());
     }
 
-    public function testGetRegionDefault(): void
+    public function testGetSinchRegionDefaultsToUsWhenUnset(): void
     {
         $mockGlobals = new MockGlobalsAccessor([]);
         $config = new GlobalConfig($mockGlobals, new MockConfigFactory());
 
-        $this->assertEquals('us', $config->getRegion());
+        $this->assertSame(Region::Us, $config->getSinchRegion());
     }
 
-    public function testGetSinchRegion(): void
+    public function testGetSinchRegionDefaultsToUsForUnknownString(): void
     {
-        $this->assertEquals('us', $this->config->getSinchRegion());
+        $mockGlobals = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_REGION => 'asia',
+        ]);
+        $config = new GlobalConfig($mockGlobals, new MockConfigFactory());
+
+        $this->assertSame(Region::Us, $config->getSinchRegion());
+    }
+
+    public function testGetSinchRegionEu(): void
+    {
+        $mockGlobals = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_REGION => 'eu',
+        ]);
+        $config = new GlobalConfig($mockGlobals, new MockConfigFactory());
+
+        $this->assertSame(Region::Eu, $config->getSinchRegion());
     }
 
     public function testGetDefaultChannel(): void

--- a/tests/Unit/GlobalConfigTest.php
+++ b/tests/Unit/GlobalConfigTest.php
@@ -168,7 +168,7 @@ class GlobalConfigTest extends TestCase
 
     public function testGetApiBaseUrlUs(): void
     {
-        $this->assertEquals('https://us.conversation.api.sinch.com', $this->config->getApiBaseUrl());
+        $this->assertEquals('https://us.conversation.api.sinch.com', $this->config->getSinchApiBaseUrl());
     }
 
     public function testGetApiBaseUrlEu(): void
@@ -178,7 +178,7 @@ class GlobalConfigTest extends TestCase
         ]);
         $config = new GlobalConfig($mockGlobals, new MockConfigFactory());
 
-        $this->assertEquals('https://eu.conversation.api.sinch.com', $config->getApiBaseUrl());
+        $this->assertEquals('https://eu.conversation.api.sinch.com', $config->getSinchApiBaseUrl());
     }
 
     public function testGetApiBaseUrlUnknownRegion(): void
@@ -189,7 +189,7 @@ class GlobalConfigTest extends TestCase
         $config = new GlobalConfig($mockGlobals, new MockConfigFactory());
 
         // Should default to US
-        $this->assertEquals('https://us.conversation.api.sinch.com', $config->getApiBaseUrl());
+        $this->assertEquals('https://us.conversation.api.sinch.com', $config->getSinchApiBaseUrl());
     }
 
     // --- Webhook config tests ---


### PR DESCRIPTION
## Summary

Two commits:

1. **fix(api): route Sinch API calls to the configured region** (85a42b4) — `ConversationApiClient` and `AppConfigurationClient` both hardcoded their Guzzle `base_uri` to `https://us.conversation.api.sinch.com`. Every relative-path API call hit the US host regardless of the configured region; EU customers' messages were either rejected or routed through the wrong infrastructure. The fix is a one-line swap per client (use the existing `getSinchBaseUrl` helper).
2. **refactor(api): introduce `Region` enum** (b632332) — the existing string-typed region (`'us' | 'eu'`) and `ConversationApiClient::SUPPORTED_REGIONS = [...]` constant array were exact textbook violations of [`reference/php-conventions.md` §380 *Enums Over Constants*](https://github.com/openCoreEMR/ocemr-docs) and §541 *Exhaustive Matching*. Replaced with a backed `Region` enum (cases `Us`, `Eu`) that owns the regional URL helpers (`conversationApiBaseUrl()`, `authBaseUrl()`, `templateApiBaseUrl()`) — each an exhaustive `match ($this) { ... }` with no `default`. Adding a new region (e.g. `Au`) means adding a case here and getting PHPStan failures from every match that doesn't yet handle it. Ripple updates: `ConfigInterface::getSinchRegion(): Region`, `ConversationApiClient::validateCredentials(..., Region $region)`, `SettingsController` parses the form value via `Region::tryFrom()`, `ConfigService::validateSettings()` lists allowed regions from `Region::cases()`. `SUPPORTED_REGIONS`, the inline `'Region is required'` validation, and the inline `'Unsupported region'` validation in `requestOAuth2Token` are all gone — the type system enforces them.

Resolves #136.

## Notes

- The inline regional URL in `ConversationApiClient::validateCredentials()` stays. An absolute URL overrides Guzzle's `base_uri`, so it's harmless — but the *reason* it's there changes. It's no longer a workaround for a hardcoded host; it's there because credential validation may be testing a region the operator is about to switch to (which differs from the currently-saved region the client was constructed with).
- `src/Module/Command/StandaloneConfig::getApiBaseUrl()` renamed to `getSinchApiBaseUrl()` to match the parent's new name.

## Test plan

- [x] `composer phpunit` — 564 tests, 1455 assertions (+11 from main: 7 RegionTest, 3 StandaloneConfigTest, +1 GlobalConfigTest for the unknown-string fallback path).
- [x] `composer phpcs`, `composer phpstan` (level max), `composer require-checker` clean.
- [x] No production callers of `getApiBaseUrl()` remain (`grep -rn getApiBaseUrl src tests` is empty).
- [x] No `SUPPORTED_REGIONS` references remain.