### PR TITLE
ci(release-please): pin reusable @1.0.0 and use `secrets: inherit`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,8 @@ permissions: {}
 
 jobs:
   release-please:
-    uses: opencoreemr/github-workflows-public/.github/workflows/release-please-reusable.yml@0.0.6
+    uses: opencoreemr/github-workflows-public/.github/workflows/release-please-reusable.yml@1.0.0
     permissions:
       contents: write
       pull-requests: write
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Bump the `release-please-reusable.yml` pin to `@1.0.0`.
- Replace the explicit `app-client-id` / `app-private-key` block (or add a missing `secrets:` block) with `secrets: inherit`.

## Why

1.0.0 of [github-workflows-public](https://github.com/openCoreEMR/github-workflows-public/pull/16) reads the App credentials from the org-level `RELEASE_PLEASE_CLIENT_ID` variable and `RELEASE_PLEASE_PRIVATE_KEY` secret automatically. With this change, release-please PRs are opened by the `oce-release-please` App identity, which triggers downstream `pull_request` workflows. PRs opened by the default `GITHUB_TOKEN` are suppressed by GitHub's anti-recursion rule, which is why release PRs on repos with required checks have been unmergeable.

Verified end-to-end against `openCoreEMR/release-please-test` before tagging 1.0.0 — see openCoreEMR/github-workflows-public#16 for the run.

## Test plan

- [ ] Merge
- [ ] Wait for the next release-please run; confirm the resulting release PR is authored by `oce-release-please[bot]` (not `github-actions[bot]`) and that downstream checks run on it
