### PR TITLE
ci: publish HTML coverage report to gh-pages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,3 +13,12 @@ jobs:
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-tests.yml@0.0.4
     with:
       coverage-php-version: '8.2'
+
+  publish-coverage:
+    needs: test
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: openCoreEMR/github-workflows-internal/.github/workflows/publish-coverage.yml@main
+    with:
+      artifact-name: coverage-report


### PR DESCRIPTION
## Summary

Adds a `publish-coverage` job that consumes the HTML coverage report already produced by the `php-tests` reusable workflow and publishes it to this repo's `gh-pages` branch via the new `publish-coverage.yml` reusable workflow in `openCoreEMR/github-workflows-internal`. PR runs get a sticky comment linking to the rendered report.

This is the first consumer of the new workflow; pinned to `@main` while the pattern is being validated. Once the pattern stabilizes (and `github-workflows-internal` cuts a release), switch the pin to a tag.

## Test plan

- [ ] CI runs `test` matrix as before
- [ ] `publish-coverage` job downloads the `coverage-report` artifact and pushes to `gh-pages`
- [ ] Sticky comment appears on this PR with working URLs:
  - `https://opencoreemr.github.io/oce-module-sinch-conversations/pr/<this-PR>/`
  - `https://opencoreemr.github.io/oce-module-sinch-conversations/sha/<short-sha>/`
- [ ] After merge, `branch/main/` is published