### PR TITLE
fix: drop redundant !$testSend condition in ConsentCheckCommand

### DIFF
--- a/src/Module/Command/ConsentCheckCommand.php
+++ b/src/Module/Command/ConsentCheckCommand.php
@@ -103,7 +103,7 @@ class ConsentCheckCommand extends Command
         // Check 3: Send to Opted-Out Number (Refutation Condition 5)
         if (is_string($phone) && $phone !== '' && $testSend) {
             $results[] = $this->checkSendToOptedOut($io, $output, $apiClient, $phone);
-        } elseif (is_string($phone) && $phone !== '' && !$testSend) {
+        } elseif (is_string($phone) && $phone !== '') {
             $results[] = [
                 'check' => 'Send to Opted-Out',
                 'condition' => 'RC-5: Platform blocks opted-out sends',


### PR DESCRIPTION
## Summary

PHPStan 2.2's `booleanNot.alwaysTrue` rule flags `!$testSend` on the `elseif` at `src/Module/Command/ConsentCheckCommand.php:106` as always-true. The preceding `if (is_string($phone) && $phone !== '' && $testSend)` already handles the truthy `$testSend` case, so by the `elseif` branch `$testSend` is necessarily falsy and `&& !$testSend` is redundant. Simplified to the phone check alone.

## Why

This is a true positive latent on `main`, surfaced by the floating `phpstan/phpstan: ^2.1` dev-dependency resolving to 2.2.x (which tightened `booleanNot.alwaysTrue` to see through the PHPDoc on `getOption()`). It is **not** caused by the export-ignore work in #178 — keeping it in its own PR so the `src/` type fix stays decoupled from that `.gitattributes`-only change.

## Test plan

- [x] Pre-commit hooks pass (PHPStan, PHPCS, Rector, composer-require-checker, CLI smoke test)