### PR TITLE
ci: drop pull_request.paths for required-check safety

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - composer.json
-    - .github/workflows/composer-normalize.yml
 
 jobs:
   composer-normalize:

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -13,12 +13,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - composer.json
-    - composer.lock
-    - '**.php'
-    - .composer-require-checker.json
-    - .github/workflows/composer-require-checker.yml
 
 jobs:
   composer-require-checker:

--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - composer.json
-    - .github/workflows/composer-validate.yml
 
 jobs:
   composer-validate:

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -11,10 +11,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - '**.php'
-    - composer.json
-    - .github/workflows/php-syntax-check.yml
 
 jobs:
   php-syntax-check:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -14,13 +14,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - '**.php'
-    - .phpcs.xml*
-    - phpcs.xml*
-    - composer.json
-    - composer.lock
-    - .github/workflows/phpcs.yml
 
 jobs:
   phpcs:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,16 +17,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - '**.php'
-    - phpstan.neon
-    - phpstan.neon.dist
-    - phpstan-baseline.neon
-    - composer.json
-    - composer.lock
-    - tools/openemr/composer.json
-    - tools/openemr/composer.lock
-    - .github/workflows/phpstan.yml
 
 jobs:
   phpstan:

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -13,12 +13,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - '**.php'
-    - rector.php
-    - composer.json
-    - composer.lock
-    - .github/workflows/rector.yml
 
 jobs:
   rector:


### PR DESCRIPTION
## Summary

Strip \`pull_request.paths\` from all PR-time workflows so each one always reports a check on every PR.

GitHub never creates a check run when \`on.pull_request.paths\` excludes a PR, so any of these checks promoted to a required check would stall auto-merge. \`push.paths\` is unchanged — post-merge runs on main remain scoped.

See ocemr-docs reference/github-actions.md "Required Checks and \`paths:\` Filters" (openCoreEMR/ocemr-docs#83) for the full rationale.

Part of openCoreEMR/toolbox#24.