### PR TITLE
fix: lower php floor to >=8.4 for consumer resolvability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "source": "https://github.com/opencoreemr/oce-module-sinch-conversations"
   },
   "require": {
-    "php": ">=8.5",
+    "php": ">=8.4",
     "ext-curl": "*",
     "ext-date": "*",
     "ext-filter": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbbcfe0630d3c57edf46b91a674d888f",
+    "content-hash": "d1f1b8393f9bb931907ab5dd8f557f58",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -5243,7 +5243,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.5",
+        "php": ">=8.4",
         "ext-curl": "*",
         "ext-date": "*",
         "ext-filter": "*",


### PR DESCRIPTION
## Summary

Lower `require.php` from `>=8.5` to `>=8.4`. The `>=8.5` floor is stricter than the code needs (no 8.5-only syntax).

## Why this matters

`openemr-internal` pins `config.platform.php` as a Composer resolver workaround for transitive deps (`laminas/laminas-mvc`, `laminas-mvc-i18n`, `laminas-xmlrpc`) that ceiling at `<8.5`. With this module flooring at `>=8.5` and those deps at `<8.5`, the satisfiable ranges are **disjoint** — no `platform.php` value resolves, so Dependabot marks every composer update `update_not_possible` and silently no-ops. Lowering to `>=8.4` makes the intersection `[8.4, 8.5)` non-empty. **Prod still runs PHP 8.5.7.**

`composer.lock` content-hash regenerated (this repo tracks the lock).