### PR TITLE
fix(bootstrap): resolve Kernel projectDir throw on oce-810

### DIFF
--- a/src/Module/Bootstrap.php
+++ b/src/Module/Bootstrap.php
@@ -44,7 +44,7 @@ class Bootstrap
 
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly Kernel $kernel = new Kernel(),
+        ?Kernel $kernel = null,
         ?ConfigAccessorInterface $configAccessor = null,
         ?ConfigFactory $configFactory = null,
     ) {
@@ -58,7 +58,7 @@ class Bootstrap
         $this->session = new SessionAccessor();
 
         $templatePath = \dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR;
-        $twig = new TwigContainer($templatePath, $this->kernel);
+        $twig = new TwigContainer($templatePath, $kernel);
         $this->twig = $twig->getTwig();
 
         $this->logger = new SystemLogger();


### PR DESCRIPTION
Make the Bootstrap kernel parameter nullable and pass it through to TwigContainer instead of manufacturing a project-dir-less `new Kernel()`. The default caused `TwigContainer::__construct()` to throw `RuntimeException: Kernel was constructed without a projectDir` on oce-810, which OpenEMR's module loader swallowed to `error_log` — the module then silently vanished from the Modules menu and Administration→Globals.

Refs opencoreemr/openemr-internal#694